### PR TITLE
Implement canonical section chunking and shard generation

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,24 +1,120 @@
 """Pydantic models for the SimpleSpecs backend."""
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Iterable, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+class BoundingBox(BaseModel):
+    """Axis-aligned rectangle used for parsed elements."""
+
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    def to_list(self) -> list[float]:
+        return [self.x0, self.y0, self.x1, self.y1]
+
+    @classmethod
+    def from_iterable(cls, values: Iterable[float]) -> "BoundingBox":
+        x0, y0, x1, y1 = list(values)
+        return cls(x0=x0, y0=y0, x1=x1, y1=y1)
 
 
 class ParsedObject(BaseModel):
     """Normalized representation of a parsed document element."""
 
-    line_id: str = Field(..., description="Unique identifier for the extracted element")
-    type: str = Field(..., description="Element type: text, table, image, other")
-    page: int | None = Field(None, description="Page number if available")
-    bbox: list[float] | None = Field(
-        None, description="Bounding box coordinates [x0, y0, x1, y1] where available"
+    object_id: str = Field(..., description="Unique identifier for the extracted element")
+    file_id: str = Field(..., description="Identifier of the parent document")
+    kind: str = Field(..., description="Element type such as text, table, or image")
+    text: str | None = Field(None, description="Primary textual content of the element")
+    content: str | None = Field(
+        None,
+        description="Alternate textual content retained for backward compatibility",
     )
-    content: str = Field(..., description="Primary textual content of the element")
-    meta: dict[str, Any] | None = Field(
+    page_index: int | None = Field(None, description="Zero-based page index if available")
+    bbox: list[float] | None = Field(
+        default=None,
+        description="Bounding box coordinates [x0, y0, x1, y1] where available",
+    )
+    order_index: int = Field(..., description="Stable ordering index for reading order")
+    metadata: dict[str, Any] | None = Field(
         default=None, description="Additional metadata for the parsed element"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_legacy_payload(cls, values: Any) -> Any:
+        """Normalize legacy payloads emitted by earlier parsing stages."""
+
+        if not isinstance(values, dict):
+            return values
+        data = dict(values)
+        if "object_id" not in data and "line_id" in data:
+            data["object_id"] = data.pop("line_id")
+        if "file_id" not in data and "document_id" in data:
+            data["file_id"] = data.get("document_id")
+        if "kind" not in data:
+            legacy_type = data.get("type")
+            if legacy_type:
+                data["kind"] = legacy_type
+        if "text" not in data and "content" in data:
+            data["text"] = data.get("content")
+        if "content" not in data and "text" in data:
+            data["content"] = data.get("text")
+        if "order_index" not in data:
+            if "order" in data:
+                data["order_index"] = data["order"]
+            else:
+                data["order_index"] = 0
+        if "page_index" not in data and "page" in data:
+            data["page_index"] = data.get("page")
+        if "metadata" not in data and "meta" in data:
+            data["metadata"] = data.get("meta")
+        bbox = data.get("bbox")
+        if isinstance(bbox, dict):
+            data["bbox"] = [
+                bbox.get("x0", 0.0),
+                bbox.get("y0", 0.0),
+                bbox.get("x1", 0.0),
+                bbox.get("y1", 0.0),
+            ]
+        if "bbox" in data and isinstance(data["bbox"], BoundingBox):
+            data["bbox"] = data["bbox"].to_list()
+        return data
+
+    @property
+    def clean_text(self) -> str:
+        """Return the object's textual representation with fallback content."""
+
+        return (self.text or self.content or "").strip()
+
+
+class SectionSpan(BaseModel):
+    """Span metadata linking sections to parsed objects."""
+
+    start_object: str | None = Field(
+        None, description="Object identifier marking the first element in the section"
+    )
+    end_object: str | None = Field(
+        None, description="Object identifier marking the last element in the section"
+    )
+    page_start: int | None = Field(None, description="First page index covered by the section")
+    page_end: int | None = Field(None, description="Last page index covered by the section")
+
+
+class SectionNode(BaseModel):
+    """Header tree node."""
+
+    section_id: str
+    file_id: str
+    number: str | None = None
+    title: str
+    depth: int
+    children: list["SectionNode"] = Field(default_factory=list)
+    span: SectionSpan | None = None
 
 
 class UploadResponse(BaseModel):
@@ -61,7 +157,15 @@ class SpecsRequest(BaseModel):
 
 
 class SpecItem(BaseModel):
-    section_number: str
-    section_name: str
-    specification: str
-    domain: str = "Mechanical"
+    spec_id: str
+    file_id: str
+    section_id: str
+    section_number: str | None = None
+    section_title: str
+    spec_text: str
+    confidence: float | None = None
+    source_object_ids: list[str] = Field(default_factory=list)
+
+
+# Resolve recursive definitions for SectionNode
+SectionNode.model_rebuild()

--- a/backend/services/chunker.py
+++ b/backend/services/chunker.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import json
 import re
+import hashlib
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from ..config import Settings, get_settings
 from ..models import ParsedObject, SectionNode
@@ -21,12 +24,17 @@ def _extract_text(obj: ParsedObject) -> str:
     )
 
 
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9])")
+_TOKEN_RE = re.compile(r"\w+")
+
+
 def _normalize_heading_text(text: str) -> str:
     """Normalize heading text for fuzzy comparisons."""
 
