### PR TITLE
Align backend models and chunking pipeline with integration tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,18 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from .database import init_db
-from .routers import export, health, headers, headers_ollama, settings, specs, upload
+from .routers import (
+    export,
+    files,
+    health,
+    headers,
+    headers_ollama,
+    ingest,
+    settings,
+    specs,
+    system,
+    upload,
+)
 
 app = FastAPI(title="SimpleSpecs", version="1.0.0")
 
@@ -22,11 +33,14 @@ app.add_middleware(
 
 app.include_router(health.router)
 app.include_router(upload.router)
+app.include_router(ingest.ingest_router)
+app.include_router(files.files_router)
 app.include_router(headers.router)
 app.include_router(headers_ollama.router)
 app.include_router(settings.router)
 app.include_router(specs.router)
 app.include_router(export.router)
+app.include_router(system.system_router)
 
 @app.on_event("startup")
 def _ensure_database() -> None:

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,24 +1,116 @@
 """Pydantic models for the SimpleSpecs backend."""
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Iterable, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
+
+
+class BoundingBox(BaseModel):
+    """Axis-aligned bounding box expressed as ``(x0, y0, x1, y1)``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce(cls, value: Any) -> Any:
+        if value is None or isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            if {"x0", "y0", "x1", "y1"}.issubset(value.keys()):
+                return value
+        if isinstance(value, Iterable):
+            items = list(value)
+            if len(items) == 4:
+                return {
+                    "x0": float(items[0]),
+                    "y0": float(items[1]),
+                    "x1": float(items[2]),
+                    "y1": float(items[3]),
+                }
+        raise TypeError("BoundingBox requires four coordinates")
+
+    def to_list(self) -> list[float]:
+        return [self.x0, self.y0, self.x1, self.y1]
+
+
+class SectionSpan(BaseModel):
+    """Half-open span referencing parsed object identifiers."""
+
+    start_object: str | None = None
+    end_object: str | None = None
+
+
+class SectionNode(BaseModel):
+    """Hierarchical section description returned by header discovery."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    section_id: str
+    file_id: str
+    title: str
+    depth: int
+    number: str | None = None
+    span: SectionSpan | None = None
+    children: list["SectionNode"] = Field(default_factory=list)
+
+    @field_validator("children", mode="before")
+    @classmethod
+    def _ensure_children(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        return value
 
 
 class ParsedObject(BaseModel):
     """Normalized representation of a parsed document element."""
 
-    line_id: str = Field(..., description="Unique identifier for the extracted element")
-    type: str = Field(..., description="Element type: text, table, image, other")
-    page: int | None = Field(None, description="Page number if available")
-    bbox: list[float] | None = Field(
+    model_config = ConfigDict(extra="allow")
+
+    object_id: str = Field(..., description="Unique identifier for the extracted element")
+    file_id: str = Field(..., description="Identifier of the owning file")
+    kind: str = Field(..., description="Element type: text, table, image, other")
+    text: str | None = Field(None, description="Primary textual content of the element")
+    page_index: int | None = Field(None, description="Zero-based page index if available")
+    bbox: BoundingBox | None = Field(
         None, description="Bounding box coordinates [x0, y0, x1, y1] where available"
     )
-    content: str = Field(..., description="Primary textual content of the element")
-    meta: dict[str, Any] | None = Field(
+    order_index: int = Field(0, description="Document order index assigned during ingestion")
+    metadata: dict[str, Any] | None = Field(
         default=None, description="Additional metadata for the parsed element"
     )
+
+    @field_validator("bbox", mode="before")
+    @classmethod
+    def _coerce_bbox(cls, value: Any) -> Any:
+        if value is None or isinstance(value, BoundingBox):
+            return value
+        return BoundingBox.model_validate(value)
+
+    @field_validator("order_index")
+    @classmethod
+    def _non_negative_order(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("order_index must be non-negative")
+        return value
+
+    @field_serializer("bbox")
+    def _serialize_bbox(self, value: BoundingBox | None) -> list[float] | None:
+        if value is None:
+            return None
+        return value.to_list()
 
 
 class UploadResponse(BaseModel):
@@ -61,7 +153,22 @@ class SpecsRequest(BaseModel):
 
 
 class SpecItem(BaseModel):
-    section_number: str
-    section_name: str
-    specification: str
-    domain: str = "Mechanical"
+    """LLM extracted mechanical specification tied to a section."""
+
+    spec_id: str
+    file_id: str
+    section_id: str
+    section_title: str
+    spec_text: str
+    source_object_ids: list[str] = Field(default_factory=list)
+    section_number: str | None = None
+    confidence: float | None = None
+
+    @field_validator("source_object_ids", mode="before")
+    @classmethod
+    def _coerce_ids(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple)):
+            return [str(item) for item in value]
+        raise TypeError("source_object_ids must be a sequence")

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -18,16 +18,32 @@ async def export_specs(upload_id: str = Query(...)) -> StreamingResponse:
     if not specs:
         raise HTTPException(status_code=404, detail="No specifications available")
 
-    header = ["Section number", "Section name", "Specification", "Domain"]
+    header = [
+        "spec_id",
+        "file_id",
+        "section_id",
+        "section_number",
+        "section_title",
+        "spec_text",
+        "confidence",
+        "source_object_ids",
+    ]
     buffer = io.StringIO()
     writer = csv.writer(buffer)
     writer.writerow(header)
     for item in specs:
+        source_ids = item.get("source_object_ids") or []
+        if not isinstance(source_ids, list):
+            source_ids = [str(source_ids)]
         row = [
-            (item.get("section_number") or "").replace("\r", " ").replace("\n", " "),
-            (item.get("section_name") or "").replace("\r", " ").replace("\n", " "),
-            (item.get("specification") or "").replace("\r", " ").replace("\n", " "),
-            (item.get("domain") or "").replace("\r", " ").replace("\n", " "),
+            item.get("spec_id", ""),
+            item.get("file_id", ""),
+            item.get("section_id", ""),
+            item.get("section_number", ""),
+            item.get("section_title", ""),
+            item.get("spec_text", ""),
+            item.get("confidence", ""),
+            ",".join(str(value) for value in source_ids),
         ]
         writer.writerow(row)
     buffer.seek(0)

--- a/backend/services/text_blocks.py
+++ b/backend/services/text_blocks.py
@@ -16,12 +16,14 @@ def document_lines(objects: Sequence[dict | ParsedObject]) -> list[str]:
         data = obj
         if isinstance(obj, ParsedObject):
             data = obj.model_dump()
-        if data.get("type") == "text":
-            content = str(data.get("content", "")).strip()
+        kind = data.get("kind") or data.get("type")
+        text = data.get("text") or data.get("content") or ""
+        if kind == "text":
+            content = str(text).strip()
             if content:
                 lines.append(content)
-        elif data.get("type") == "table":
-            content = str(data.get("content", "")).strip()
+        elif kind == "table":
+            content = str(text).strip()
             if content:
                 lines.extend(line.strip() for line in content.splitlines() if line.strip())
     return lines

--- a/ollama_test.py
+++ b/ollama_test.py
@@ -1,19 +1,49 @@
-import requests
-OLLAMA_API = "http://AA-248:11434/api/chat"
-HEADERS = {"Content-Type": "application/json"}
-# MODEL = "deepseek-r1"
-MODEL = "llama3.2"
-# MODEL = "qwen2.5vl"
+"""Quick utility script for interacting with a local Ollama instance."""
+from __future__ import annotations
 
-messages = [
-    {"role": "user", "content": "Tell me a random dad joke."}
-]
+from dataclasses import dataclass
 
-payload = {
-        "model": MODEL,
-        "messages": messages,
+try:  # pragma: no cover - optional dependency for local tooling
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - graceful import for test collection
+    requests = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class OllamaConfig:
+    """Lightweight configuration for Ollama chat queries."""
+
+    api_url: str = "http://AA-248:11434/api/chat"
+    model: str = "llama3.2"
+    headers: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial setter
+        if self.headers is None:
+            object.__setattr__(self, "headers", {"Content-Type": "application/json"})
+
+
+def query_ollama(prompt: str, config: OllamaConfig | None = None) -> str:
+    """Send a single-turn chat message to Ollama and return the response text."""
+
+    if requests is None:  # pragma: no cover - dependency not installed in CI
+        raise RuntimeError("The 'requests' package is required to query Ollama.")
+
+    cfg = config or OllamaConfig()
+    payload = {
+        "model": cfg.model,
+        "messages": [{"role": "user", "content": prompt}],
         "stream": False,
     }
+    response = requests.post(cfg.api_url, json=payload, headers=cfg.headers, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    message = data.get("message", {})
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+    raise RuntimeError("Unexpected response payload from Ollama")
 
-response = requests.post(OLLAMA_API, json=payload, headers=HEADERS)
-print(response.json()['message']['content'])
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    print(query_ollama("Tell me a random dad joke."))


### PR DESCRIPTION
## Summary
- expand the backend models to include bounding boxes, section spans, and richer spec metadata to match the integration contracts
- wire the FastAPI app up to the new file/header/spec endpoints and update the exports/utilities to use the revised shapes
- overhaul the chunker so residual content is captured deterministically while keeping leaf spans non-overlapping, and harden the Ollama helper against missing dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e116b971308324a74a9a5af1549d1e