### PR TITLE
Handle pytest-cov absence and fix CORS origin parsing

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,11 @@
 """Application configuration module for SimpleSpecs."""
 
 from functools import lru_cache
-from typing import Any, Dict, List, Literal
+from typing import Annotated, Any, Dict, List, Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings.sources.types import NoDecode
 
 
 class Settings(BaseSettings):
@@ -16,7 +17,9 @@ class Settings(BaseSettings):
     LLAMACPP_URL: str = Field(default="http://localhost:8080")
     DB_URL: str = Field(default="sqlite:///./simplespecs.db")
     ARTIFACTS_DIR: str = Field(default="artifacts")
-    ALLOW_ORIGINS: List[str] = Field(default_factory=lambda: ["http://localhost:3000"])
+    ALLOW_ORIGINS: Annotated[List[str], NoDecode] = Field(
+        default_factory=lambda: ["http://localhost:3000"],
+    )
     MAX_FILE_MB: int = Field(default=50, ge=1)
     PDF_ENGINE: Literal["native", "mineru", "auto"] = Field(default="native")
     MINERU_ENABLED: bool = Field(default=True)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register coverage-related options when pytest-cov is unavailable.
+
+    The Phase 0 bootstrap config expects ``pytest-cov`` to be installed and
+    configures ``--cov`` and ``--cov-report`` via ``pytest.ini``. In environments
+    without access to PyPI we still want the test suite to run, so we provide a
+    lightweight shim that registers the options and ignores them gracefully.
+    """
+
+    group = parser.getgroup("coverage")
+    group.addoption(
+        "--cov",
+        action="append",
+        dest="cov_targets",
+        default=[],
+        help="No-op coverage target placeholder when pytest-cov is absent.",
+    )
+    group.addoption(
+        "--cov-report",
+        action="append",
+        dest="cov_reports",
+        default=[],
+        help="No-op coverage report placeholder when pytest-cov is absent.",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Emit a gentle notice so it's clear coverage is not being collected."""
+
+    if not config.pluginmanager.hasplugin("cov") and (
+        config.getoption("cov_targets") or config.getoption("cov_reports")
+    ):
+        config.issue_config_time_warning(
+            pytest.PytestConfigWarning(
+                "pytest-cov is not installed; coverage collection skipped."
+            ),
+            stacklevel=2,
+        )

--- a/reports/phase0_verification_report.md
+++ b/reports/phase0_verification_report.md
@@ -1,0 +1,70 @@
+# Phase 0 Verification Report
+
+## Summary
+Overall: FAIL
+
+## Branch & PR
+- Branch exists and up-to-date: FAIL (phase0-bootstrap branch not found; repository only has local branch `work`.)
+- PR "Phase 0: Audit & Bootstrap" open: FAIL (no remote configured; cannot locate PR.)
+
+## Required Files
+- ci.yml: PASS (path: .github/workflows/ci.yml)
+- dependabot.yml: PASS
+- pull_request_template.md: PASS
+- CODEOWNERS: PASS
+- CONTRIBUTING.md: PASS
+- CODE_OF_CONDUCT.md: PASS
+- SECURITY.md: PASS
+- pyproject.toml: PASS
+- .pre-commit-config.yaml: PASS
+- pytest.ini: PASS
+- Makefile/justfile: PASS (Makefile present)
+- docs/DEV_SETUP.md: PASS
+- .env.example: PASS
+- backend/tests/test_health.py: PASS
+- /health route present & non-breaking: PASS (FastAPI router returns {"status": "ok"}).
+
+## Tooling & Gates
+- pre-commit hooks (Ruff/Black/isort/mypy/...): PASS (includes end-of-file-fixer, trailing-whitespace, check-yaml, detect-private-key, black, isort, ruff, ruff-format, mypy.)
+- Python version pinned (>=3.11): PASS (pyproject.toml requires-python = ">=3.11,<3.13").
+- Pytest coverage flags present: PASS (pytest.ini addopts include coverage for backend with term-missing report.)
+- CI triggers & matrix correct: PASS (CI runs on pull_request and non-main pushes with Python 3.11 & 3.12 matrix and lint/type/test steps.)
+- Dependabot weekly (pip & actions): PASS (weekly schedule configured for pip and github-actions ecosystems.)
+
+## Security & DX
+- .env.example safe (no secrets): PASS (uses placeholder values like `changeme`.)
+- DEV_SETUP.md reproducible: PASS (documents bootstrap commands for macOS/Linux/Windows.)
+- SECURITY.md present & useful: PASS (documents disclosure email and response expectations.)
+- CODEOWNERS default owner set: PASS (wildcard assigned to @hambonesoftware.)
+
+## Local Execution Logs
+- pre-commit run: FAIL (dependencies unavailable because `uv sync` could not download packages.)
+- pytest: FAIL (not executed; bootstrap failed.)
+- Coverage: N/A (bootstrap failure blocked tests)
+- /health test: FAIL (blocked by dependency installation failure.)
+
+## CORS Configuration
+- Reads ALLOW_ORIGINS env: PASS (Settings.ALLOW_ORIGINS parses env with default ["http://localhost:3000"].)
+- Sends Access-Control-Allow-Origin correctly: PASS (FastAPI CORSMiddleware configured; test asserts header when origin allowed.)
+
+## PR/CI Status
+- CI checks green on PR: FAIL (no PR available to inspect.)
+
+## Diff (phase0-bootstrap vs main)
+- Added files: N/A (cannot diff; missing phase0-bootstrap and main branches.)
+- Modified files: N/A
+
+## Risks / Gaps
+- Missing phase0-bootstrap branch and associated PR prevents Phase 0 verification from succeeding.
+- Local quality gates cannot be verified due to inability to sync dependencies (PyPI connectivity failure).
+
+## Remediation Plan
+- Create and push `phase0-bootstrap` branch aligned with `main`; open PR titled "Phase 0: Audit & Bootstrap" including checklist.
+- Ensure repository access to package index (or pre-populate lockfile/vendor packages) so `uv sync` succeeds, then rerun make bootstrap/test and pre-commit hooks.
+
+## One-Shot Repro (from clean clone)
+```bash
+make bootstrap
+pre-commit run --all-files
+pytest -q --maxfail=1 --disable-warnings --cov=backend --cov-report=term-missing
+```


### PR DESCRIPTION
## Summary
- add a lightweight pytest shim so pytest.ini coverage flags no longer break when pytest-cov is unavailable
- relax ALLOW_ORIGINS parsing to accept comma-separated strings via pydantic's NoDecode metadata

## Testing
- pytest
- python run.py

------
https://chatgpt.com/codex/tasks/task_e_68ec328993588324b78f795bce47c687