-    cleaned = re.sub(r"[\s]+", " ", text or "").strip().lower()
+    cleaned = re.sub(r"[\s]+", " ", (text or "")).strip().lower()
+    cleaned = re.sub(r"^[0-9ivxlcdm\.\)\(\- ]+", "", cleaned)
     cleaned = re.sub(r"[^0-9a-z ]+", "", cleaned)
-    return cleaned
+    return cleaned.strip()
 
 
 def _sorted_objects(objects: list[ParsedObject]) -> list[ParsedObject]:
@@ -54,12 +62,37 @@ def _load_sections(file_id: str, settings: Settings) -> SectionNode:
     return SectionNode.model_validate(payload)
 
 
-def _persist_chunks(file_id: str, mapping: dict[str, list[str]], settings: Settings) -> None:
+def _estimate_tokens(text: str) -> int:
+    return len(_TOKEN_RE.findall(text))
+
+
+@dataclass
+class _ChunkComputationResult:
+    mapping: dict[str, list[str]]
+    ordered_objects: list[ParsedObject]
+    object_index: dict[str, int]
+    parent_map: dict[str, SectionNode | None]
+    section_lookup: dict[str, SectionNode]
+
+
+def _persist_chunks(
+    file_id: str,
+    mapping: dict[str, list[str]],
+    canonical: list[dict[str, Any]],
+    shards: list[dict[str, Any]],
+    settings: Settings,
+) -> None:
     base = Path(settings.ARTIFACTS_DIR) / file_id / "chunks"
     base.mkdir(parents=True, exist_ok=True)
     target = base / "chunks.json"
     with target.open("w", encoding="utf-8") as handle:
         json.dump(mapping, handle, indent=2)
+    canonical_target = base / "canonical.json"
+    with canonical_target.open("w", encoding="utf-8") as handle:
+        json.dump(canonical, handle, indent=2)
+    shards_target = base / "shards.json"
+    with shards_target.open("w", encoding="utf-8") as handle:
+        json.dump(shards, handle, indent=2)
 
 
 def load_persisted_chunks(file_id: str, settings: Settings | None = None) -> dict[str, list[str]]:
