### PR TITLE
Split header extraction endpoints by provider

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from .database import init_db
-from .routers import export, health, headers, settings, specs, upload
+from .routers import export, health, headers, headers_ollama, settings, specs, upload
 
 app = FastAPI(title="SimpleSpecs", version="1.0.0")
 
@@ -23,6 +23,7 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(upload.router)
 app.include_router(headers.router)
+app.include_router(headers_ollama.router)
 app.include_router(settings.router)
 app.include_router(specs.router)
 app.include_router(export.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -31,13 +31,19 @@ class ObjectsResponse(BaseModel):
     total: int
 
 
-class HeadersRequest(BaseModel):
+class OpenRouterHeadersRequest(BaseModel):
     upload_id: str
-    provider: Literal["openrouter", "llamacpp"]
     model: str
     params: dict[str, Any] | None = None
-    api_key: str | None = None
+    api_key: str
     base_url: str | None = None
+
+
+class OllamaHeadersRequest(BaseModel):
+    upload_id: str
+    model: str
+    params: dict[str, Any] | None = None
+    base_url: str
 
 
 class HeaderItem(BaseModel):

--- a/backend/routers/_headers_common.py
+++ b/backend/routers/_headers_common.py
@@ -1,0 +1,101 @@
+"""Shared helpers for header extraction endpoints."""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from fastapi import HTTPException, status
+
+from ..models import HeaderItem
+from ..services.text_blocks import document_text
+from ..store import headers_path, read_jsonl, upload_objects_path, write_json
+
+_HEADERS_PROMPT = """Please show a simple numbered nested list of all headers and subheaders for this document.
+Return ONLY the list enclosed in #headers# fencing, like:
+
+#headers#
+1. Top Level
+   1.1 Sub
+      1.1.1 Sub-sub
+2. Another Top
+#headers#
+"""
+
+_HEADERS_BLOCK_RE = re.compile(r"#headers#(.*?)#headers#", re.DOTALL | re.IGNORECASE)
+_SECTION_LINE_RE = re.compile(r"^(\d+(?:\.\d+)*)[\s\-\.]+(.+)$")
+
+
+def fetch_document_text(upload_id: str) -> str:
+    """Return the concatenated text for an uploaded document.
+
+    Raises an ``HTTPException`` if the upload cannot be located or contains no text.
+    """
+
+    objects_raw = read_jsonl(upload_objects_path(upload_id))
+    if not objects_raw:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Upload not found")
+
+    document = document_text(objects_raw)
+    if not document.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Document is empty")
+    return document
+
+
+def build_header_messages(document: str) -> list[dict[str, str]]:
+    """Construct chat messages for requesting headers from an LLM."""
+
+    return [
+        {"role": "system", "content": "You analyze engineering specification documents."},
+        {"role": "user", "content": f"{_HEADERS_PROMPT}\n\nDocument contents:\n{document}"},
+    ]
+
+
+def _parse_headers_block(block: str) -> list[HeaderItem]:
+    headers: list[HeaderItem] = []
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _SECTION_LINE_RE.match(line)
+        if not match:
+            continue
+        section_number = match.group(1).strip()
+        section_name = match.group(2).strip()
+        if section_number and section_name:
+            headers.append(
+                HeaderItem(section_number=section_number, section_name=section_name)
+            )
+    return headers
+
+
+def persist_headers(upload_id: str, headers: Iterable[HeaderItem]) -> None:
+    """Persist header items for future retrieval."""
+
+    write_json(headers_path(upload_id), [header.model_dump() for header in headers])
+
+
+def parse_and_store_headers(upload_id: str, response_text: str) -> list[HeaderItem]:
+    """Extract ``HeaderItem`` entries from an LLM response and persist them."""
+
+    match = _HEADERS_BLOCK_RE.search(response_text)
+    if not match:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LLM returned unexpected format",
+        )
+
+    headers = _parse_headers_block(match.group(1))
+    if not headers:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="No headers parsed",
+        )
+
+    persist_headers(upload_id, headers)
+    return headers
+
+__all__ = [
+    "build_header_messages",
+    "fetch_document_text",
+    "parse_and_store_headers",
+]

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,66 +1,41 @@
-"""Headers extraction endpoint (with minimal OpenRouter direct-call support)."""
+"""Headers extraction endpoint for OpenRouter models."""
 from __future__ import annotations
 
-import re
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException, status
 
