### PR TITLE
Raise max token defaults to 50k

### DIFF
--- a/backend/models_db.py
+++ b/backend/models_db.py
@@ -13,7 +13,7 @@ class ModelSettingsBase(SQLModel):
     provider: str = Field(default="openrouter", max_length=50)
     model: str = Field(default="", max_length=255)
     temperature: float = Field(default=0.2, ge=0.0, le=2.0)
-    max_tokens: int = Field(default=MAX_TOKENS_LIMIT, ge=16, le=32768)
+    max_tokens: int = Field(default=MAX_TOKENS_LIMIT, ge=16, le=MAX_TOKENS_LIMIT)
     api_key: str | None = Field(default=None, max_length=512)
     base_url: str | None = Field(default=None, max_length=512)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,7 +59,7 @@
               <label>Model <input type="text" name="model" placeholder="Model name" required /></label>
               <div class="grid">
                 <label>Temperature <input type="number" name="temperature" step="0.1" min="0" max="2" value="0.2" /></label>
-                <label>Max tokens <input type="number" name="max_tokens" min="16" max="8192" /></label>
+                <label>Max tokens <input type="number" name="max_tokens" min="16" max="50000" /></label>
               </div>
             </form>
           </section>

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -1,1 +1,1 @@
-export const MAX_TOKENS_LIMIT = 20000;
+export const MAX_TOKENS_LIMIT = 50000;


### PR DESCRIPTION
## Summary
- allow saved model settings to use the full MAX_TOKENS_LIMIT value
- bump the UI defaults so header/spec requests send 50k tokens on the first try

## Testing
- pytest backend/tests/test_model_settings.py::test_model_settings_persist_between_requests -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b026abd08324ac1440e59d03a4a2