@@ -80,9 +113,10 @@ def run_chunking(file_id: str, settings: Settings | None = None) -> dict[str, li
     settings = settings or get_settings()
     objects = _load_parsed_objects(file_id, settings)
     sections = _load_sections(file_id, settings)
-    mapping = compute_section_spans(sections, objects)
-    _persist_chunks(file_id, mapping, settings)
-    return mapping
+    computation = _compute_chunks(sections, objects)
+    canonical, shards = _build_canonical_artifacts(computation)
+    _persist_chunks(file_id, computation.mapping, canonical, shards, settings)
+    return computation.mapping
 
 
 def compute_section_spans(root: SectionNode, objects: list[ParsedObject]) -> dict[str, list[str]]:
@@ -93,86 +127,98 @@ def compute_section_spans(root: SectionNode, objects: list[ParsedObject]) -> dic
     receive the ordered concatenation of their descendant leaf chunks.
     """
 
+    return _compute_chunks(root, objects).mapping
+
+
+def _compute_chunks(root: SectionNode, objects: list[ParsedObject]) -> _ChunkComputationResult:
     ordered_objects = _sorted_objects(list(objects))
     object_index: dict[str, int] = {obj.object_id: idx for idx, obj in enumerate(ordered_objects)}
 
+    parent_map: dict[str, SectionNode | None] = {root.section_id: None}
+    section_lookup: dict[str, SectionNode] = {}
     leaf_nodes: list[SectionNode] = []
     all_nodes: list[SectionNode] = []
 
-    def _collect(node: SectionNode) -> None:
+    def _collect(node: SectionNode, parent: SectionNode | None) -> None:
+        parent_map[node.section_id] = parent
+        section_lookup[node.section_id] = node
         all_nodes.append(node)
         if not node.children:
             leaf_nodes.append(node)
         for child in node.children:
-            _collect(child)
+            _collect(child, node)
 
-    _collect(root)
+    _collect(root, None)
 
-    leaf_ranges: dict[str, tuple[int, int]] = {}
-    anchor_index: dict[str, int] = {}
-    ordered_leaf_entries: list[tuple[int, int, str, SectionNode, int | None, int]] = []
+    total_objects = len(ordered_objects)
+    intervals: list[dict[str, Any]] = []
     for leaf in leaf_nodes:
         span = leaf.span
         if span is None or span.start_object is None:
             continue
-        start_index = object_index.get(span.start_object)
-        if start_index is None:
+        anchor_idx = object_index.get(span.start_object)
+        if anchor_idx is None:
             continue
-        end_index = object_index.get(span.end_object) if span.end_object is not None else None
-        order_position = (
-            min(start_index, end_index)
-            if end_index is not None
-            else start_index
-        )
-        anchor_index[leaf.section_id] = start_index
-        ordered_leaf_entries.append(
-            (order_position, leaf.depth, leaf.section_id, leaf, end_index, start_index)
-        )
-
-    ordered_leaf_entries.sort(key=lambda item: (item[0], item[1], item[2]))
-
-    total_objects = len(ordered_objects)
-    for idx, (order_pos, _, section_id, leaf, explicit_end, anchor_pos) in enumerate(ordered_leaf_entries):
-        next_boundary = total_objects
-        for later_idx in range(idx + 1, len(ordered_leaf_entries)):
-            candidate_pos = ordered_leaf_entries[later_idx][0]
-            if candidate_pos > order_pos:
-                next_boundary = candidate_pos
-                break
-        effective_end = next_boundary - 1 if next_boundary > 0 else -1
-        if explicit_end is not None:
-            effective_end = min(effective_end, explicit_end)
-        anchor_obj = ordered_objects[anchor_pos] if 0 <= anchor_pos < total_objects else None
+        anchor_obj = ordered_objects[anchor_idx] if 0 <= anchor_idx < total_objects else None
         anchor_text = _normalize_heading_text(_extract_text(anchor_obj)) if anchor_obj else ""
         title_text = _normalize_heading_text(leaf.title)
-        is_heading_anchor = bool(
-            anchor_text
-            and title_text
-            and (anchor_text.startswith(title_text) or title_text.startswith(anchor_text))
+        start_idx = anchor_idx + 1 if anchor_text and title_text and anchor_text == title_text else anchor_idx
+        explicit_end: int | None = None
+        if span.end_object:
+            end_idx = object_index.get(span.end_object)
+            if end_idx is not None:
+                explicit_end = min(end_idx + 1, total_objects)
+        container_end = _resolve_container_end(leaf, parent_map, object_index, total_objects)
+        intervals.append(
+            {
+                "leaf": leaf,
+                "anchor_idx": anchor_idx,
+                "start": max(0, min(start_idx, total_objects)),
+                "explicit_end": explicit_end,
+                "container_end": container_end,
+            }
         )
-        start_inclusive = anchor_pos + 1 if is_heading_anchor else anchor_pos
-        if start_inclusive > effective_end:
-            continue
-        leaf_ranges[section_id] = (start_inclusive, effective_end)
+
+    intervals.sort(
+        key=lambda item: (
+            item["anchor_idx"],
+            item["leaf"].depth,
+            item["leaf"].section_id,
+        )
+    )
+
+    for idx, info in enumerate(intervals):
+        candidates = [total_objects]
+        if info.get("explicit_end") is not None:
+            candidates.append(info["explicit_end"])
+        if info.get("container_end") is not None:
+            candidates.append(info["container_end"])
+        if idx + 1 < len(intervals):
+            candidates.append(intervals[idx + 1]["anchor_idx"])
+        end_exclusive = min(candidates)
+        end_exclusive = max(info["start"], min(end_exclusive, total_objects))
+        info["end"] = end_exclusive
+
+    prev_end = 0
+    for info in intervals:
+        start = max(info["start"], prev_end)
+        end = max(start, info.get("end", start))
+        info["start"] = start
+        info["end"] = min(end, total_objects)
+        prev_end = info["end"]
 
     leaf_chunks: dict[str, list[str]] = {leaf.section_id: [] for leaf in leaf_nodes}
-
-    for index, obj in enumerate(ordered_objects):
-        candidates: list[tuple[int, int, str, SectionNode]] = []
-        for leaf in leaf_nodes:
-            span = leaf_ranges.get(leaf.section_id)
-            anchor_pos = anchor_index.get(leaf.section_id)
-            if span is None or anchor_pos is None:
-                continue
-            start_idx, end_idx = span
-            if index < start_idx or index > end_idx:
-                continue
-            distance = index - anchor_pos
-            candidates.append((distance, leaf.depth, leaf.section_id, leaf))
-        if not candidates:
+    for info in intervals:
+        start_idx = info["start"]
+        end_idx = info["end"]
+        if start_idx >= end_idx:
+            leaf_chunks[info["leaf"].section_id] = []
             continue
-        _, _, _, chosen_leaf = min(candidates, key=lambda item: (item[0], item[1], item[2]))
-        leaf_chunks[chosen_leaf.section_id].append(obj.object_id)
+        chunk_ids = [
+            ordered_objects[pos].object_id
+            for pos in range(start_idx, min(end_idx, total_objects))
+        ]
+        leaf_chunks[info["leaf"].section_id] = chunk_ids
 
     result: dict[str, list[str]] = {}
 
@@ -205,4 +251,211 @@ def compute_section_spans(root: SectionNode, objects: list[ParsedObject]) -> dic
     for node in all_nodes:
         result.setdefault(node.section_id, [])
 
-    return result
+    return _ChunkComputationResult(
+        mapping=result,
+        ordered_objects=ordered_objects,
+        object_index=object_index,
+        parent_map=parent_map,
+        section_lookup=section_lookup,
+    )
+
+
+def _resolve_container_end(
+    node: SectionNode,
+    parent_map: dict[str, SectionNode | None],
+    object_index: dict[str, int],
+    default_end: int,
+) -> int:
+    current: SectionNode | None = node
+    while current is not None:
+        span = current.span
+        if span and span.end_object:
+            end_idx = object_index.get(span.end_object)
+            if end_idx is not None:
+                return min(end_idx + 1, default_end)
+        current = parent_map.get(current.section_id)
+    return default_end
+
+
+def _build_header_path(
+    section_id: str,
+    lookup: dict[str, SectionNode],
+    parent_map: dict[str, SectionNode | None],
+) -> list[str]:
+    titles: list[str] = []
+    current = lookup.get(section_id)
+    while current is not None:
+        title = (current.title or "").strip()
+        if title:
+            titles.append(title)
+        current = parent_map.get(current.section_id)
+    titles.reverse()
+    if titles:
+        return titles[:-1]
+    return []
+
+
+def _build_canonical_artifacts(
+    computation: _ChunkComputationResult,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    object_lookup = {obj.object_id: obj for obj in computation.ordered_objects}
+    canonical: list[dict[str, Any]] = []
+    shards: list[dict[str, Any]] = []
+    for section_id, node in computation.section_lookup.items():
+        object_ids = computation.mapping.get(section_id, [])
+        positions = [
+            computation.object_index[oid]
+            for oid in object_ids
+            if oid in computation.object_index
+        ]
+        object_span = (
+            [min(positions), max(positions) + 1]
+            if positions
+            else None
+        )
+        page_candidates: list[int] = []
+        for oid in object_ids:
+            obj = object_lookup.get(oid)
+            if obj and obj.page_index is not None:
+                page_candidates.append(obj.page_index)
+        span = node.span
+        if not page_candidates and span:
+            if span.page_start is not None:
+                page_candidates.append(span.page_start)
+            if span.page_end is not None:
+                page_candidates.append(span.page_end)
+        page_span = (
+            [min(page_candidates), max(page_candidates)]
+            if page_candidates
+            else None
+        )
+        body_lines: list[str] = []
+        outbound: list[str] = []
+        for oid in object_ids:
+            obj = object_lookup.get(oid)
+            if not obj:
+                continue
+            text = obj.clean_text
+            if text:
+                body_lines.append(text)
+            kind_lower = obj.kind.lower() if isinstance(obj.kind, str) else ""
+            if kind_lower in {"table", "figure", "image", "chart"}:
+                outbound.append(oid)
+        header_text = (node.title or "").strip()
+        if body_lines:
+            clean_text = "\n".join([header_text] + body_lines) if header_text else "\n".join(body_lines)
+        else:
+            clean_text = header_text
+        token_count = _estimate_tokens(clean_text)
+        header_path = _build_header_path(
+            section_id, computation.section_lookup, computation.parent_map
+        )
+        parent = computation.parent_map.get(section_id)
+        entry = {
+            "section_id": section_id,
+            "file_id": node.file_id,
+            "parent_section_id": parent.section_id if parent else None,
+            "header_text": header_text,
+            "header_path": header_path,
+            "level": node.depth,
+            "page_span": page_span,
+            "object_index_span": object_span,
+            "token_count": token_count,
+            "text": clean_text,
+            "source_object_ids": object_ids,
+            "outbound_object_ids": outbound,
+            "hash": hashlib.sha1(clean_text.encode("utf-8")).hexdigest(),
+        }
+        canonical.append(entry)
+        shards.extend(_build_shards_for_entry(entry))
+    return canonical, shards
+
+
+def _split_into_shards(
+    text: str,
+    target_tokens: int = 300,
+    min_tokens: int = 200,
+    max_tokens: int = 400,
+    overlap_ratio: float = 0.15,
+) -> list[tuple[int, int, str, int]]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+    sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(stripped) if s.strip()]
+    if not sentences:
+        sentences = [stripped]
+    tokens_per_sentence = [max(1, _estimate_tokens(sentence)) for sentence in sentences]
+    total = len(sentences)
+    shards: list[tuple[int, int, str, int]] = []
+    start = 0
+    while start < total:
+        token_sum = 0
+        end = start
+        while end < total and token_sum < target_tokens:
+            token_sum += tokens_per_sentence[end]
+            end += 1
+            if token_sum >= max_tokens:
+                break
+        while end < total and token_sum < min_tokens:
+            token_sum += tokens_per_sentence[end]
+            end += 1
+            if token_sum >= max_tokens:
+                break
+        if end == start:
+            end = min(start + 1, total)
+            token_sum = tokens_per_sentence[start]
+        shard_text = " ".join(sentences[start:end]).strip()
+        shards.append((start, end, shard_text, token_sum))
+        if end >= total:
+            break
+        overlap_tokens = max(1, int(token_sum * overlap_ratio)) if token_sum > 0 else 0
+        if overlap_tokens <= 0:
+            start = end
+            continue
+        token_back = 0
+        new_start = end
+        while new_start > start:
+            new_start -= 1
+            token_back += tokens_per_sentence[new_start]
+            if token_back >= overlap_tokens:
+                break
+        if new_start == start:
+            start = end
+        else:
+            start = new_start
+    return shards
+
+
+def _build_shards_for_entry(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    header_segments = [seg for seg in entry.get("header_path", []) if seg]
+    header_segments.append(entry.get("header_text", ""))
+    prefix = " > ".join([seg for seg in header_segments if seg])
+    lines = entry.get("text", "").splitlines()
+    body_text = "\n".join(lines[1:]).strip() if len(lines) > 1 else entry.get("text", "").strip()
+    if not body_text:
+        body_text = entry.get("header_text", "").strip()
+    shard_chunks = _split_into_shards(body_text)
+    if not shard_chunks:
+        shard_chunks = [(0, 1, body_text, _estimate_tokens(body_text))]
+    shards: list[dict[str, Any]] = []
+    for idx, (_, _, chunk_text, _) in enumerate(shard_chunks):
+        chunk_body = chunk_text.strip()
+        if chunk_body:
+            shard_text = f"{prefix}\n\n{chunk_body}" if prefix else chunk_body
+        else:
+            shard_text = prefix
+        shard_payload = {
+            "shard_id": f"{entry['section_id']}-shard-{idx:03d}",
+            "parent_section_id": entry.get("parent_section_id"),
+            "section_id": entry["section_id"],
+            "file_id": entry["file_id"],
+            "header_path": entry.get("header_path", []),
+            "header_text": entry.get("header_text"),
+            "text": shard_text,
+            "token_count": _estimate_tokens(shard_text),
+            "object_index_span": entry.get("object_index_span"),
+            "page_span": entry.get("page_span"),
+            "hash": hashlib.sha1(shard_text.encode("utf-8")).hexdigest(),
+        }
+        shards.append(shard_payload)
+    return shards

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -9,6 +9,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from backend.models import ParsedObject, SectionNode, SectionSpan
+import backend.services.chunker as chunker
 from backend.services.chunker import compute_section_spans
 
 
@@ -103,3 +104,88 @@ def test_compute_section_spans() -> None:
         "sec-gamma",
         "sec-parent",
     }
+
+
+def _make_custom_object(
+    file_id: str,
+    index: int,
+    text: str,
+    *,
+    kind: str = "text",
+    page: int | None = 0,
+) -> ParsedObject:
+    return ParsedObject(
+        object_id=f"{file_id}-obj-{index}",
+        file_id=file_id,
+        kind=kind,
+        text=text,
+        page_index=page,
+        bbox=None,
+        order_index=index,
+    )
+
+
+def test_canonical_artifacts_and_shards() -> None:
+    file_id = "file"
+    objects = [
+        _make_custom_object(file_id, 0, "1 Alpha"),
+        _make_custom_object(file_id, 1, "Alpha body first sentence."),
+        _make_custom_object(file_id, 2, "Alpha body second sentence."),
+        _make_custom_object(file_id, 3, "1.1 Beta", page=1),
+        _make_custom_object(file_id, 4, "Beta body includes a table.", page=1),
+        _make_custom_object(
+            file_id,
+            5,
+            "Table 1: Dimensions",
+            kind="table",
+            page=1,
+        ),
+    ]
+
+    section_alpha = SectionNode(
+        section_id="sec-alpha",
+        file_id=file_id,
+        title="Alpha",
+        depth=1,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[0].object_id,
+            end_object=objects[2].object_id,
+        ),
+    )
+    section_beta = SectionNode(
+        section_id="sec-beta",
+        file_id=file_id,
+        title="Beta",
+        depth=1,
+        children=[],
+        span=SectionSpan(
+            start_object=objects[3].object_id,
+            end_object=objects[5].object_id,
+        ),
+    )
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        title="Document",
+        depth=0,
+        children=[section_alpha, section_beta],
+    )
+
+    computation = chunker._compute_chunks(root, objects)
+    canonical, shards = chunker._build_canonical_artifacts(computation)
+
+    alpha_entry = next(item for item in canonical if item["section_id"] == "sec-alpha")
+    beta_entry = next(item for item in canonical if item["section_id"] == "sec-beta")
+
+    assert alpha_entry["object_index_span"] == [1, 3]
+    assert "Alpha body first sentence." in alpha_entry["text"]
+    assert alpha_entry["header_path"] == ["Document"]
+
+    assert beta_entry["object_index_span"] == [4, 6]
+    assert beta_entry["outbound_object_ids"] == [objects[5].object_id]
+
+    beta_shards = [item for item in shards if item["section_id"] == "sec-beta"]
+    assert beta_shards
+    assert beta_shards[0]["text"].startswith("Document > Beta")
+    assert beta_shards[0]["parent_section_id"] == "root"


### PR DESCRIPTION
## Summary
- update the backend models to expose structured parsed objects, section spans, and spec metadata
- refactor the chunking pipeline to compute deterministic section ranges and persist canonical + shard artifacts for retrieval
- add tests that validate canonical chunks and shard prefixes in addition to existing span mapping assertions

## Testing
- pytest backend/tests/test_chunker.py

------
https://chatgpt.com/codex/tasks/task_e_68e10f51a0b48324a9321514628bee14