-from ..models import HeaderItem, HeadersRequest
-from ..services.llm import get_provider
-from ..services.text_blocks import document_text
-from ..store import headers_path, read_jsonl, upload_objects_path, write_json
+from ..models import HeaderItem, OpenRouterHeadersRequest
+from ._headers_common import (
+    build_header_messages,
+    fetch_document_text,
+    parse_and_store_headers,
+)
 
-router = APIRouter(prefix="/api")
-
-_HEADERS_PROMPT = """Please show a simple numbered nested list of all headers and subheaders for this document.
-Return ONLY the list enclosed in #headers# fencing, like:
-
-#headers#
-1. Top Level
-   1.1 Sub
-      1.1.1 Sub-sub
-2. Another Top
-#headers#
-"""
-
-# ---------------------------
-# Minimal OpenRouter helpers
-# ---------------------------
-
-def _is_openrouter(base_url: Optional[str], provider_name: Optional[str]) -> bool:
-    """Detect OpenRouter by base_url or explicit provider name."""
-    if base_url and "openrouter.ai" in base_url:
-        return True
-    if provider_name and provider_name.lower() in {"openrouter", "openrouter.ai"}:
-        return True
-    return False
+router = APIRouter(prefix="/api/openrouter", tags=["headers"])
 
 
 async def _chat_via_openrouter(
     *,
     base_url: str,
     api_key: str,
-    model: Optional[str],
+    model: str,
     messages: List[Dict[str, str]],
     params: Optional[Dict[str, Any]] = None,
     timeout: float = 60.0,
 ) -> str:
-    """
-    Minimal OpenRouter call using OpenAI-compatible /chat/completions.
-    Sends OpenAI-style payload and extracts choices[0].message.content.
-    """
-    if not base_url.rstrip("/").endswith("/chat/completions"):
-        base_url = base_url.rstrip("/") + "/chat/completions"
+    """Call OpenRouter's OpenAI-compatible chat completions endpoint."""
+
+    endpoint = base_url.rstrip("/")
+    if not endpoint.endswith("/chat/completions"):
+        endpoint = f"{endpoint}/chat/completions"
 
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-    # Optional, but recommended by OpenRouter; safe no-ops if not provided.
-    # Callers can pass these via payload.params if desired.
     if params:
         referer = params.get("http_referer") or params.get("HTTP-Referer")
         if isinstance(referer, str) and referer.strip():
@@ -74,122 +49,82 @@ async def _chat_via_openrouter(
         "messages": messages,
         "stream": False,
     }
-
-    # Pass through a few common OpenAI-style params when present.
     if params:
-        for k in ("temperature", "top_p", "max_tokens", "presence_penalty", "frequency_penalty", "stop"):
-            if k in params:
-                body[k] = params[k]
+        for key in (
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "presence_penalty",
+            "frequency_penalty",
+            "stop",
+        ):
+            if key in params:
+                body[key] = params[key]
 
     async with httpx.AsyncClient(timeout=timeout, headers=headers) as client:
         try:
-            resp = await client.post(base_url, json=body)
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as e:
+            response = await client.post(endpoint, json=body)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"OpenRouter HTTP {resp.status_code}: {resp.text}",
-            ) from e
-        except httpx.RequestError as e:
+                detail=f"OpenRouter HTTP {exc.response.status_code}: {exc.response.text}",
+            ) from exc
+        except httpx.RequestError as exc:  # pragma: no cover - network errors
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"OpenRouter connection error: {e!r}",
-            ) from e
+                detail=f"OpenRouter connection error: {exc!r}",
+            ) from exc
 
-        try:
-            data = resp.json()
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"OpenRouter returned non-JSON: {resp.text[:1000]}",
-            )
-
-    # Extract OpenAI-like response
-    if not isinstance(data, dict) or "choices" not in data or not data["choices"]:
+    try:
+        payload = response.json()
+    except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"OpenRouter unexpected response shape: {str(data)[:1000]}",
-        )
+            detail=f"OpenRouter returned non-JSON: {response.text[:1000]}",
+        ) from exc
 
-    first = data["choices"][0]
+    choices = payload.get("choices") if isinstance(payload, dict) else None
+    if not choices:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"OpenRouter unexpected response shape: {str(payload)[:1000]}",
+        )
+    first = choices[0] if isinstance(choices, list) else None
     message = first.get("message") if isinstance(first, dict) else None
     content = message.get("content") if isinstance(message, dict) else None
     if not isinstance(content, str) or not content.strip():
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"OpenRouter returned empty content: {str(data)[:1000]}",
+            detail=f"OpenRouter returned empty content: {str(payload)[:1000]}",
         )
     return content.strip()
 
