### PR TITLE
Enrich headers with location metadata and preview UI

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -217,6 +217,9 @@ class OllamaHeadersRequest(BaseModel):
 class HeaderItem(BaseModel):
     section_number: str
     section_name: str
+    page_number: int | None = None
+    line_number: int | None = None
+    chunk_text: str | None = None
 
 
 class SpecsRequest(BaseModel):

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -64,7 +64,7 @@ async def extract_specs(payload: SpecsRequest) -> List[SpecItem]:
 
     specs: list[SpecItem] = []
     for header in headers:
-        text = section_text(lines, headers, header)
+        text = header.chunk_text or section_text(lines, headers, header)
         prompt = _SPEC_PROMPT_TEMPLATE.format(
             section_number=header.section_number,
             section_name=header.section_name,

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -7,7 +7,9 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from backend.models import LINE_KIND, PARAGRAPH_KIND, TABLE_KIND
+from backend.routers._headers_common import parse_and_store_headers
 from backend.services.parsing import parse_document
+from backend.store import headers_path, read_json, upload_objects_path, write_jsonl
 
 
 def test_parse_txt(tmp_path: Path) -> None:
@@ -63,3 +65,76 @@ def test_parse_pdf(tmp_path: Path) -> None:
     contents = "\n".join(obj["text"] for obj in objects if obj["kind"] == LINE_KIND)
     assert "Introduction" in contents
     assert "Provide two bolts" in contents
+
+
+def test_parse_and_store_headers_includes_locations(
+    tmp_path: Path, monkeypatch
+) -> None:
+    upload_id = "sample"
+
+    objects = [
+        {
+            "object_id": "obj-1",
+            "file_id": upload_id,
+            "kind": "line",
+            "text": "1 Introduction",
+            "page_index": 0,
+            "line_index": 0,
+            "order_index": 0,
+        },
+        {
+            "object_id": "obj-2",
+            "file_id": upload_id,
+            "kind": "line",
+            "text": "Project overview and goals.",
+            "page_index": 0,
+            "line_index": 1,
+            "order_index": 1,
+        },
+        {
+            "object_id": "obj-3",
+            "file_id": upload_id,
+            "kind": "line",
+            "text": "2 Scope",
+            "page_index": 1,
+            "line_index": 0,
+            "order_index": 2,
+        },
+        {
+            "object_id": "obj-4",
+            "file_id": upload_id,
+            "kind": "line",
+            "text": "System requirements and constraints.",
+            "page_index": 1,
+            "line_index": 1,
+            "order_index": 3,
+        },
+    ]
+
+    from backend import store
+
+    monkeypatch.setattr(store, "_TMP_DIR", tmp_path, raising=False)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    write_jsonl(upload_objects_path(upload_id), objects)
+
+    response = "\n".join(["#headers#", "1 Introduction", "2 Scope", "#headers#"])
+    headers = parse_and_store_headers(upload_id, response)
+
+    assert len(headers) == 2
+
+    intro, scope = headers
+
+    assert intro.page_number == 1
+    assert intro.line_number == 1
+    assert intro.chunk_text == "1 Introduction\nProject overview and goals."
+
+    assert scope.page_number == 2
+    assert scope.line_number == 1
+    assert scope.chunk_text == "2 Scope\nSystem requirements and constraints."
+
+    persisted = read_json(headers_path(upload_id))
+    assert isinstance(persisted, list)
+    assert persisted[0]["page_number"] == 1
+    assert persisted[0]["line_number"] == 1
+    assert "chunk_text" in persisted[0]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,7 +78,9 @@
             <div id="headers-tree" class="headers-tree"></div>
             <div class="preview">
               <h3>Section Preview</h3>
-              <pre id="section-preview">Select a header to preview text.</pre>
+              <div id="section-preview" class="section-preview-body">
+                <p class="section-preview-placeholder">Select a header to preview text.</p>
+              </div>
             </div>
           </section>
           <section class="tab-content hidden" id="tab-specs">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -137,9 +137,16 @@ function getProcessedSections() {
 function selectHeader(header, { refresh = true } = {}) {
   if (!header) return;
   activeSection = header.section_number;
-  const preview = state.sectionTexts.get(header.section_number) || computeSectionText(header);
-  setSectionText(header.section_number, preview);
-  updateSectionPreview(sectionPreviewEl, preview);
+  let preview = header.chunk_text;
+  if (preview == null) {
+    preview = state.sectionTexts.get(header.section_number);
+  }
+  if (preview == null) {
+    preview = computeSectionText(header);
+  }
+  const text = preview ?? "";
+  setSectionText(header.section_number, text);
+  updateSectionPreview(sectionPreviewEl, { header, text });
   if (refresh) {
     refreshHeaders();
   }
@@ -230,8 +237,10 @@ async function handleHeaders() {
     const headers = await requestHeaders(config);
     setHeaders(headers);
     headers.forEach((header) => {
-      const text = computeSectionText(header);
-      if (text) setSectionText(header.section_number, text);
+      const text = header.chunk_text || computeSectionText(header);
+      if (text !== undefined && text !== null) {
+        setSectionText(header.section_number, text);
+      }
     });
     if (headers.length > 0) {
       selectHeader(headers[0], { refresh: false });

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -34,10 +34,29 @@ function createHeaderButton(header, { activeSection, processedSections, onSelect
   }
   button.appendChild(status);
 
-  const label = document.createElement("span");
-  label.className = "header-label";
-  label.textContent = `${header.section_number} ${header.section_name}`;
-  button.appendChild(label);
+  const details = document.createElement("div");
+  details.className = "header-details";
+
+  const title = document.createElement("span");
+  title.className = "header-label";
+  title.textContent = `${header.section_number} ${header.section_name}`;
+  details.appendChild(title);
+
+  const locationParts = [];
+  if (header.page_number != null) {
+    locationParts.push(`Page ${header.page_number}`);
+  }
+  if (header.line_number != null) {
+    locationParts.push(`Line ${header.line_number}`);
+  }
+  if (locationParts.length > 0) {
+    const meta = document.createElement("span");
+    meta.className = "header-meta";
+    meta.textContent = locationParts.join(" • ");
+    details.appendChild(meta);
+  }
+
+  button.appendChild(details);
 
   button.addEventListener("click", () => onSelect?.(header));
   return button;
@@ -95,8 +114,54 @@ export function renderSidebarHeadersList(container, headers, { onSelect, activeS
   container.appendChild(list);
 }
 
-export function updateSectionPreview(element, text) {
-  element.textContent = text || "No preview available.";
+export function updateSectionPreview(element, preview) {
+  element.innerHTML = "";
+
+  if (!preview) {
+    const placeholder = document.createElement("p");
+    placeholder.className = "section-preview-placeholder";
+    placeholder.textContent = "Select a header to preview text.";
+    element.appendChild(placeholder);
+    return;
+  }
+
+  if (typeof preview === "string") {
+    const placeholder = document.createElement("p");
+    placeholder.className = "section-preview-placeholder";
+    placeholder.textContent = preview;
+    element.appendChild(placeholder);
+    return;
+  }
+
+  const { header, text } = preview;
+  if (!header) {
+    updateSectionPreview(element, text || "Select a header to preview text.");
+    return;
+  }
+
+  const title = document.createElement("p");
+  title.className = "section-preview-title";
+  title.textContent = `${header.section_number} ${header.section_name}`;
+  element.appendChild(title);
+
+  const metaParts = [];
+  if (header.page_number != null) {
+    metaParts.push(`Page ${header.page_number}`);
+  }
+  if (header.line_number != null) {
+    metaParts.push(`Line ${header.line_number}`);
+  }
+  if (metaParts.length > 0) {
+    const meta = document.createElement("p");
+    meta.className = "section-preview-meta";
+    meta.textContent = metaParts.join(" • ");
+    element.appendChild(meta);
+  }
+
+  const pre = document.createElement("pre");
+  pre.className = "section-preview-text";
+  pre.textContent = text || "No preview available.";
+  element.appendChild(pre);
 }
 
 function normalize(value) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -205,7 +205,7 @@ button:hover {
 
 .header-node {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   width: 100%;
   background: none;
@@ -242,9 +242,22 @@ button:hover {
   color: #22c55e;
 }
 
-.header-label {
+.header-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
   flex: 1;
+  min-width: 0;
+}
+
+.header-label {
+  font-weight: 600;
   white-space: normal;
+}
+
+.header-meta {
+  font-size: 0.75rem;
+  color: var(--muted);
 }
 
 .preview {
@@ -255,11 +268,37 @@ button:hover {
   padding: 1rem;
 }
 
-.preview pre {
-  max-height: 200px;
+.section-preview-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section-preview-title {
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-preview-placeholder {
+  color: var(--muted);
+  margin: 0;
+}
+
+.section-preview-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.section-preview-text {
+  max-height: 240px;
   overflow-y: auto;
   white-space: pre-wrap;
   font-size: 0.85rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
 }
 
 .right-pane {


### PR DESCRIPTION
## Summary
- add page and line tracking plus chunk text when parsing headers
- reuse stored section chunks during spec extraction and expose metadata in the UI preview
- update styling, layout, and tests to cover the new header annotations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13d34f5cc8324a8c39a1b2f1ac1fd