### PR TITLE
Ensure OpenRouter requests use correct endpoint

### DIFF
--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -32,5 +32,9 @@ def normalize_openrouter_base_url(raw_base_url: str | None) -> str:
             detail="base_url must include a hostname",
         )
 
-    return str(parsed)
+    sanitized = parsed.copy_with(query=None, fragment=None)
+    if sanitized.scheme == "http":
+        sanitized = sanitized.copy_with(scheme="https")
+
+    return str(sanitized)
 

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException, status
-from httpx import InvalidURL
 
 from ..models import HeaderItem, OpenRouterHeadersRequest
+from ..openrouter import normalize_openrouter_base_url
 from ._headers_common import (
     build_header_messages,
     fetch_document_text,
@@ -15,41 +15,6 @@ from ._headers_common import (
 )
 
 router = APIRouter(prefix="/api/openrouter", tags=["headers"])
-
-
-def _normalize_openrouter_base_url(raw_base_url: str | None) -> str:
-    """Return a sanitized base URL for OpenRouter requests.
-
-    The UI allows users to input a custom base URL. Some users provide a host
-    without a scheme (e.g. ``openrouter.ai/api/v1``), which causes ``httpx`` to
-    treat the entire string as a hostname and yields a DNS error such as
-    ``getaddrinfo failed``. To avoid this sharp edge we coerce the scheme to
-    HTTPS when missing and rely on ``httpx``'s URL parser to validate the
-    resulting URL.
-    """
-
-    base_url = (raw_base_url or "https://openrouter.ai/api/v1").strip()
-    if not base_url:
-        base_url = "https://openrouter.ai/api/v1"
-
-    if "://" not in base_url:
-        base_url = f"https://{base_url}"
-
-    try:
-        parsed = httpx.URL(base_url)
-    except InvalidURL as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid base_url: {exc}",
-        ) from exc
-
-    if not parsed.scheme or not parsed.host:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="base_url must include a hostname",
-        )
-
-    return str(parsed)
 
 
 async def _chat_via_openrouter(
@@ -154,7 +119,7 @@ async def extract_openrouter_headers(
     document = fetch_document_text(payload.upload_id)
     messages = build_header_messages(document)
 
-    base_url = _normalize_openrouter_base_url(payload.base_url)
+    base_url = normalize_openrouter_base_url(payload.base_url)
     timeout = float((payload.params or {}).get("timeout", 60.0))
     response_text = await _chat_via_openrouter(
         base_url=base_url,

--- a/backend/tests/test_headers_router.py
+++ b/backend/tests/test_headers_router.py
@@ -32,6 +32,13 @@ def test_normalize_base_url_adds_scheme_when_missing() -> None:
     )
 
 
+def test_normalize_base_url_upgrades_http_scheme() -> None:
+    assert (
+        normalize_openrouter_base_url("http://openrouter.ai/api/v1")
+        == "https://openrouter.ai/api/v1"
+    )
+
+
 def test_normalize_base_url_rejects_invalid_value() -> None:
     with pytest.raises(HTTPException) as exc_info:
         normalize_openrouter_base_url("http://")

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -84,6 +84,8 @@ export async function updateModelSettings(payload) {
 function buildPayload({ uploadId, provider, model, params, apiKey, baseUrl }, options = {}) {
   const includeProvider = options.includeProvider !== false;
   const normalizedProvider = provider || "openrouter";
+  const sanitizedApiKey = typeof apiKey === "string" ? apiKey.trim() : "";
+  const sanitizedBaseUrl = typeof baseUrl === "string" ? baseUrl.trim() : "";
   const payload = {
     upload_id: uploadId,
     model,
@@ -93,15 +95,12 @@ function buildPayload({ uploadId, provider, model, params, apiKey, baseUrl }, op
     payload.provider = normalizedProvider;
   }
   if (normalizedProvider === "openrouter") {
-    if (apiKey) {
-      payload.api_key = apiKey;
-    }
-    if (baseUrl) {
-      payload.base_url = baseUrl;
+    if (sanitizedApiKey) {
+      payload.api_key = sanitizedApiKey;
     }
   }
-  if (normalizedProvider === "llamacpp" && baseUrl) {
-    payload.base_url = baseUrl;
+  if (normalizedProvider === "llamacpp" && sanitizedBaseUrl) {
+    payload.base_url = sanitizedBaseUrl;
   }
   return payload;
 }


### PR DESCRIPTION
## Summary
- reuse the shared OpenRouter base URL normalizer for the headers router and upgrade any http scheme to https
- stop including the llama.cpp base URL when issuing OpenRouter requests from the UI and trim submitted credentials
- add coverage that verifies the normalization handles http URLs for OpenRouter

## Testing
- pytest backend/tests/test_headers_router.py backend/tests/test_openrouter_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68e12771b5c483249f949c71214fe466