### PR TITLE
Refactor parsed object schema

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 
 from ..config import get_settings
-from ..models import ParsedObject, SectionNode, SpecItem
+from ..models import PARSED_OBJECT_ADAPTER, ParsedObject, SectionNode, SpecItem
 from ..services.chunker import load_persisted_chunks, run_chunking
 from ..services.headers import load_persisted_headers, run_header_discovery
 from ..services.specs import extract_specs_for_sections
@@ -53,7 +53,7 @@ def _load_parsed_objects(file_id: str, base: Path) -> list[ParsedObject]:
     if not parsed_path.exists():
         raise FileNotFoundError("parsed_objects_missing")
     data = _load_json(parsed_path)
-    return [ParsedObject.model_validate(item) for item in data]
+    return [PARSED_OBJECT_ADAPTER.validate_python(item) for item in data]
 
 
 @files_router.post("/chunks/{file_id}", response_model=dict[str, list[str]])

--- a/backend/routers/upload.py
+++ b/backend/routers/upload.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
-from ..models import ObjectsResponse, ParsedObject, UploadResponse
+from ..models import ObjectsResponse, PARSED_OBJECT_ADAPTER, ParsedObject, UploadResponse
 from ..services.parsing import parse_document
 from ..store import read_jsonl, upload_objects_path, write_jsonl
 
