### PR TITLE
Respect custom OpenRouter base URL

### DIFF
--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -1,0 +1,36 @@
+"""Utilities for interacting with the OpenRouter API."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import HTTPException, status
+
+DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def normalize_openrouter_base_url(raw_base_url: str | None) -> str:
+    """Return a sanitized base URL for OpenRouter requests."""
+
+    base_url = (raw_base_url or DEFAULT_OPENROUTER_BASE_URL).strip()
+    if not base_url:
+        base_url = DEFAULT_OPENROUTER_BASE_URL
+
+    if "://" not in base_url:
+        base_url = f"https://{base_url}"
+
+    try:
+        parsed = httpx.URL(base_url)
+    except httpx.InvalidURL as exc:  # pragma: no cover - input validation
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid base_url: {exc}",
+        ) from exc
+
+    if not parsed.scheme or not parsed.host:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="base_url must include a hostname",
+        )
+
+    return str(parsed)
+

--- a/backend/services/llm/llm_provider.py
+++ b/backend/services/llm/llm_provider.py
@@ -55,7 +55,12 @@ def get_provider(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="OpenRouter API key is required",
             )
-        return OpenRouterProvider(model=model, params=params, api_key=api_key)
+        return OpenRouterProvider(
+            model=model,
+            params=params,
+            api_key=api_key,
+            base_url=base_url,
+        )
     if provider == "llamacpp":
         from .llamacpp import LlamaCPPProvider
 

--- a/backend/services/llm/openrouter.py
+++ b/backend/services/llm/openrouter.py
@@ -5,14 +5,27 @@ from typing import Any, List
 
 import httpx
 
+from ...openrouter import normalize_openrouter_base_url
 from .llm_provider import LLMProvider
 
 
 class OpenRouterProvider(LLMProvider):
-    def __init__(self, *, model: str, params: dict[str, Any] | None, api_key: str) -> None:
+    def __init__(
+        self,
+        *,
+        model: str,
+        params: dict[str, Any] | None,
+        api_key: str,
+        base_url: str | None = None,
+    ) -> None:
         super().__init__(model=model, params=params)
         self.api_key = api_key
-        self.endpoint = "https://openrouter.ai/api/v1/chat/completions"
+        normalized_base_url = normalize_openrouter_base_url(base_url)
+        endpoint = normalized_base_url.rstrip("/")
+        if not endpoint.endswith("/chat/completions"):
+            endpoint = f"{endpoint}/chat/completions"
+        self.base_url = normalized_base_url
+        self.endpoint = endpoint
 
     async def _chat(self, messages: List[dict[str, str]]) -> str:
         payload: dict[str, Any] = {"model": self.model, "messages": messages}

--- a/backend/tests/test_headers_router.py
+++ b/backend/tests/test_headers_router.py
@@ -11,30 +11,30 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backend.routers.headers import _normalize_openrouter_base_url
+from backend.openrouter import normalize_openrouter_base_url
 
 
 def test_normalize_base_url_defaults_to_openrouter() -> None:
     assert (
-        _normalize_openrouter_base_url(None)
+        normalize_openrouter_base_url(None)
         == "https://openrouter.ai/api/v1"
     )
     assert (
-        _normalize_openrouter_base_url("  \t")
+        normalize_openrouter_base_url("  \t")
         == "https://openrouter.ai/api/v1"
     )
 
 
 def test_normalize_base_url_adds_scheme_when_missing() -> None:
     assert (
-        _normalize_openrouter_base_url("openrouter.ai/api/v1")
+        normalize_openrouter_base_url("openrouter.ai/api/v1")
         == "https://openrouter.ai/api/v1"
     )
 
 
 def test_normalize_base_url_rejects_invalid_value() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        _normalize_openrouter_base_url("http://")
+        normalize_openrouter_base_url("http://")
 
     error = exc_info.value
     assert error.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/tests/test_openrouter_provider.py
+++ b/backend/tests/test_openrouter_provider.py
@@ -1,0 +1,162 @@
+"""Tests for the OpenRouter LLM provider."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.services.llm.openrouter import OpenRouterProvider
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Configure pytest-anyio to use asyncio."""
+
+    return "asyncio"
+
+
+def _mock_async_client(
+    expected_url: str,
+    expected_payload: Dict[str, Any],
+    expected_headers: Dict[str, str],
+    response_data: Dict[str, Any],
+):
+    class _AsyncClient:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - test helper
+            self.args = args
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> "_AsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, json: dict, headers: Dict[str, str]):
+            assert url == expected_url
+            assert json == expected_payload
+            assert headers.get("Authorization") == expected_headers["Authorization"]
+            assert headers.get("Content-Type") == expected_headers["Content-Type"]
+            return httpx.Response(
+                status_code=200,
+                json=response_data,
+                request=httpx.Request("POST", url),
+            )
+
+    return _AsyncClient
+
+
+@pytest.mark.anyio
+async def test_openrouter_provider_uses_default_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = OpenRouterProvider(
+        model="gpt-4",
+        params={},
+        api_key="secret",
+        base_url=None,
+    )
+    expected_payload = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    response_data = {
+        "choices": [{"message": {"role": "assistant", "content": "Hi"}}],
+    }
+    mock_client = _mock_async_client(
+        "https://openrouter.ai/api/v1/chat/completions",
+        expected_payload,
+        {
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        },
+        response_data,
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", mock_client)
+
+    result = await provider._chat([{"role": "user", "content": "Hello"}])
+
+    assert result == "Hi"
+
+
+@pytest.mark.anyio
+async def test_openrouter_provider_respects_custom_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = OpenRouterProvider(
+        model="spec-model",
+        params={"temperature": 0.2},
+        api_key="secret",
+        base_url="https://router.example/api/v1",
+    )
+    expected_payload = {
+        "model": "spec-model",
+        "messages": [{"role": "user", "content": "Ping"}],
+        "temperature": 0.2,
+    }
+    response_data = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "Pong"}},
+        ],
+    }
+    mock_client = _mock_async_client(
+        "https://router.example/api/v1/chat/completions",
+        expected_payload,
+        {
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        },
+        response_data,
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", mock_client)
+
+    result = await provider._chat([{"role": "user", "content": "Ping"}])
+
+    assert result == "Pong"
+
+
+@pytest.mark.anyio
+async def test_openrouter_provider_accepts_base_url_without_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = OpenRouterProvider(
+        model="spec-model",
+        params={},
+        api_key="secret",
+        base_url="router.example/api/v1",
+    )
+    response_data = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "Response"}},
+        ],
+    }
+    mock_client = _mock_async_client(
+        "https://router.example/api/v1/chat/completions",
+        {
+            "model": "spec-model",
+            "messages": [{"role": "user", "content": "Hi"}],
+        },
+        {
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        },
+        response_data,
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", mock_client)
+
+    result = await provider._chat([{"role": "user", "content": "Hi"}])
+
+    assert result == "Response"
+
+
+def test_openrouter_provider_rejects_invalid_base_url() -> None:
+    with pytest.raises(HTTPException):
+        OpenRouterProvider(
+            model="spec-model",
+            params={},
+            api_key="secret",
+            base_url="http://",
+        )
+


### PR DESCRIPTION
## Summary
- centralize OpenRouter base URL normalization and reuse it across the backend
- ensure OpenRouter providers honour the configured base URL when sending requests
- cover the new behaviour with focused unit tests

## Testing
- pytest backend/tests/test_headers_router.py backend/tests/test_openrouter_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68e12535e3cc8324be8040268af86179