### PR TITLE
Restrict MinerU parser to native mineru client

### DIFF
--- a/backend/tests/test_parse_pdf_mineru.py
+++ b/backend/tests/test_parse_pdf_mineru.py
@@ -12,10 +12,7 @@ from backend.services import pdf_mineru
 
 
 client = TestClient(create_app())
-MINERU_AVAILABLE = any(
-    importlib.util.find_spec(name) is not None
-    for name in ("magic_pdf", "mineru", "mineru_core")
-)
+MINERU_AVAILABLE = importlib.util.find_spec("mineru") is not None
 
 
 def _build_pdf_bytes() -> bytes:

--- a/backend/tests/test_pdf_parity.py
+++ b/backend/tests/test_pdf_parity.py
@@ -12,10 +12,7 @@ from backend.models import FIGURE_KIND, LINE_KIND, PARAGRAPH_KIND, TABLE_KIND
 
 
 client = TestClient(create_app())
-MINERU_AVAILABLE = any(
-    importlib.util.find_spec(name) is not None
-    for name in ("magic_pdf", "mineru", "mineru_core")
-)
+MINERU_AVAILABLE = importlib.util.find_spec("mineru") is not None
 
 
 def _build_pdf_bytes() -> bytes:


### PR DESCRIPTION
## Summary
- update the MinerU service to import only the `mineru` client library and remove the legacy `magic_pdf` fallback path
- adjust MinerU parsing tests to reflect the single-client expectation

## Testing
- pytest backend/tests/test_mineru_startup.py backend/tests/test_parse_pdf_mineru.py backend/tests/test_pdf_parity.py *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68e25ab2e3e48324aa5d827bbf594995