### PR TITLE
Track header request and completion status

### DIFF
--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -37,7 +37,7 @@ export function setHeaders(headers) {
   headers.forEach((header) => {
     if (header?.section_number) {
       const key = String(header.section_number);
-      state.headerProgress.set(key, false);
+      state.headerProgress.set(key, { requested: false, completed: false });
     }
   });
 }
@@ -46,13 +46,30 @@ export function setSpecs(specs) {
   state.specs = specs;
 }
 
-export function markHeaderProcessed(sectionNumber) {
-  if (!sectionNumber) return;
+function ensureHeaderProgress(sectionNumber) {
+  if (!sectionNumber) return null;
   if (!state.headerProgress) {
     state.headerProgress = new Map();
   }
   const key = String(sectionNumber);
-  state.headerProgress.set(key, true);
+  const current = state.headerProgress.get(key) || { requested: false, completed: false };
+  state.headerProgress.set(key, current);
+  return { key, current };
+}
+
+export function markHeaderRequested(sectionNumber) {
+  const result = ensureHeaderProgress(sectionNumber);
+  if (!result) return;
+  const { key, current } = result;
+  state.headerProgress.set(key, { ...current, requested: true });
+}
+
+export function markHeaderProcessed(sectionNumber) {
+  if (!sectionNumber) return;
+  const result = ensureHeaderProgress(sectionNumber);
+  if (!result) return;
+  const { key, current } = result;
+  state.headerProgress.set(key, { ...current, requested: true, completed: true });
 }
 
 export function setSectionText(sectionNumber, text) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -17,7 +17,7 @@ function buildTree(headers) {
   return root;
 }
 
-function createHeaderButton(header, { activeSection, processedSections, onSelect } = {}) {
+function createHeaderButton(header, { activeSection, headerProgress, onSelect } = {}) {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "header-node";
@@ -28,9 +28,13 @@ function createHeaderButton(header, { activeSection, processedSections, onSelect
   const status = document.createElement("span");
   status.className = "header-status";
   const key = header?.section_number ? String(header.section_number) : null;
-  if (key && processedSections?.has(key)) {
+  const progress = key ? headerProgress?.get(key) : null;
+  if (progress?.requested) {
+    status.classList.add("header-status--requested");
+    status.textContent = progress.completed ? "✓✓" : "✓";
+  }
+  if (progress?.completed) {
     status.classList.add("header-status--complete");
-    status.textContent = "✓";
   }
   button.appendChild(status);
 
@@ -62,36 +66,36 @@ function createHeaderButton(header, { activeSection, processedSections, onSelect
   return button;
 }
 
-function renderTreeNode(node, activeSection, processedSections, onSelect) {
+function renderTreeNode(node, activeSection, headerProgress, onSelect) {
   if (!node.children) return document.createDocumentFragment();
   const ul = document.createElement("ul");
   const entries = Array.from(node.children.entries()).sort((a, b) => a[0].localeCompare(b[0], undefined, { numeric: true }));
   entries.forEach(([, child]) => {
     const li = document.createElement("li");
     if (child.header) {
-      const button = createHeaderButton(child.header, { activeSection, processedSections, onSelect });
+      const button = createHeaderButton(child.header, { activeSection, headerProgress, onSelect });
       li.appendChild(button);
     }
     if (child.children && child.children.size > 0) {
-      li.appendChild(renderTreeNode(child, activeSection, processedSections, onSelect));
+      li.appendChild(renderTreeNode(child, activeSection, headerProgress, onSelect));
     }
     ul.appendChild(li);
   });
   return ul;
 }
 
-export function renderHeadersTree(container, headers, { onSelect, activeSection, processedSections } = {}) {
+export function renderHeadersTree(container, headers, { onSelect, activeSection, headerProgress } = {}) {
   container.innerHTML = "";
   if (!headers?.length) {
     container.textContent = "No headers extracted yet.";
     return;
   }
   const tree = buildTree(headers);
-  const fragment = renderTreeNode(tree, activeSection, processedSections, onSelect);
+  const fragment = renderTreeNode(tree, activeSection, headerProgress, onSelect);
   container.appendChild(fragment);
 }
 
-export function renderSidebarHeadersList(container, headers, { onSelect, activeSection, processedSections } = {}) {
+export function renderSidebarHeadersList(container, headers, { onSelect, activeSection, headerProgress } = {}) {
   container.innerHTML = "";
   if (!headers?.length) {
     container.textContent = "No headers extracted yet.";
@@ -106,7 +110,7 @@ export function renderSidebarHeadersList(container, headers, { onSelect, activeS
     .sort((a, b) => a.section_number.localeCompare(b.section_number, undefined, { numeric: true }))
     .forEach((header) => {
       const item = document.createElement("li");
-      const button = createHeaderButton(header, { activeSection, processedSections, onSelect });
+      const button = createHeaderButton(header, { activeSection, headerProgress, onSelect });
       item.appendChild(button);
       list.appendChild(item);
     });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -230,12 +230,16 @@ button:hover {
 }
 
 .header-status {
-  width: 1.25rem;
+  width: 1.75rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 0.85rem;
   color: var(--muted);
+}
+
+.header-status--requested {
+  color: var(--accent);
 }
 
 .header-status--complete {


### PR DESCRIPTION
## Summary
- add tracking for header request and completion states so the UI can differentiate between pending and processed sections
- update the sidebar/tree rendering to show one checkmark when a request is sent and two when the response is processed
- adjust styling to support the new dual-checkmark indicators

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b214ab78832494983546e886b4df