@@ -63,7 +63,7 @@ async def get_objects(
     if not path.exists():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Upload not found")
     raw_objects = read_jsonl(path)
-    objects = [ParsedObject.model_validate(obj) for obj in raw_objects]
+    objects = [PARSED_OBJECT_ADAPTER.validate_python(obj) for obj in raw_objects]
 
     total = len(objects)
     start = (page - 1) * page_size

--- a/backend/services/chunker.py
+++ b/backend/services/chunker.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from ..config import Settings, get_settings
-from ..models import ParsedObject, SectionNode, SectionSpan
+from ..models import PARSED_OBJECT_ADAPTER, ParsedObject, SectionNode, SectionSpan
 
 __all__ = ["compute_section_spans", "load_persisted_chunks", "run_chunking"]
 
@@ -42,7 +42,7 @@ def _load_parsed_objects(file_id: str, settings: Settings) -> list[ParsedObject]
         raise FileNotFoundError("parsed_objects_missing")
     with objects_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
-    return [ParsedObject.model_validate(item) for item in payload]
+    return [PARSED_OBJECT_ADAPTER.validate_python(item) for item in payload]
 
 
 def _load_sections(file_id: str, settings: Settings) -> SectionNode:

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -11,7 +11,7 @@ import httpx
 from ..constants import MAX_TOKENS_LIMIT
 
 from ..config import Settings, get_settings
-from ..models import ParsedObject, SectionNode, SectionSpan
+from ..models import PARSED_OBJECT_ADAPTER, ParsedObject, SectionNode, SectionSpan
 from .llm_client import LLMAdapter
 
 __all__ = ["build_headers_prompt", "parse_nested_list_to_tree"]
@@ -350,7 +350,7 @@ def run_header_discovery(file_id: str, llm_choice: str | None) -> SectionNode:
         raise FileNotFoundError("parsed_objects_missing")
     with objects_path.open("r", encoding="utf-8") as handle:
         data = json.load(handle)
-    objects = [ParsedObject.model_validate(item) for item in data]
+    objects = [PARSED_OBJECT_ADAPTER.validate_python(item) for item in data]
     prompt = build_headers_prompt(objects)
     adapter = _select_adapter(llm_choice, settings)
     try:

--- a/backend/services/parse_docx.py
+++ b/backend/services/parse_docx.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..models import ParsedObject
+from ..models import ParagraphObject, ParsedObject, TableObject
 
 try:  # pragma: no cover - optional dependency
     from docx import Document
@@ -26,14 +26,12 @@ def parse_docx(file_path: str) -> list[ParsedObject]:
         if not text:
             continue
         objects.append(
-            ParsedObject(
+            ParagraphObject(
                 object_id=f"{file_id}-docx-text-{order_index:06d}",
                 file_id=file_id,
-                kind="text",
                 text=text,
-                page_index=None,
-                bbox=None,
                 order_index=order_index,
+                paragraph_index=order_index,
                 metadata={"engine": "docx", "source": "python-docx"},
             )
         )
@@ -44,15 +42,17 @@ def parse_docx(file_path: str) -> list[ParsedObject]:
         for row in table.rows:
             rows.append([cell.text.strip() for cell in row.cells])
         table_text = "\n".join("\t".join(cell for cell in row) for row in rows)
+        n_rows = len(rows) or None
+        n_cols = max((len(row) for row in rows), default=0) or None
         objects.append(
-            ParsedObject(
+            TableObject(
                 object_id=f"{file_id}-docx-table-{table_index:06d}",
                 file_id=file_id,
-                kind="table",
                 text=table_text or None,
-                page_index=None,
-                bbox=None,
                 order_index=order_index,
+                markdown=table_text or None,
+                n_rows=n_rows,
+                n_cols=n_cols,
                 metadata={"engine": "docx", "source": "python-docx"},
             )
         )

--- a/backend/services/parse_txt.py
+++ b/backend/services/parse_txt.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from charset_normalizer import from_path
 
-from ..models import ParsedObject
+from ..models import LineObject, ParsedObject
 
 
 def parse_txt(file_path: str) -> list[ParsedObject]:
@@ -20,14 +20,15 @@ def parse_txt(file_path: str) -> list[ParsedObject]:
     objects: list[ParsedObject] = []
     for index, line in enumerate(text.splitlines()):
         objects.append(
-            ParsedObject(
+            LineObject(
                 object_id=f"{file_id}-txt-{index:06d}",
                 file_id=file_id,
-                kind="text",
                 text=line,
                 page_index=0,
                 bbox=None,
                 order_index=index,
+                line_index=index,
+                is_blank=len(line.strip()) == 0,
                 metadata={"engine": "txt", "encoding": best.encoding if best else "utf-8"},
             )
         )

--- a/backend/services/parsing/pdf_parser.py
+++ b/backend/services/parsing/pdf_parser.py
@@ -8,13 +8,17 @@ from uuid import uuid4
 
 import pdfplumber
 
+from ...models import FIGURE_KIND, LINE_KIND, TABLE_KIND
+
 
 def parse_pdf(path: Path) -> list[dict[str, Any]]:
     """Parse a PDF document into normalized objects."""
 
     objects: list[dict[str, Any]] = []
     with pdfplumber.open(path) as pdf:
-        for page_index, page in enumerate(pdf.pages, start=1):
+        for page_number, page in enumerate(pdf.pages, start=1):
+            page_index = page_number - 1
+            line_counter = 0
             words = page.extract_words(use_text_flow=True, keep_blank_chars=False)
             lines: dict[tuple[int | None, float], list[dict[str, Any]]] = defaultdict(list)
             for word in words:
@@ -34,14 +38,18 @@ def parse_pdf(path: Path) -> list[dict[str, Any]]:
                 ]
                 objects.append(
                     {
-                        "line_id": str(uuid4()),
-                        "type": "text",
-                        "page": page_index,
+                        "object_id": str(uuid4()),
+                        "file_id": path.stem,
+                        "kind": LINE_KIND,
+                        "text": content,
+                        "page_index": page_index,
                         "bbox": bbox,
-                        "content": content,
-                        "meta": None,
+                        "order_index": len(objects),
+                        "line_index": line_counter,
+                        "metadata": {"source": "pdf_parser"},
                     }
                 )
+                line_counter += 1
 
             # Fallback to raw text if no words were detected
             if not words:
@@ -52,14 +60,18 @@ def parse_pdf(path: Path) -> list[dict[str, Any]]:
                         continue
                     objects.append(
                         {
-                            "line_id": str(uuid4()),
-                            "type": "text",
-                            "page": page_index,
+                            "object_id": str(uuid4()),
+                            "file_id": path.stem,
+                            "kind": LINE_KIND,
+                            "text": text,
+                            "page_index": page_index,
                             "bbox": None,
-                            "content": text,
-                            "meta": None,
+                            "order_index": len(objects),
+                            "line_index": line_counter,
+                            "metadata": {"source": "pdf_parser", "fallback": True},
                         }
                     )
+                    line_counter += 1
 
             tables = page.extract_tables() or []
             for table in tables:
@@ -68,12 +80,16 @@ def parse_pdf(path: Path) -> list[dict[str, Any]]:
                 content_rows = [", ".join(filter(None, row)) for row in table]
                 objects.append(
                     {
-                        "line_id": str(uuid4()),
-                        "type": "table",
-                        "page": page_index,
+                        "object_id": str(uuid4()),
+                        "file_id": path.stem,
+                        "kind": TABLE_KIND,
+                        "text": "\n".join(content_rows),
+                        "page_index": page_index,
                         "bbox": None,
-                        "content": "\n".join(content_rows),
-                        "meta": {"rows": table},
+                        "order_index": len(objects),
+                        "n_rows": len(table) or None,
+                        "n_cols": max((len(row) for row in table), default=0) or None,
+                        "metadata": {"source": "pdf_parser", "rows": table},
                     }
                 )
 
@@ -86,12 +102,17 @@ def parse_pdf(path: Path) -> list[dict[str, Any]]:
                 ]
                 objects.append(
                     {
-                        "line_id": str(uuid4()),
-                        "type": "image",
-                        "page": page_index,
+                        "object_id": str(uuid4()),
+                        "file_id": path.stem,
+                        "kind": FIGURE_KIND,
+                        "text": "Embedded image",
+                        "page_index": page_index,
                         "bbox": bbox,
-                        "content": "Embedded image",
-                        "meta": {k: v for k, v in image.items() if k not in {"stream"}},
+                        "order_index": len(objects),
+                        "metadata": {
+                            "source": "pdf_parser",
+                            **{k: v for k, v in image.items() if k not in {"stream"}},
+                        },
                     }
                 )
 

--- a/backend/services/parsing/txt_parser.py
+++ b/backend/services/parsing/txt_parser.py
@@ -5,22 +5,32 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from ...models import LINE_KIND
+
 
 def parse_txt(path: Path) -> list[dict[str, Any]]:
+    """Parse a UTF-8 text file into canonical parsed objects."""
+
+    file_id = path.stem
     objects: list[dict[str, Any]] = []
     with path.open("r", encoding="utf-8") as fh:
-        for line in fh:
-            text = line.strip()
-            if not text:
+        for line_index, raw_line in enumerate(fh):
+            text = raw_line.rstrip("\n")
+            stripped = text.strip()
+            if not stripped:
                 continue
             objects.append(
                 {
-                    "line_id": str(uuid4()),
-                    "type": "text",
-                    "page": None,
+                    "object_id": str(uuid4()),
+                    "file_id": file_id,
+                    "kind": LINE_KIND,
+                    "text": stripped,
+                    "page_index": 0,
                     "bbox": None,
-                    "content": text,
-                    "meta": None,
+                    "order_index": len(objects),
+                    "line_index": line_index,
+                    "is_blank": False,
+                    "metadata": {"source": "txt_parser"},
                 }
             )
     return objects

--- a/backend/services/pdf_mineru.py
+++ b/backend/services/pdf_mineru.py
@@ -6,7 +6,15 @@ from pathlib import Path
 from typing import Any
 
 from ..config import Settings, get_settings
-from ..models import ParsedObject
+from ..models import (
+    FigureObject,
+    HeaderObject,
+    LineObject,
+    ParagraphObject,
+    ParsedObject,
+    TableObject,
+    Word,
+)
 from .pdf_native import NativePdfParser
 
 __all__ = ["MinerUPdfParser", "MinerUUnavailableError"]
@@ -83,25 +91,96 @@ class MinerUPdfParser:
 
         objects: list[ParsedObject] = []
         order_index = 0
+        def _coerce_int(value: Any) -> int | None:
+            if value is None:
+                return None
+            if isinstance(value, bool):
+                return int(value)
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+            if isinstance(value, str):
+                text = value.strip()
+                if not text:
+                    return None
+                try:
+                    return int(float(text))
+                except ValueError:
+                    return None
+            return None
+
         for item in result if isinstance(result, list) else []:
-            kind = item.get("kind", "text")
-            text = item.get("text")
-            page_index = item.get("page_index")
-            bbox = item.get("bbox")
-            metadata = item.get("metadata", {})
-            metadata = {**metadata, "engine": engine}
-            objects.append(
-                ParsedObject(
-                    object_id=f"{file_id}-mineru-{order_index:06d}",
-                    file_id=file_id,
-                    kind=kind,
-                    text=text,
-                    page_index=page_index,
-                    bbox=bbox,
-                    order_index=order_index,
-                    metadata=metadata,
+            metadata = {**(item.get("metadata") or {}), "engine": engine}
+            base_kwargs = {
+                "object_id": f"{file_id}-mineru-{order_index:06d}",
+                "file_id": file_id,
+                "text": item.get("text"),
+                "page_index": item.get("page_index"),
+                "bbox": item.get("bbox"),
+                "order_index": order_index,
+                "metadata": metadata,
+            }
+            kind = (item.get("kind") or "para").lower()
+            if kind in {"line", "textline"}:
+                words_payload = item.get("words") or []
+                words: list[Word] = []
+                for word in words_payload:
+                    if isinstance(word, Word):
+                        words.append(word)
+                    elif isinstance(word, str):
+                        words.append(Word(text=word))
+                    else:
+                        words.append(Word.model_validate(word))
+                obj = LineObject(
+                    **base_kwargs,
+                    words=words,
+                    line_index=item.get("line_index"),
+                    is_blank=item.get("is_blank"),
                 )
-            )
+            elif kind in {"para", "paragraph", "text"}:
+                line_span = item.get("line_span")
+                if isinstance(line_span, (list, tuple)):
+                    processed_span = []
+                    for entry in line_span:
+                        try:
+                            processed_span.append(int(entry))
+                        except (TypeError, ValueError):
+                            break
+                    else:
+                        line_span = processed_span
+                else:
+                    line_span = None
+                obj = ParagraphObject(
+                    **base_kwargs,
+                    line_span=line_span if isinstance(line_span, list) else None,
+                    paragraph_index=item.get("paragraph_index"),
+                )
+            elif kind in {"header", "heading"}:
+                obj = HeaderObject(
+                    **base_kwargs,
+                    level=int(item.get("level", 1)),
+                    number=item.get("number"),
+                    normalized_text=item.get("normalized_text"),
+                    path=item.get("path"),
+                )
+            elif kind == "table":
+                obj = TableObject(
+                    **base_kwargs,
+                    n_rows=_coerce_int(item.get("n_rows")),
+                    n_cols=_coerce_int(item.get("n_cols")),
+                    has_header_row=item.get("has_header_row"),
+                    markdown=item.get("markdown") or item.get("text"),
+                )
+            elif kind in {"figure", "image"}:
+                obj = FigureObject(
+                    **base_kwargs,
+                    caption=item.get("caption"),
+                    ref_id=item.get("ref_id"),
+                )
+            else:
+                raise ValueError(f"Unsupported MinerU object kind: {kind}")
+            objects.append(obj)
             order_index += 1
         if not objects:
             # As a last resort fall back to the native parser but annotate provenance.

--- a/backend/services/pdf_parser.py
+++ b/backend/services/pdf_parser.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from ..config import Settings, get_settings
-from ..models import ParsedObject
+from ..models import (
+    FIGURE_KIND,
+    LINE_KIND,
+    PARAGRAPH_KIND,
+    TABLE_KIND,
+    ParsedObject,
+)
 from .pdf_mineru import MinerUPdfParser, MinerUUnavailableError
 from .pdf_native import NativePdfParser
 
@@ -38,9 +44,12 @@ class AutoPdfParser:
     def _should_use_mineru(self, native_objects: list[ParsedObject]) -> bool:
         if not self.settings.MINERU_ENABLED:
             return False
-        text_chars = sum(len(obj.text or "") for obj in native_objects if obj.kind == "text")
-        has_images = any(obj.kind == "image" for obj in native_objects)
-        has_tables = any(obj.kind == "table" for obj in native_objects)
+        textual_kinds = {LINE_KIND, PARAGRAPH_KIND}
+        text_chars = sum(
+            len(obj.text or "") for obj in native_objects if obj.kind in textual_kinds
+        )
+        has_images = any(obj.kind == FIGURE_KIND for obj in native_objects)
+        has_tables = any(obj.kind == TABLE_KIND for obj in native_objects)
         low_density = text_chars < 200
         return (low_density and has_images) or (not has_tables and has_images)
 

--- a/backend/services/specs.py
+++ b/backend/services/specs.py
@@ -8,12 +8,13 @@ from pathlib import Path
 from typing import Iterable
 
 from ..config import Settings, get_settings
-from ..models import ParsedObject, SectionNode, SpecItem
+from ..models import LINE_KIND, PARAGRAPH_KIND, ParsedObject, SectionNode, SpecItem
 from .llm_client import LLMAdapter
 
 __all__ = ["build_specs_prompt", "extract_specs_for_sections"]
 
 _MAX_SECTION_TEXT = 10_000
+_TEXTUAL_KINDS = {LINE_KIND, PARAGRAPH_KIND}
 _UNIT_PATTERN = re.compile(
     r"\b\d+(?:\.\d+)?\s?(?:mm|cm|m|in|ft|N|kN|MPa|GPa|°C|°F)\b",
     re.IGNORECASE,
@@ -191,7 +192,7 @@ def extract_specs_for_sections(
         section_lines: list[str] = []
         for object_id in sorted_ids:
             obj = indexed_objects[object_id]
-            if obj.kind != "text":
+            if obj.kind not in _TEXTUAL_KINDS:
                 continue
             text = (obj.text or "").strip()
             if text:

--- a/backend/services/text_blocks.py
+++ b/backend/services/text_blocks.py
@@ -5,7 +5,15 @@ import difflib
 import re
 from typing import Sequence
 
-from ..models import HeaderItem, ParsedObject
+from ..models import (
+    HEADER_KIND,
+    LINE_KIND,
+    PARAGRAPH_KIND,
+    TABLE_KIND,
+    HeaderItem,
+    PARSED_OBJECT_TYPES,
+    ParsedObject,
+)
 
 
 def document_lines(objects: Sequence[dict | ParsedObject]) -> list[str]:
@@ -14,15 +22,15 @@ def document_lines(objects: Sequence[dict | ParsedObject]) -> list[str]:
     lines: list[str] = []
     for obj in objects:
         data = obj
-        if isinstance(obj, ParsedObject):
+        if isinstance(obj, PARSED_OBJECT_TYPES):
             data = obj.model_dump()
         kind = data.get("kind") or data.get("type")
         text = data.get("text") or data.get("content") or ""
-        if kind == "text":
+        if kind in {LINE_KIND, PARAGRAPH_KIND, HEADER_KIND}:
             content = str(text).strip()
             if content:
                 lines.append(content)
-        elif kind == "table":
+        elif kind == TABLE_KIND:
             content = str(text).strip()
             if content:
                 lines.extend(line.strip() for line in content.splitlines() if line.strip())

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -8,19 +8,19 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backend.models import ParsedObject, SectionNode, SectionSpan
+from backend.models import ParagraphObject, ParsedObject, SectionNode, SectionSpan
 from backend.services.chunker import compute_section_spans
 
 
 def _make_object(file_id: str, index: int, text: str) -> ParsedObject:
-    return ParsedObject(
+    return ParagraphObject(
         object_id=f"{file_id}-obj-{index}",
         file_id=file_id,
-        kind="text",
         text=text,
         page_index=0,
         bbox=None,
         order_index=index,
+        paragraph_index=index,
     )
 
 

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -8,19 +8,19 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backend.models import BoundingBox, ParsedObject, SectionNode, SpecItem
+from backend.models import BoundingBox, LineObject, SectionNode, SpecItem
 
 
 def test_models_schema() -> None:
     bbox = BoundingBox(x0=0, y0=0, x1=10, y1=10)
-    parsed = ParsedObject(
+    parsed = LineObject(
         object_id="file-obj-1",
         file_id="file",
-        kind="text",
         text="example",
         page_index=0,
         bbox=[bbox.x0, bbox.y0, bbox.x1, bbox.y1],
         order_index=0,
+        line_index=0,
     )
     section = SectionNode(
         section_id="sec-root",
@@ -45,7 +45,7 @@ def test_models_schema() -> None:
         source_object_ids=[parsed.object_id],
     )
 
-    assert parsed.kind == "text"
+    assert parsed.kind == "line"
     assert parsed.order_index == 0
     assert section.children[0].depth == 1
     assert spec.source_object_ids == [parsed.object_id]

--- a/backend/tests/test_parent_aggregation.py
+++ b/backend/tests/test_parent_aggregation.py
@@ -15,7 +15,7 @@ if str(ROOT) not in sys.path:
 
 from backend.config import get_settings
 from backend.main import create_app
-from backend.models import ParsedObject, SectionNode
+from backend.models import PARSED_OBJECT_ADAPTER, ParsedObject, SectionNode
 from backend.services.chunker import compute_section_spans
 
 
@@ -67,7 +67,7 @@ def test_parent_equals_union() -> None:
     try:
         with objects_path.open("r", encoding="utf-8") as handle:
             raw_objects = json.load(handle)
-        objects = [ParsedObject.model_validate(item) for item in raw_objects]
+        objects = [PARSED_OBJECT_ADAPTER.validate_python(item) for item in raw_objects]
 
         mapping = compute_section_spans(root, objects)
         mapping_again = compute_section_spans(root, objects)

--- a/backend/tests/test_parse_docx.py
+++ b/backend/tests/test_parse_docx.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import create_app
+from backend.models import LINE_KIND, PARAGRAPH_KIND
 
 
 client = TestClient(create_app())
@@ -54,5 +55,9 @@ def test_parse_docx_golden() -> None:
     assert parsed.status_code == 200, parsed.text
     objects = parsed.json()
     _assert_objects_shape(objects)
-    texts = [obj.get("text") for obj in objects if obj["kind"] == "text" and obj.get("text")]
+    texts = [
+        obj.get("text")
+        for obj in objects
+        if obj["kind"] in {LINE_KIND, PARAGRAPH_KIND} and obj.get("text")
+    ]
     assert any(text and ("Hello" in text or "World" in text) for text in texts)

--- a/backend/tests/test_parse_pdf_native.py
+++ b/backend/tests/test_parse_pdf_native.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import create_app
+from backend.models import LINE_KIND, PARAGRAPH_KIND
 
 
 client = TestClient(create_app())
@@ -77,4 +78,4 @@ def test_pdf_native_golden() -> None:
     assert parsed.status_code == 200, parsed.text
     objects = parsed.json()
     _assert_objects_shape(objects)
-    assert any(obj["kind"] == "text" for obj in objects)
+    assert any(obj["kind"] in {LINE_KIND, PARAGRAPH_KIND} for obj in objects)

--- a/backend/tests/test_parse_txt.py
+++ b/backend/tests/test_parse_txt.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from backend.main import create_app
+from backend.models import LINE_KIND, PARAGRAPH_KIND
 
 
 client = TestClient(create_app())
@@ -40,7 +41,11 @@ def test_parse_txt_golden() -> None:
     assert parsed.status_code == 200, parsed.text
     objects = parsed.json()
     _assert_objects_shape(objects)
-    texts = [obj.get("text") for obj in objects if obj["kind"] == "text" and obj.get("text")]
+    texts = [
+        obj.get("text")
+        for obj in objects
+        if obj["kind"] in {LINE_KIND, PARAGRAPH_KIND} and obj.get("text")
+    ]
     assert any(
         text is not None and any(line in text for line in ("alpha", "beta", "gamma"))
         for text in texts

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from backend.models import LINE_KIND, PARAGRAPH_KIND, TABLE_KIND
 from backend.services.parsing import parse_document
 
 
@@ -16,8 +17,8 @@ def test_parse_txt(tmp_path: Path) -> None:
     objects = parse_document(sample)
 
     assert len(objects) == 3
-    assert all(obj["type"] == "text" for obj in objects)
-    assert {obj["content"] for obj in objects} == {"Line one", "Line two", "Line three"}
+    assert all(obj["kind"] == LINE_KIND for obj in objects)
+    assert {obj["text"] for obj in objects} == {"Line one", "Line two", "Line three"}
 
 
 def test_parse_docx(tmp_path: Path) -> None:
@@ -36,11 +37,11 @@ def test_parse_docx(tmp_path: Path) -> None:
 
     objects = parse_document(sample)
 
-    texts = [obj for obj in objects if obj["type"] == "text"]
-    tables = [obj for obj in objects if obj["type"] == "table"]
+    texts = [obj for obj in objects if obj["kind"] == PARAGRAPH_KIND]
+    tables = [obj for obj in objects if obj["kind"] == TABLE_KIND]
 
-    assert any(obj["content"] == "Introduction" for obj in texts)
-    assert any("Header" in obj["content"] for obj in tables)
+    assert any(obj["text"] == "Introduction" for obj in texts)
+    assert any("Header" in (obj["text"] or "") for obj in tables)
 
 
 def test_parse_pdf(tmp_path: Path) -> None:
@@ -58,7 +59,7 @@ def test_parse_pdf(tmp_path: Path) -> None:
 
     objects = parse_document(sample)
 
-    assert any(obj["type"] == "text" for obj in objects)
-    contents = "\n".join(obj["content"] for obj in objects if obj["type"] == "text")
+    assert any(obj["kind"] == LINE_KIND for obj in objects)
+    contents = "\n".join(obj["text"] for obj in objects if obj["kind"] == LINE_KIND)
     assert "Introduction" in contents
     assert "Provide two bolts" in contents

--- a/backend/tests/test_pdf_parity.py
+++ b/backend/tests/test_pdf_parity.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import create_app
+from backend.models import FIGURE_KIND, LINE_KIND, PARAGRAPH_KIND, TABLE_KIND
 
 
 client = TestClient(create_app())
@@ -84,8 +85,9 @@ def test_native_vs_mineru_parity() -> None:
 
     native_kinds = {obj["kind"] for obj in native_objects}
     mineru_kinds = {obj["kind"] for obj in mineru_objects}
-    assert native_kinds & {"text", "table", "image"}
-    assert mineru_kinds & {"text", "table", "image"}
-    assert native_kinds & {"text", "table", "image"} == mineru_kinds & {"text", "table", "image"}
+    canonical_kinds = {LINE_KIND, PARAGRAPH_KIND, TABLE_KIND, FIGURE_KIND}
+    assert native_kinds & canonical_kinds
+    assert mineru_kinds & canonical_kinds
+    assert (native_kinds & canonical_kinds) == (mineru_kinds & canonical_kinds)
 
     assert abs(len(native_objects) - len(mineru_objects)) <= max(2, len(native_objects) // 2)

--- a/backend/tests/test_specs_merge.py
+++ b/backend/tests/test_specs_merge.py
@@ -11,7 +11,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from backend.config import get_settings
-from backend.models import ParsedObject, SectionNode
+from backend.models import ParagraphObject, ParsedObject, SectionNode
 from backend.services.specs import extract_specs_for_sections
 
 
@@ -57,21 +57,21 @@ def test_dedup_and_merge() -> None:
         (chunks_dir / "chunks.json").write_text(json.dumps(chunk_map))
 
         objects = [
-            ParsedObject(
+            ParagraphObject(
                 object_id="obj-1",
                 file_id=file_id,
-                kind="text",
                 text="- Maximum load 500 N",
                 page_index=0,
                 order_index=0,
+                paragraph_index=0,
             ),
-            ParsedObject(
+            ParagraphObject(
                 object_id="obj-2",
                 file_id=file_id,
-                kind="text",
                 text="- Allowable stress per ASTM A36",
                 page_index=0,
                 order_index=1,
+                paragraph_index=1,
             ),
         ]
 


### PR DESCRIPTION
## Summary
- replace the generic `ParsedObject` model with typed line/paragraph/header/table/figure variants and shared constants
- update ingestion, parsing, and spec utilities to emit validated canonical objects and refresh corresponding tests
- align the standalone parsing helpers and their unit tests with the canonical schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11d4bc4dc83249472fbaf48b22b57