### PR TITLE
Align TOC filtering between backend and frontend

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -64,6 +64,12 @@ let allowSettingsAutosave = false;
 let lastPersistedSettings = null;
 const reportedInvalidHeaderMatches = new Set();
 
+const TOC_PATTERNS = [
+  /(?:\. ?){4,}/,
+  /(?:[_\-·•]\s?){3,}/,
+  /(?:[._\-·•]\s?){4,}(?:\d{1,4}|[IVXLCDM]{1,6})\s*$/i,
+];
+
 function log(message) {
   addLog(message);
   appendLog(logConsole, message);
@@ -94,11 +100,9 @@ function normalize(value) {
 
 function isLikelyTableOfContentsLine(line) {
   if (!line) return false;
-  const compact = line.replace(/\s+/g, "");
-  if (!compact) return false;
-  if (compact.includes("....")) return true;
-  const dotCount = (compact.match(/\./g) || []).length;
-  return dotCount >= 6;
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  return TOC_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
 function findLineIndex(lines, header, { reportMismatch = false } = {}) {


### PR DESCRIPTION
## Summary
- add reusable helper on the backend to detect table-of-contents leader patterns and ignore them when anchoring headers
- align the frontend heuristics with the backend so matching UI rows are suppressed consistently
- extend header parsing tests to cover several representative TOC lines

## Testing
- PYTHONPATH=. pytest backend/tests/test_headers_parse.py

------
https://chatgpt.com/codex/tasks/task_e_68e1913d57848324b781b796a1eb6681