-# ---------------------------
-# Endpoint
-# ---------------------------
 
 @router.post("/headers", response_model=list[HeaderItem])
-async def extract_headers(payload: HeadersRequest) -> List[HeaderItem]:
-    objects_raw = read_jsonl(upload_objects_path(payload.upload_id))
-    if not objects_raw:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Upload not found")
+async def extract_openrouter_headers(
+    payload: OpenRouterHeadersRequest,
+) -> List[HeaderItem]:
+    """Extract headers for an upload using an OpenRouter-hosted model."""
 
-    document = document_text(objects_raw)
-    if not document.strip():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Document is empty")
-
-    messages = [
-        {"role": "system", "content": "You analyze engineering specification documents."},
-        {
-            "role": "user",
-            "content": f"{_HEADERS_PROMPT}\n\nDocument contents:\n{document}",
-        },
-    ]
-
-    # Minimal change: if OpenRouter is detected, call it directly with OpenAI-style messaging.
-    if _is_openrouter(payload.base_url, payload.provider):
-        if not payload.api_key:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="api_key is required for OpenRouter")
-        if not payload.base_url:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="base_url is required for OpenRouter")
-        if not payload.model:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="model is required for OpenRouter")
-
-        response_text = await _chat_via_openrouter(
-            base_url=payload.base_url,
-            api_key=payload.api_key,
-            model=payload.model,
-            messages=messages,
-            params=payload.params,
-            timeout=float((payload.params or {}).get("timeout", 60.0)),
+    api_key = payload.api_key.strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="api_key is required for OpenRouter",
         )
-    else:
-        # Default path: use your provider abstraction exactly as before.
-        provider = get_provider(
-            payload.provider,
-            model=payload.model,
-            params=payload.params,
-            api_key=payload.api_key,
-            base_url=payload.base_url,
-        )
-        response_text = await provider.chat(messages)
 
-    match = re.search(r"#headers#(.*?)#headers#", response_text, re.DOTALL | re.IGNORECASE)
-    if not match:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="LLM returned unexpected format")
+    document = fetch_document_text(payload.upload_id)
+    messages = build_header_messages(document)
 
-    content = match.group(1)
-    headers: list[HeaderItem] = []
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        match_line = re.match(r"^(\d+(?:\.\d+)*)[\s\-\.]+(.+)$", line)
-        if not match_line:
-            continue
-        section_number = match_line.group(1).strip()
-        section_name = match_line.group(2).strip()
-        headers.append(HeaderItem(section_number=section_number, section_name=section_name))
-
-    if not headers:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="No headers parsed")
-
-    write_json(headers_path(payload.upload_id), [header.model_dump() for header in headers])
-    return headers
+    base_url = payload.base_url or "https://openrouter.ai/api/v1"
+    timeout = float((payload.params or {}).get("timeout", 60.0))
+    response_text = await _chat_via_openrouter(
+        base_url=base_url,
+        api_key=api_key,
+        model=payload.model,
+        messages=messages,
+        params=payload.params,
+        timeout=timeout,
+    )
+    return parse_and_store_headers(payload.upload_id, response_text)

--- a/backend/routers/headers_ollama.py
+++ b/backend/routers/headers_ollama.py
@@ -1,0 +1,33 @@
+"""Headers extraction endpoint for llama.cpp/Ollama models."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+
+from ..models import HeaderItem, OllamaHeadersRequest
+from ..services.llm import get_provider
+from ._headers_common import (
+    build_header_messages,
+    fetch_document_text,
+    parse_and_store_headers,
+)
+
+router = APIRouter(prefix="/api/ollama", tags=["headers"])
+
+
+@router.post("/headers", response_model=list[HeaderItem])
+async def extract_ollama_headers(payload: OllamaHeadersRequest) -> List[HeaderItem]:
+    """Extract headers for an upload using a llama.cpp-compatible endpoint."""
+
+    document = fetch_document_text(payload.upload_id)
+    messages = build_header_messages(document)
+
+    provider = get_provider(
+        "llamacpp",
+        model=payload.model,
+        params=payload.params,
+        base_url=payload.base_url.strip(),
+    )
+    response_text = await provider.chat(messages)
+    return parse_and_store_headers(payload.upload_id, response_text)


### PR DESCRIPTION
## Summary
- add shared helpers for building header prompts and parsing responses
- expose dedicated OpenRouter and llama.cpp header extraction routes and wire them into the app
- update the frontend API client to choose the correct endpoint based on the saved provider

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0683773748324adc344867b35946f