### PR TITLE
Silence third-party deprecation warnings in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = backend/tests
 python_files = test_parsers.py
+filterwarnings =
+    ignore:the load_module\(\) method is deprecated:DeprecationWarning
+    ignore:ast\.NameConstant is deprecated:DeprecationWarning


### PR DESCRIPTION
## Summary
- update the Pytest configuration to ignore deprecation warnings emitted by dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0739a60cc8324af96d8b67c75b137