### PR TITLE
Log raw header LLM responses to console

### DIFF
--- a/backend/services/llm/llamacpp.py
+++ b/backend/services/llm/llamacpp.py
@@ -17,7 +17,11 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from ...logging import get_logger
 from .llm_provider import LLMProvider
+
+
+logger = get_logger(__name__)
 
 
 class LlamaCPPProvider(LLMProvider):
@@ -74,6 +78,7 @@ class LlamaCPPProvider(LLMProvider):
 
         async with httpx.AsyncClient(timeout=self.timeout, headers=self.headers) as client:
             resp = await client.post(url, json=payload)
+            logger.info("Header LM raw response (llama.cpp provider): %s", resp.text)
             # Raise detailed HTTP errors early
             try:
                 resp.raise_for_status()

--- a/backend/services/llm/openrouter.py
+++ b/backend/services/llm/openrouter.py
@@ -7,6 +7,7 @@ from typing import Any, List
 
 import httpx
 
+from ...logging import get_logger
 from ...openrouter import normalize_openrouter_base_url
 from .llm_provider import LLMProvider
 
@@ -50,6 +51,9 @@ class _OpenRouterRateLimiter:
 _OPENROUTER_RATE_LIMITER = _OpenRouterRateLimiter()
 
 
+logger = get_logger(__name__)
+
+
 class OpenRouterProvider(LLMProvider):
     def __init__(
         self,
@@ -79,6 +83,7 @@ class OpenRouterProvider(LLMProvider):
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(self.endpoint, json=payload, headers=headers)
         response.raise_for_status()
+        logger.info("Header LM raw response (OpenRouter provider): %s", response.text)
         data = response.json()
         try:
             return data["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- add logging hooks in the header discovery adapters to print raw LLM responses
- log raw responses in both OpenRouter and llama.cpp providers used for headers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c076562883248feeca3cd29335b5