### PR TITLE
Stream specs progress to update header status live

### DIFF
--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -29,12 +29,15 @@ function createHeaderButton(header, { activeSection, headerProgress, onSelect } 
   status.className = "header-status";
   const key = header?.section_number ? String(header.section_number) : null;
   const progress = key ? headerProgress?.get(key) : null;
-  if (progress?.requested) {
-    status.classList.add("header-status--requested");
-    status.textContent = progress.completed ? "✓✓" : "✓";
-  }
   if (progress?.completed) {
-    status.classList.add("header-status--complete");
+    status.classList.add("header-status--responded", "header-status--complete");
+    status.textContent = "✓✓";
+  } else if (progress?.responded) {
+    status.classList.add("header-status--responded");
+    status.textContent = "✓✓";
+  } else if (progress?.requested) {
+    status.classList.add("header-status--requested");
+    status.textContent = "✓";
   }
   button.appendChild(status);
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -242,6 +242,11 @@ button:hover {
   color: var(--accent);
 }
 
+.header-status--responded {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .header-status--complete {
   color: #22c55e;
 }


### PR DESCRIPTION
## Summary
- add a streaming specs endpoint that emits request, response, and processed events per section
- update the frontend to consume streamed progress so header checkmarks reflect each stage of the LLM calls in real time
- expose a streaming specs helper and reset header progress maps before each extraction run

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b50d887c8324aaef7364e7f21277