### PR TITLE
Normalize OpenRouter base URL inputs

### DIFF
--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException, status
+from httpx import InvalidURL
 
 from ..models import HeaderItem, OpenRouterHeadersRequest
 from ._headers_common import (
@@ -14,6 +15,41 @@ from ._headers_common import (
 )
 
 router = APIRouter(prefix="/api/openrouter", tags=["headers"])
+
+
+def _normalize_openrouter_base_url(raw_base_url: str | None) -> str:
+    """Return a sanitized base URL for OpenRouter requests.
+
+    The UI allows users to input a custom base URL. Some users provide a host
+    without a scheme (e.g. ``openrouter.ai/api/v1``), which causes ``httpx`` to
+    treat the entire string as a hostname and yields a DNS error such as
+    ``getaddrinfo failed``. To avoid this sharp edge we coerce the scheme to
+    HTTPS when missing and rely on ``httpx``'s URL parser to validate the
+    resulting URL.
+    """
+
+    base_url = (raw_base_url or "https://openrouter.ai/api/v1").strip()
+    if not base_url:
+        base_url = "https://openrouter.ai/api/v1"
+
+    if "://" not in base_url:
+        base_url = f"https://{base_url}"
+
+    try:
+        parsed = httpx.URL(base_url)
+    except InvalidURL as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid base_url: {exc}",
+        ) from exc
+
+    if not parsed.scheme or not parsed.host:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="base_url must include a hostname",
+        )
+
+    return str(parsed)
 
 
 async def _chat_via_openrouter(
@@ -117,7 +153,7 @@ async def extract_openrouter_headers(
     document = fetch_document_text(payload.upload_id)
     messages = build_header_messages(document)
 
-    base_url = payload.base_url or "https://openrouter.ai/api/v1"
+    base_url = _normalize_openrouter_base_url(payload.base_url)
     timeout = float((payload.params or {}).get("timeout", 60.0))
     response_text = await _chat_via_openrouter(
         base_url=base_url,

--- a/backend/tests/test_headers_router.py
+++ b/backend/tests/test_headers_router.py
@@ -1,0 +1,41 @@
+"""Tests for OpenRouter header utilities."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, status
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.routers.headers import _normalize_openrouter_base_url
+
+
+def test_normalize_base_url_defaults_to_openrouter() -> None:
+    assert (
+        _normalize_openrouter_base_url(None)
+        == "https://openrouter.ai/api/v1"
+    )
+    assert (
+        _normalize_openrouter_base_url("  \t")
+        == "https://openrouter.ai/api/v1"
+    )
+
+
+def test_normalize_base_url_adds_scheme_when_missing() -> None:
+    assert (
+        _normalize_openrouter_base_url("openrouter.ai/api/v1")
+        == "https://openrouter.ai/api/v1"
+    )
+
+
+def test_normalize_base_url_rejects_invalid_value() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _normalize_openrouter_base_url("http://")
+
+    error = exc_info.value
+    assert error.status_code == status.HTTP_400_BAD_REQUEST
+    assert "base_url" in error.detail


### PR DESCRIPTION
## Summary
- normalize OpenRouter base URL inputs to prevent DNS failures from missing schemes
- validate the URL before calling OpenRouter and surface a clear 400 error when invalid
- add unit tests covering the normalization helper

## Testing
- pytest backend/tests/test_headers_router.py

------
https://chatgpt.com/codex/tasks/task_e_68e06a8ededc83249d295b99770bf483