### PR TITLE
Add section-based RAG pipeline for specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Settings are loaded from environment variables (prefixed with `SIMPLS_` when des
 - `HEADERS_SUPPRESS_RUNNING` — filter recurring running headers/footers (default `true`)
 - `PARSER_ENABLE_OCR` — invoke Tesseract OCR on text-light pages when available (default `false`)
 - `PARSER_DEBUG` — emit structured JSON debug logs during native parsing (default `false`)
+- `RAG_ENABLE` — toggles the retrieval-augmented spec workflows (default `true`)
+- `RAG_CHUNK_MODE` — hard-enforced to `section`; overrides any token length or overlap settings
+- `RAG_MODEL_PATH` — local embeddings model path (default `./models/all-MiniLM-L6-v2`)
+- `RAG_INDEX_DIR` — directory used for persisted RAG indices (default `./.rag_index`)
+- `RAG_LIGHT_MODE` — set to `1` for offline hashing stubs during CI/local smoke tests (default `1`)
+- `RAG_HYBRID_ALPHA` — blend weight between sparse and dense scores during hybrid search (default `0.5`)
+
+> **Note**
+> When `RAG_CHUNK_MODE` is present it is locked to `section`, ensuring exactly one
+> chunk per document section regardless of legacy token-size or overlap
+> configuration.
 
 ### Native header parsing CLI
 
@@ -44,6 +55,29 @@ python -m backend.cli.parse_headers path/to/document.pdf --json headers.json --d
 
 The optional `--debug` flag toggles `PARSER_DEBUG` logging and echoes the active
 feature flags for quick verification.
+
+## Specification RAG workflow
+
+The section-based chunker, rule-driven atomizer, and hybrid search endpoints
+run fully offline when `SIMPLS_RAG_LIGHT_MODE=1` (the default). To extract and
+index specifications for a processed upload, run:
+
+```bash
+python -m backend.cli.specs_index <file_id_or_source_path> --rebuild
+```
+
+Query the indexed specifications locally without the API server:
+
+```bash
+python -m backend.cli.specs_query --file-id <file_id> --q "24 VDC safety relay" --k 5
+```
+
+The FastAPI layer also exposes additive endpoints:
+
+- `POST /api/specs/extract` — run atomization over chunked sections.
+- `POST /api/specs/index` — persist hybrid embeddings/BM25 index data.
+- `POST /api/specs/search` — return weighted hybrid hits.
+- `POST /api/specs/export` — retrieve the stored specification payload.
 
 ## Tests
 ```bash

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application-level helpers for SimpleSpecs."""

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""Routers for the RAG specification pipeline."""
+
+from . import specs
+
+__all__ = ["specs"]

--- a/backend/app/routers/specs.py
+++ b/backend/app/routers/specs.py
@@ -1,0 +1,86 @@
+"""RAG specification endpoints."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ...models import SpecItem
+from ...services.spec_rag import export_specs, extract_specs, index_specs, search_specs
+from ...services.spec_rag import load_spec_items
+
+router = APIRouter(prefix="/api/specs", tags=["specs-rag"])
+
+
+class SpecFileRequest(BaseModel):
+    file_id: str = Field(..., min_length=1)
+
+
+class SpecIndexResponse(BaseModel):
+    file_id: str
+    indexed: int
+
+
+class SpecSearchRequest(SpecFileRequest):
+    query: str = Field(..., min_length=1)
+    top_k: int = Field(default=5, ge=1, le=50)
+
+
+class SpecSearchHit(BaseModel):
+    chunk_id: str
+    score: float
+    bm25: float
+    vector: float
+    text: str
+    metadata: dict[str, Any]
+
+
+@router.post("/extract", response_model=list[SpecItem])
+def extract_endpoint(payload: SpecFileRequest) -> list[SpecItem]:
+    """Run deterministic extraction for a file."""
+
+    try:
+        return extract_specs(payload.file_id)
+    except FileNotFoundError as exc:  # pragma: no cover - error branch
+        detail = str(exc) or "Required artifacts are missing."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
+
+
+@router.post("/index", response_model=SpecIndexResponse)
+def index_endpoint(payload: SpecFileRequest) -> SpecIndexResponse:
+    """Persist the hybrid index for a file's specs."""
+
+    try:
+        try:
+            specs = load_spec_items(payload.file_id)
+        except FileNotFoundError:
+            specs = extract_specs(payload.file_id)
+        index_specs(payload.file_id, specs=specs)
+    except FileNotFoundError as exc:  # pragma: no cover - error branch
+        detail = str(exc) or "Required artifacts are missing."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
+    return SpecIndexResponse(file_id=payload.file_id, indexed=len(specs))
+
+
+@router.post("/search", response_model=list[SpecSearchHit])
+def search_endpoint(payload: SpecSearchRequest) -> list[SpecSearchHit]:
+    """Search the indexed specifications."""
+
+    try:
+        hits = search_specs(payload.file_id, payload.query, top_k=payload.top_k)
+    except FileNotFoundError as exc:  # pragma: no cover - error branch
+        detail = str(exc) or "Specification index not found."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
+    return [SpecSearchHit.model_validate(hit) for hit in hits]
+
+
+@router.post("/export", response_model=dict[str, Any])
+def export_endpoint(payload: SpecFileRequest) -> dict[str, Any]:
+    """Return the persisted specification payload."""
+
+    try:
+        return export_specs(payload.file_id)
+    except FileNotFoundError as exc:  # pragma: no cover - error branch
+        detail = str(exc) or "Specifications not found."
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc

--- a/backend/cli/specs_index.py
+++ b/backend/cli/specs_index.py
@@ -1,0 +1,40 @@
+"""CLI entrypoint for indexing specification chunks."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ..services.spec_rag import extract_specs, index_specs, load_spec_items
+
+
+def _determine_file_id(source: str, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    path = Path(source)
+    if path.is_file():
+        return path.stem
+    return source
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Index specification chunks for hybrid search")
+    parser.add_argument("source", help="File identifier or source document path")
+    parser.add_argument("--file-id", help="Explicit file identifier override")
+    parser.add_argument("--rebuild", action="store_true", help="Re-run extraction before indexing")
+    args = parser.parse_args()
+
+    file_id = _determine_file_id(args.source, args.file_id)
+
+    if args.rebuild:
+        specs = extract_specs(file_id)
+    else:
+        try:
+            specs = load_spec_items(file_id)
+        except FileNotFoundError:
+            specs = extract_specs(file_id)
+    index_specs(file_id, specs=specs)
+    print(f"Indexed {len(specs)} specifications for '{file_id}'.")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/backend/cli/specs_query.py
+++ b/backend/cli/specs_query.py
@@ -1,0 +1,34 @@
+"""CLI entrypoint for querying indexed specs."""
+from __future__ import annotations
+
+import argparse
+
+from ..services.spec_rag import search_specs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query indexed specifications")
+    parser.add_argument("--file-id", default="sample1", help="File identifier to query (default: sample1)")
+    parser.add_argument("--q", required=True, help="Search query")
+    parser.add_argument("--k", type=int, default=5, help="Number of results to return")
+    args = parser.parse_args()
+
+    hits = search_specs(args.file_id, args.q, top_k=args.k)
+    if not hits:
+        print("No matches found.")
+        return
+    for idx, hit in enumerate(hits, start=1):
+        metadata = hit.get("metadata", {})
+        header_path = metadata.get("header_path", "")
+        print(f"{idx}. [{hit['score']:.3f}] {hit['text']}")
+        if header_path:
+            print(f"   Section: {header_path}")
+        if metadata.get("normalized_value") is not None:
+            unit = metadata.get("normalized_unit") or ""
+            print(
+                f"   Normalized: {metadata['normalized_value']} {unit}".strip()
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/backend/config.py
+++ b/backend/config.py
@@ -47,6 +47,23 @@ class Settings(BaseSettings):
         default=False,
         validation_alias=AliasChoices("PARSER_DEBUG", "SIMPLS_PARSER_DEBUG"),
     )
+    RAG_ENABLE: bool = Field(default=True)
+    RAG_CHUNK_MODE: Literal["section"] = Field(default="section")
+    RAG_MODEL_PATH: str = Field(default="./models/all-MiniLM-L6-v2")
+    RAG_INDEX_DIR: str = Field(default="./.rag_index")
+    RAG_HYBRID_ALPHA: float = Field(default=0.5)
+    RAG_LIGHT_MODE: int = Field(default=1, ge=0, le=1)
+
+    @field_validator("RAG_CHUNK_MODE", mode="before")
+    @classmethod
+    def _enforce_section_chunk_mode(cls, value: Any) -> Literal["section"]:
+        """Ensure that only section chunking is permitted for RAG."""
+
+        if value != "section":
+            raise ValueError(
+                "RAG_CHUNK_MODE is hard-enforced to 'section' for Phase 2."
+            )
+        return "section"
 
     @field_validator("ALLOW_ORIGINS", mode="before")
     @classmethod

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .config import get_settings
 from .database import init_db
+from .app.routers import specs as rag_specs
 from .routers import (
     export,
     files,
@@ -20,7 +21,7 @@ from .routers import (
     ingest,
     parse,
     settings,
-    specs,
+    specs as legacy_specs,
     system,
     upload,
 )
@@ -64,7 +65,8 @@ def _build_app() -> FastAPI:
     application.include_router(headers.router)
     application.include_router(headers_ollama.router)
     application.include_router(settings.router)
-    application.include_router(specs.router)
+    application.include_router(legacy_specs.router)
+    application.include_router(rag_specs.router)
     application.include_router(export.router)
     application.include_router(system.system_router)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -242,6 +242,11 @@ class SpecItem(BaseModel):
     source_object_ids: list[str] = Field(default_factory=list)
     section_number: str | None = None
     confidence: float | None = None
+    header_path: str | None = None
+    raw_value: str | None = None
+    normalized_value: float | None = None
+    normalized_unit: str | None = None
+    category: str | None = None
 
     @field_validator("source_object_ids", mode="before")
     @classmethod

--- a/backend/services/embeddings.py
+++ b/backend/services/embeddings.py
@@ -1,0 +1,87 @@
+"""Embeddings service with deterministic hashing fallback."""
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Iterable, Sequence
+
+from ..config import Settings, get_settings
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer  # type: ignore
+except Exception:  # pragma: no cover
+    SentenceTransformer = None  # type: ignore
+
+__all__ = ["EmbeddingService"]
+
+
+def _ensure_list(vector: Sequence[float] | Iterable[float]) -> list[float]:
+    if isinstance(vector, list):
+        return [float(item) for item in vector]
+    if hasattr(vector, "tolist"):
+        return [float(item) for item in vector.tolist()]
+    return [float(item) for item in vector]
+
+
+def _normalize(values: Sequence[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm == 0.0:
+        return [0.0 for _ in values]
+    return [float(value / norm) for value in values]
+
+
+class EmbeddingService:
+    """Produce sentence embeddings with optional hashing stub."""
+
+    def __init__(self, settings: Settings | None = None, dimension: int = 384) -> None:
+        self._settings = settings or get_settings()
+        self._dimension = dimension
+        self._light_mode = bool(self._settings.RAG_LIGHT_MODE)
+        self._model: SentenceTransformer | None = None
+        if not self._light_mode and SentenceTransformer is not None:
+            try:
+                self._model = SentenceTransformer(self._settings.RAG_MODEL_PATH)
+                if hasattr(self._model, "get_sentence_embedding_dimension"):
+                    self._dimension = int(self._model.get_sentence_embedding_dimension())
+            except Exception:  # pragma: no cover - fallback to stub mode
+                self._model = None
+                self._light_mode = True
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        if self._model is not None:
+            vectors = self._model.encode(
+                list(texts),
+                show_progress_bar=False,
+                normalize_embeddings=True,
+            )
+            return [_normalize(_ensure_list(vector)) for vector in vectors]
+        return [self._hash_vector(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        if self._model is not None:
+            vector = self._model.encode(
+                [text],
+                show_progress_bar=False,
+                normalize_embeddings=True,
+            )
+            return _normalize(_ensure_list(vector[0]))
+        return self._hash_vector(text)
+
+    def batch_encode(self, batched_texts: Iterable[Sequence[str]]) -> Iterable[list[list[float]]]:
+        for texts in batched_texts:
+            yield self.embed_documents(list(texts))
+
+    def _hash_vector(self, text: str) -> list[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        if not digest:
+            return [0.0] * self._dimension
+        values = [digest[i % len(digest)] for i in range(self._dimension)]
+        mean = sum(values) / len(values)
+        centered = [value - mean for value in values]
+        return _normalize(centered)

--- a/backend/services/index_store.py
+++ b/backend/services/index_store.py
@@ -1,0 +1,109 @@
+"""Lightweight vector index for hybrid RAG search."""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from ..config import Settings, get_settings
+
+__all__ = ["IndexItem", "IndexStore"]
+
+
+@dataclass(slots=True)
+class IndexItem:
+    chunk_id: str
+    text: str
+    metadata: dict[str, object]
+
+
+def _normalize_vector(vector: Sequence[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0.0:
+        return [0.0 for _ in vector]
+    return [float(value / norm) for value in vector]
+
+
+class IndexStore:
+    """Persist embeddings to disk and serve cosine similarity queries."""
+
+    def __init__(self, dimension: int, *, index_name: str = "specs", settings: Settings | None = None) -> None:
+        self._settings = settings or get_settings()
+        self._dimension = dimension
+        self._index_name = index_name
+        self._index_dir = Path(self._settings.RAG_INDEX_DIR)
+        self._index_dir.mkdir(parents=True, exist_ok=True)
+        self._index_path = self._index_dir / f"{self._index_name}.json"
+        self._vectors: list[list[float]] = []
+        self._normalized_vectors: list[list[float]] = []
+        self._items: list[IndexItem] = []
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def build(self, vectors: Sequence[Sequence[float]], items: Sequence[IndexItem]) -> None:
+        self._vectors = [list(map(float, vector)) for vector in vectors]
+        self._items = [
+            IndexItem(chunk_id=item.chunk_id, text=item.text, metadata=dict(item.metadata))
+            for item in items
+        ]
+        if any(len(vector) != self._dimension for vector in self._vectors):
+            raise ValueError("All vectors must match the configured dimension")
+        self._normalized_vectors = [_normalize_vector(vector) for vector in self._vectors]
+        self._persist()
+
+    def _persist(self) -> None:
+        payload = []
+        for item, vector in zip(self._items, self._vectors):
+            payload.append(
+                {
+                    "chunk_id": item.chunk_id,
+                    "text": item.text,
+                    "metadata": item.metadata,
+                    "vector": vector,
+                }
+            )
+        with self._index_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    def load(self) -> None:
+        if not self._index_path.exists():
+            return
+        with self._index_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        self._vectors = []
+        self._items = []
+        for entry in payload:
+            vector = [float(value) for value in entry.get("vector", [])]
+            if len(vector) != self._dimension:
+                continue
+            metadata = entry.get("metadata") or {}
+            chunk_id = str(entry.get("chunk_id"))
+            text = str(entry.get("text", ""))
+            self._vectors.append(vector)
+            self._items.append(IndexItem(chunk_id=chunk_id, text=text, metadata=dict(metadata)))
+        self._normalized_vectors = [_normalize_vector(vector) for vector in self._vectors]
+
+    def search(self, query_vector: Sequence[float], k: int) -> list[tuple[str, float, dict[str, object]]]:
+        if not self._items:
+            return []
+        normalized_query = _normalize_vector(query_vector)
+        scores: list[tuple[str, float, dict[str, object]]] = []
+        for item, vector in zip(self._items, self._normalized_vectors):
+            score = sum(a * b for a, b in zip(vector, normalized_query))
+            scores.append((item.chunk_id, float(score), dict(item.metadata)))
+        scores.sort(key=lambda item: item[1], reverse=True)
+        return scores[:k]
+
+    def clear(self) -> None:
+        self._vectors = []
+        self._normalized_vectors = []
+        self._items = []
+        if self._index_path.exists():
+            self._index_path.unlink()
+
+    def items(self) -> list[IndexItem]:
+        return list(self._items)

--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -1,0 +1,140 @@
+"""Hybrid sparse/dense search utilities."""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..config import Settings, get_settings
+from .embeddings import EmbeddingService
+from .index_store import IndexItem, IndexStore
+
+__all__ = ["ChunkRecord", "BM25Corpus", "HybridSearch"]
+
+_TOKEN_RE = re.compile(r"[\w%°\.]+", re.UNICODE)
+
+
+@dataclass(slots=True)
+class ChunkRecord:
+    chunk_id: str
+    text: str
+    metadata: dict[str, object]
+
+
+class BM25Corpus:
+    """Simplified BM25 scorer."""
+
+    def __init__(self, documents: Sequence[ChunkRecord]) -> None:
+        self._documents = list(documents)
+        self._doc_lengths: list[int] = []
+        self._avg_len = 0.0
+        self._idf: dict[str, float] = {}
+        self._doc_term_freqs: list[dict[str, int]] = []
+        self._build()
+
+    def _build(self) -> None:
+        doc_freqs: dict[str, int] = {}
+        for record in self._documents:
+            tokens = self._tokenize(record.text)
+            term_counts: dict[str, int] = {}
+            for token in tokens:
+                term_counts[token] = term_counts.get(token, 0) + 1
+            self._doc_term_freqs.append(term_counts)
+            self._doc_lengths.append(len(tokens))
+            for token in term_counts:
+                doc_freqs[token] = doc_freqs.get(token, 0) + 1
+        if self._doc_lengths:
+            self._avg_len = sum(self._doc_lengths) / len(self._doc_lengths)
+        total_docs = len(self._documents)
+        self._idf = {
+            token: math.log(1 + (total_docs - freq + 0.5) / (freq + 0.5))
+            for token, freq in doc_freqs.items()
+        }
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return [token.lower() for token in _TOKEN_RE.findall(text)]
+
+    def score(self, query: str, *, k1: float = 1.5, b: float = 0.75) -> dict[str, float]:
+        tokens = self._tokenize(query)
+        scores: dict[str, float] = {}
+        for doc_index, term_counts in enumerate(self._doc_term_freqs):
+            score = 0.0
+            doc_len = self._doc_lengths[doc_index] or 1
+            for token in tokens:
+                freq = term_counts.get(token)
+                if not freq:
+                    continue
+                idf = self._idf.get(token, 0.0)
+                denom = freq + k1 * (1 - b + b * doc_len / (self._avg_len or 1.0))
+                score += idf * (freq * (k1 + 1)) / denom
+            if score > 0.0:
+                scores[self._documents[doc_index].chunk_id] = score
+        return scores
+
+
+class HybridSearch:
+    """Hybrid search using dense vectors and BM25 fusion."""
+
+    def __init__(
+        self,
+        embedding_service: EmbeddingService | None = None,
+        index_store: IndexStore | None = None,
+        *,
+        settings: Settings | None = None,
+    ) -> None:
+        self._settings = settings or get_settings()
+        self._embedding = embedding_service or EmbeddingService(self._settings)
+        self._index = index_store or IndexStore(self._embedding.dimension, settings=self._settings)
+        self._alpha = float(self._settings.RAG_HYBRID_ALPHA)
+        self._records: list[ChunkRecord] = []
+        self._bm25: BM25Corpus | None = None
+        self._record_map: dict[str, ChunkRecord] = {}
+
+    def index(self, records: Sequence[ChunkRecord]) -> None:
+        self._records = list(records)
+        self._record_map = {record.chunk_id: record for record in self._records}
+        self._bm25 = BM25Corpus(self._records)
+        embeddings = self._embedding.embed_documents([record.text for record in self._records])
+        items = [
+            IndexItem(chunk_id=record.chunk_id, text=record.text, metadata=record.metadata)
+            for record in self._records
+        ]
+        self._index.build(embeddings, items)
+
+    def search(self, query: str, k: int = 5) -> list[dict[str, object]]:
+        if not self._records:
+            return []
+        bm25_scores = self._bm25.score(query) if self._bm25 else {}
+        dense_vector = self._embedding.embed_query(query)
+        dense_results = self._index.search(dense_vector, max(k, 10))
+        dense_scores = {chunk_id: score for chunk_id, score, _ in dense_results}
+        candidate_ids = set(bm25_scores) | set(dense_scores)
+        results: list[tuple[str, float, float, float]] = []
+        for chunk_id in candidate_ids:
+            bm25 = bm25_scores.get(chunk_id, 0.0)
+            dense = dense_scores.get(chunk_id, 0.0)
+            score = self._alpha * dense + (1.0 - self._alpha) * bm25
+            results.append((chunk_id, score, bm25, dense))
+        results.sort(key=lambda item: item[1], reverse=True)
+        limited = results[:k]
+        response: list[dict[str, object]] = []
+        for chunk_id, score, bm25, dense in limited:
+            record = self._record_map.get(chunk_id)
+            if not record:
+                continue
+            response.append(
+                {
+                    "chunk_id": chunk_id,
+                    "score": score,
+                    "bm25": bm25,
+                    "vector": dense,
+                    "text": record.text,
+                    "metadata": record.metadata,
+                }
+            )
+        return response
+
+    def records(self) -> list[ChunkRecord]:
+        return list(self._records)

--- a/backend/services/spec_atomizer.py
+++ b/backend/services/spec_atomizer.py
@@ -1,0 +1,219 @@
+"""Rule-based specification atomizer."""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Iterable, Sequence
+
+from ..models import SpecItem
+
+_SPEC_TRIGGER_WORDS = ("shall", "must", "should", "required", "ensure", "provide", "include")
+_VALUE_UNIT_RE = re.compile(
+    r"(?P<value>-?\d+(?:\.\d+)?)\s*(?P<unit>°\s?[CF]|deg\s?[CF]|mm|cm|m|in|ft|kg|g|lb|lbs|psi|bar|vdc|vac|kv|v|amp|amps|a|ma|hz|rpm|%)",
+    re.IGNORECASE,
+)
+_UNIT_CONVERSIONS: dict[str, tuple[str, float]] = {
+    "mm": ("mm", 1.0),
+    "cm": ("mm", 10.0),
+    "m": ("mm", 1000.0),
+    "in": ("mm", 25.4),
+    "ft": ("mm", 304.8),
+    "kg": ("kg", 1.0),
+    "g": ("kg", 0.001),
+    "lb": ("lb", 1.0),
+    "lbs": ("lb", 1.0),
+    "psi": ("psi", 1.0),
+    "bar": ("bar", 1.0),
+    "v": ("V", 1.0),
+    "kv": ("V", 1000.0),
+    "vdc": ("VDC", 1.0),
+    "vac": ("VAC", 1.0),
+    "a": ("A", 1.0),
+    "amp": ("A", 1.0),
+    "amps": ("A", 1.0),
+    "ma": ("A", 0.001),
+    "hz": ("Hz", 1.0),
+    "rpm": ("RPM", 1.0),
+    "%": ("%", 1.0),
+}
+_TEMPERATURE_UNITS = {"°c", "degc", "c"}
+_TEMPERATURE_F_UNITS = {"°f", "degf", "f"}
+_CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "dimensional": (
+        "length",
+        "width",
+        "height",
+        "diameter",
+        "thickness",
+        "spacing",
+        "clearance",
+        "distance",
+        "depth",
+    ),
+    "electrical": (
+        "voltage",
+        "current",
+        "power",
+        "watt",
+        "phase",
+        "supply",
+        "volts",
+        "amps",
+    ),
+    "controls": (
+        "controller",
+        "plc",
+        "relay",
+        "sensor",
+        "io",
+        "i/o",
+        "modbus",
+        "ethernet",
+        "control",
+    ),
+    "software": (
+        "software",
+        "firmware",
+        "version",
+        "api",
+        "protocol",
+        "ui",
+    ),
+    "project_management": (
+        "training",
+        "documentation",
+        "schedule",
+        "timeline",
+        "delivery",
+        "commissioning",
+        "maintenance",
+    ),
+}
+_UNIT_CATEGORY_HINT = {
+    "mm": "dimensional",
+    "kg": "dimensional",
+    "lb": "dimensional",
+    "degc": "dimensional",
+    "v": "electrical",
+    "vdc": "electrical",
+    "vac": "electrical",
+    "a": "electrical",
+    "hz": "electrical",
+    "rpm": "controls",
+}
+
+
+def _clean_line(text: str) -> str:
+    cleaned = text.strip()
+    cleaned = re.sub(r"^[\-\u2022*]+\s*", "", cleaned)
+    cleaned = re.sub(r"^\d+(?:\.\d+)*[.)]\s*", "", cleaned)
+    return cleaned.strip()
+
+
+def _spec_id(file_id: str, section_id: str, text: str) -> str:
+    digest = hashlib.sha1(f"{file_id}:{section_id}:{text}".encode("utf-8")).hexdigest()[:12]
+    return f"spec-{digest}"
+
+
+def _normalize_unit(match: re.Match[str]) -> tuple[str | None, float | None, str | None]:
+    raw_value = match.group("value")
+    raw_unit = match.group("unit").replace(" ", "")
+    raw_token = raw_unit.lower()
+    value = float(raw_value)
+    if raw_token in _TEMPERATURE_UNITS:
+        return f"{raw_value} {match.group('unit').strip()}", value, "degC"
+    if raw_token in _TEMPERATURE_F_UNITS:
+        celsius = (value - 32.0) * 5.0 / 9.0
+        return f"{raw_value} {match.group('unit').strip()}", round(celsius, 4), "degC"
+    conversion = _UNIT_CONVERSIONS.get(raw_token)
+    if not conversion:
+        return f"{raw_value} {match.group('unit').strip()}", value, raw_unit
+    unit, factor = conversion
+    return f"{raw_value} {match.group('unit').strip()}", round(value * factor, 4), unit
+
+
+def _classify(text: str, normalized_unit: str | None) -> str:
+    if normalized_unit:
+        token = normalized_unit.lower()
+        hinted = _UNIT_CATEGORY_HINT.get(token)
+        if hinted:
+            return hinted
+    lowered = text.lower()
+    for category, keywords in _CATEGORY_KEYWORDS.items():
+        for keyword in keywords:
+            if keyword.isalpha():
+                pattern = rf"\b{re.escape(keyword)}\b"
+                if re.search(pattern, lowered):
+                    return category
+            else:
+                if keyword in lowered:
+                    return category
+    return "general"
+
+
+def _confidence(text: str, has_value: bool, category: str) -> float:
+    lowered = text.lower()
+    base = 0.5
+    if any(trigger in lowered for trigger in ("shall", "must", "required")):
+        base = 0.9
+    elif any(trigger in lowered for trigger in ("should", "ensure", "include")):
+        base = 0.75
+    elif _VALUE_UNIT_RE.search(text):
+        base = 0.65
+    if has_value:
+        base += 0.05
+    if category != "general":
+        base += 0.05
+    return round(min(base, 1.0), 2)
+
+
+def _candidate_lines(lines: Iterable[str]) -> list[str]:
+    candidates: list[str] = []
+    for raw in lines:
+        cleaned = _clean_line(raw)
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        if any(trigger in lowered for trigger in _SPEC_TRIGGER_WORDS) or _VALUE_UNIT_RE.search(cleaned):
+            candidates.append(cleaned)
+    return candidates
+
+
+def atomize_section_text(
+    *,
+    file_id: str,
+    section_id: str,
+    section_title: str,
+    section_number: str | None,
+    lines: Sequence[str],
+    source_object_ids: Sequence[str] | None = None,
+) -> list[SpecItem]:
+    """Return ``SpecItem`` entries extracted from *lines* for a section."""
+
+    object_ids = [str(item) for item in (source_object_ids or [])]
+    specs: list[SpecItem] = []
+    for line in _candidate_lines(lines):
+        match = _VALUE_UNIT_RE.search(line)
+        raw_value: str | None = None
+        normalized_value: float | None = None
+        normalized_unit: str | None = None
+        if match:
+            raw_value, normalized_value, normalized_unit = _normalize_unit(match)
+        category = _classify(line, normalized_unit)
+        confidence = _confidence(line, normalized_value is not None, category)
+        spec = SpecItem(
+            spec_id=_spec_id(file_id, section_id, line),
+            file_id=file_id,
+            section_id=section_id,
+            section_title=section_title,
+            spec_text=line,
+            section_number=section_number,
+            source_object_ids=list(object_ids),
+            confidence=confidence,
+            raw_value=raw_value,
+            normalized_value=normalized_value,
+            normalized_unit=normalized_unit,
+            category=category,
+        )
+        specs.append(spec)
+    return specs

--- a/backend/services/spec_rag.py
+++ b/backend/services/spec_rag.py
@@ -1,0 +1,189 @@
+"""RAG extraction, indexing, and search helpers for specification chunks."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from ..config import Settings, get_settings
+from ..models import PARSED_OBJECT_ADAPTER, ParsedObject, SectionNode, SpecItem
+from .chunker import SectionChunk, build_section_chunks
+from .headers import load_persisted_headers
+from .search import ChunkRecord, HybridSearch
+from .spec_atomizer import atomize_section_text
+from .embeddings import EmbeddingService
+from .index_store import IndexStore
+
+__all__ = [
+    "extract_specs",
+    "load_spec_items",
+    "index_specs",
+    "search_specs",
+    "export_specs",
+]
+
+
+@dataclass(slots=True)
+class _SectionInfo:
+    node: SectionNode
+    chunk: SectionChunk
+
+
+def _load_parsed_objects(file_id: str, settings: Settings) -> list[ParsedObject]:
+    base = Path(settings.ARTIFACTS_DIR) / file_id / "parsed" / "objects.json"
+    if not base.exists():
+        raise FileNotFoundError("parsed_objects_missing")
+    with base.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return [PARSED_OBJECT_ADAPTER.validate_python(item) for item in payload]
+
+
+def _persist_spec_items(file_id: str, specs: Sequence[SpecItem], settings: Settings) -> None:
+    target_dir = Path(settings.ARTIFACTS_DIR) / file_id / "specs"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    payload = [spec.model_dump(mode="json") for spec in specs]
+    with (target_dir / "specs.json").open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def _collect_section_info(root: SectionNode, objects: list[ParsedObject]) -> list[_SectionInfo]:
+    chunk_records = build_section_chunks(root, objects)
+    node_map: dict[str, SectionNode] = {}
+
+    def visit(node: SectionNode) -> None:
+        node_map[node.section_id] = node
+        for child in node.children:
+            visit(child)
+
+    visit(root)
+    info: list[_SectionInfo] = []
+    for chunk in chunk_records:
+        node = node_map.get(chunk.section_id)
+        if not node:
+            continue
+        info.append(_SectionInfo(node=node, chunk=chunk))
+    return info
+
+
+def extract_specs(
+    file_id: str,
+    *,
+    settings: Settings | None = None,
+    persist: bool = True,
+) -> list[SpecItem]:
+    """Run deterministic atomization across all section chunks."""
+
+    resolved = settings or get_settings()
+    root = load_persisted_headers(file_id)
+    objects = _load_parsed_objects(file_id, resolved)
+    object_map = {obj.object_id: obj for obj in objects}
+
+    specs: list[SpecItem] = []
+    for info in _collect_section_info(root, objects):
+        if info.node.section_id == root.section_id:
+            continue
+        lines: list[str] = []
+        for object_id in info.chunk.object_ids:
+            obj = object_map.get(object_id)
+            if not obj:
+                continue
+            text = (obj.text or "").strip()
+            if not text:
+                continue
+            lines.extend(line.strip() for line in text.splitlines() if line.strip())
+        if not lines:
+            continue
+        extracted = atomize_section_text(
+            file_id=file_id,
+            section_id=info.node.section_id,
+            section_title=info.node.title,
+            section_number=info.node.number,
+            lines=lines,
+            source_object_ids=info.chunk.object_ids,
+        )
+        for spec in extracted:
+            spec.header_path = info.chunk.header_path
+            specs.append(spec)
+    if persist:
+        _persist_spec_items(file_id, specs, resolved)
+    return specs
+
+
+def load_spec_items(file_id: str, *, settings: Settings | None = None) -> list[SpecItem]:
+    resolved = settings or get_settings()
+    target = Path(resolved.ARTIFACTS_DIR) / file_id / "specs" / "specs.json"
+    if not target.exists():
+        raise FileNotFoundError("specs_missing")
+    with target.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return [SpecItem.model_validate(item) for item in payload]
+
+
+def _build_records(specs: Sequence[SpecItem]) -> list[ChunkRecord]:
+    records: list[ChunkRecord] = []
+    for spec in specs:
+        metadata = {
+            "file_id": spec.file_id,
+            "spec_id": spec.spec_id,
+            "section_id": spec.section_id,
+            "section_title": spec.section_title,
+            "section_number": spec.section_number,
+            "header_path": spec.header_path,
+            "normalized_unit": spec.normalized_unit,
+            "normalized_value": spec.normalized_value,
+            "raw_value": spec.raw_value,
+            "category": spec.category,
+        }
+        records.append(
+            ChunkRecord(
+                chunk_id=spec.spec_id,
+                text=spec.spec_text,
+                metadata=metadata,
+            )
+        )
+    return records
+
+
+def index_specs(
+    file_id: str,
+    *,
+    settings: Settings | None = None,
+    specs: Sequence[SpecItem] | None = None,
+) -> HybridSearch:
+    """Build and persist the hybrid search index for a file's specifications."""
+
+    resolved = settings or get_settings()
+    spec_items = list(specs) if specs is not None else load_spec_items(file_id, settings=resolved)
+    records = _build_records(spec_items)
+    embedding = EmbeddingService(resolved)
+    index_store = IndexStore(embedding.dimension, index_name=f"specs_{file_id}", settings=resolved)
+    searcher = HybridSearch(embedding_service=embedding, index_store=index_store, settings=resolved)
+    searcher.index(records)
+    return searcher
+
+
+def search_specs(
+    file_id: str,
+    query: str,
+    *,
+    top_k: int = 5,
+    settings: Settings | None = None,
+) -> list[dict[str, object]]:
+    """Execute a hybrid search query for a file's indexed specs."""
+
+    resolved = settings or get_settings()
+    specs = load_spec_items(file_id, settings=resolved)
+    searcher = index_specs(file_id, settings=resolved, specs=specs)
+    return searcher.search(query, k=top_k)
+
+
+def export_specs(file_id: str, *, settings: Settings | None = None) -> dict[str, object]:
+    """Return a serializable export payload for persisted specs."""
+
+    resolved = settings or get_settings()
+    specs = load_spec_items(file_id, settings=resolved)
+    return {
+        "file_id": file_id,
+        "specs": [spec.model_dump(mode="json") for spec in specs],
+    }

--- a/backend/tests/golden/sample1_specs.json
+++ b/backend/tests/golden/sample1_specs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "spec_id": "sample1-spec-1",
+    "file_id": "sample1",
+    "section_id": "sec-1",
+    "section_title": "Electrical Requirements",
+    "spec_text": "The safety relay shall operate at 24 VDC supply.",
+    "source_object_ids": ["sample1-obj-1"],
+    "section_number": "1",
+    "confidence": 1.0,
+    "header_path": "Document / Electrical Requirements",
+    "raw_value": "24 VDC",
+    "normalized_value": 24.0,
+    "normalized_unit": "VDC",
+    "category": "electrical"
+  },
+  {
+    "spec_id": "sample1-spec-2",
+    "file_id": "sample1",
+    "section_id": "sec-1",
+    "section_title": "Electrical Requirements",
+    "spec_text": "Maintain 5 mm clearance around the enclosure.",
+    "source_object_ids": ["sample1-obj-2"],
+    "section_number": "1",
+    "confidence": 1.0,
+    "header_path": "Document / Electrical Requirements",
+    "raw_value": "5 mm",
+    "normalized_value": 5.0,
+    "normalized_unit": "mm",
+    "category": "dimensional"
+  }
+]

--- a/backend/tests/golden/sample2_specs.json
+++ b/backend/tests/golden/sample2_specs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "spec_id": "sample2-spec-1",
+    "file_id": "sample2",
+    "section_id": "sec-2",
+    "section_title": "Software",
+    "spec_text": "Software version should be 1.2.0 or later.",
+    "source_object_ids": ["sample2-obj-1"],
+    "section_number": "2",
+    "confidence": 0.8,
+    "header_path": "Document / Software",
+    "raw_value": null,
+    "normalized_value": null,
+    "normalized_unit": null,
+    "category": "software"
+  }
+]

--- a/backend/tests/test_atomizer.py
+++ b/backend/tests/test_atomizer.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.services.spec_atomizer import atomize_section_text
+
+
+def _find(items, needle):
+    for item in items:
+        if needle in item.spec_text:
+            return item
+    raise AssertionError(f"Spec containing '{needle}' not found")
+
+
+def test_atomizer_normalizes_units_and_classifies() -> None:
+    lines = [
+        "- The enclosure shall be rated IP65 for outdoor service.",
+        "Spacing shall be 2 cm between mounting holes.",
+        "Panel must operate at 24 VDC ±10%.",
+        "Software version should be 1.2.0 or later.",
+        "Ambient temperature must not exceed 140 °F.",
+        "General marketing copy.",
+    ]
+
+    items = atomize_section_text(
+        file_id="file-1",
+        section_id="sec-1",
+        section_title="Controls",
+        section_number="1.2",
+        lines=lines,
+        source_object_ids=["obj-1"],
+    )
+
+    assert len(items) == 5
+    assert len({item.spec_id for item in items}) == len(items)
+    assert all(item.spec_id.startswith("spec-") for item in items)
+    assert all(item.source_object_ids == ["obj-1"] for item in items)
+
+    spacing = _find(items, "Spacing shall")
+    assert spacing.raw_value == "2 cm"
+    assert spacing.normalized_unit == "mm"
+    assert spacing.normalized_value == 20.0
+    assert spacing.category == "dimensional"
+    assert spacing.confidence == 1.0
+
+    voltage = _find(items, "24 VDC")
+    assert voltage.normalized_unit == "VDC"
+    assert voltage.normalized_value == 24.0
+    assert voltage.category == "electrical"
+    assert voltage.confidence == 1.0
+
+    software = _find(items, "Software version")
+    assert software.category == "software"
+    assert software.confidence == 0.8
+
+    temperature = _find(items, "140 °F")
+    assert temperature.normalized_unit == "degC"
+    assert round(temperature.normalized_value or 0.0, 2) == 60.0
+    assert temperature.category == "dimensional"

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.config import Settings
+from backend.services.embeddings import EmbeddingService
+from backend.services.index_store import IndexStore
+from backend.services.search import ChunkRecord, HybridSearch
+
+
+def test_hybrid_search_ranks_relevant_chunks(tmp_path) -> None:
+    settings = Settings(RAG_INDEX_DIR=str(tmp_path / "index"), RAG_LIGHT_MODE=1)
+    embedding = EmbeddingService(settings)
+    index_store = IndexStore(embedding.dimension, index_name="unit", settings=settings)
+    searcher = HybridSearch(embedding_service=embedding, index_store=index_store, settings=settings)
+
+    records = [
+        ChunkRecord(
+            chunk_id="chunk-1",
+            text="The safety relay shall operate on a 24 VDC supply with redundant contacts.",
+            metadata={"header_path": "Document / Safety"},
+        ),
+        ChunkRecord(
+            chunk_id="chunk-2",
+            text="Maintain 5 mm clearance around the enclosure for cooling airflow.",
+            metadata={"header_path": "Document / Mechanical"},
+        ),
+        ChunkRecord(
+            chunk_id="chunk-3",
+            text="Provide software update checklist and operator documentation.",
+            metadata={"header_path": "Document / Software"},
+        ),
+    ]
+
+    searcher.index(records)
+    assert len(searcher.records()) == 3
+
+    results = searcher.search("24 VDC safety relay", k=2)
+    assert results
+    assert results[0]["chunk_id"] == "chunk-1"
+    assert results[0]["metadata"]["header_path"] == "Document / Safety"
+    assert results[0]["bm25"] > 0
+
+    software_results = searcher.search("software checklist", k=2)
+    assert software_results[0]["chunk_id"] == "chunk-3"
+
+    reloaded = IndexStore(embedding.dimension, index_name="unit", settings=settings)
+    reloaded.load()
+    vector_hits = reloaded.search(embedding.embed_query("24 VDC safety relay"), k=3)
+    assert any(hit[0] == "chunk-1" for hit in vector_hits)

--- a/backend/tests/test_specs_routes.py
+++ b/backend/tests/test_specs_routes.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.config import get_settings
+from backend.main import create_app
+from backend.models import LineObject, ParagraphObject, SectionNode, SectionSpan
+
+
+def _prepare_artifacts(tmp_path: Path) -> str:
+    artifacts_dir = tmp_path / "artifacts"
+    index_dir = tmp_path / "index"
+    os.environ["SIMPLS_ARTIFACTS_DIR"] = str(artifacts_dir)
+    os.environ["SIMPLS_RAG_INDEX_DIR"] = str(index_dir)
+    os.environ["SIMPLS_RAG_LIGHT_MODE"] = "1"
+    get_settings.cache_clear()
+    settings = get_settings()
+
+    file_id = "unit-spec"
+    artifact_root = Path(settings.ARTIFACTS_DIR) / file_id
+    parsed_dir = artifact_root / "parsed"
+    headers_dir = artifact_root / "headers"
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+    headers_dir.mkdir(parents=True, exist_ok=True)
+
+    objects = [
+        LineObject(
+            object_id=f"{file_id}-obj-0",
+            file_id=file_id,
+            text="Electrical Requirements",
+            page_index=0,
+            order_index=0,
+            paragraph_index=0,
+        ),
+        ParagraphObject(
+            object_id=f"{file_id}-obj-1",
+            file_id=file_id,
+            text="The safety relay shall operate at 24 VDC supply.",
+            page_index=0,
+            order_index=1,
+            paragraph_index=1,
+        ),
+        ParagraphObject(
+            object_id=f"{file_id}-obj-2",
+            file_id=file_id,
+            text="Maintain 5 mm clearance around the enclosure.",
+            page_index=0,
+            order_index=2,
+            paragraph_index=2,
+        ),
+        LineObject(
+            object_id=f"{file_id}-obj-3",
+            file_id=file_id,
+            text="Software",
+            page_index=1,
+            order_index=3,
+            paragraph_index=3,
+        ),
+        ParagraphObject(
+            object_id=f"{file_id}-obj-4",
+            file_id=file_id,
+            text="Software version should be 1.2.0 or later.",
+            page_index=1,
+            order_index=4,
+            paragraph_index=4,
+        ),
+    ]
+    with (parsed_dir / "objects.json").open("w", encoding="utf-8") as handle:
+        json.dump([obj.model_dump(mode="json") for obj in objects], handle, indent=2)
+
+    section_elec = SectionNode(
+        section_id="sec-1",
+        file_id=file_id,
+        title="Electrical Requirements",
+        depth=1,
+        number="1",
+        span=SectionSpan(
+            start_object=objects[0].object_id,
+            end_object=objects[2].object_id,
+        ),
+        children=[],
+    )
+    section_soft = SectionNode(
+        section_id="sec-2",
+        file_id=file_id,
+        title="Software",
+        depth=1,
+        number="2",
+        span=SectionSpan(
+            start_object=objects[3].object_id,
+            end_object=objects[4].object_id,
+        ),
+        children=[],
+    )
+    root = SectionNode(
+        section_id="root",
+        file_id=file_id,
+        title="Document",
+        depth=0,
+        children=[section_elec, section_soft],
+    )
+    with (headers_dir / "sections.json").open("w", encoding="utf-8") as handle:
+        json.dump(root.model_dump(mode="json"), handle, indent=2)
+
+    return file_id
+
+
+def test_spec_endpoints_roundtrip(tmp_path) -> None:
+    file_id = _prepare_artifacts(tmp_path)
+    app = create_app()
+    client = TestClient(app)
+
+    extract_response = client.post("/api/specs/extract", json={"file_id": file_id})
+    assert extract_response.status_code == 200
+    extracted = extract_response.json()
+    assert len(extracted) == 3
+    assert any("24 VDC" in item["spec_text"] for item in extracted)
+
+    index_response = client.post("/api/specs/index", json={"file_id": file_id})
+    assert index_response.status_code == 200
+    assert index_response.json()["indexed"] == 3
+
+    search_response = client.post(
+        "/api/specs/search",
+        json={"file_id": file_id, "query": "24 VDC safety", "top_k": 2},
+    )
+    assert search_response.status_code == 200
+    hits = search_response.json()
+    assert hits
+    assert any("24 VDC" in hit["text"] for hit in hits)
+
+    export_response = client.post("/api/specs/export", json={"file_id": file_id})
+    assert export_response.status_code == 200
+    export_payload = export_response.json()
+    assert export_payload["file_id"] == file_id
+    assert len(export_payload["specs"]) == 3
+
+    for key in ["SIMPLS_ARTIFACTS_DIR", "SIMPLS_RAG_INDEX_DIR", "SIMPLS_RAG_LIGHT_MODE"]:
+        os.environ.pop(key, None)
+    get_settings.cache_clear()

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -86,6 +86,35 @@ variables (with or without the `SIMPLS_` prefix):
 - `PARSER_ENABLE_OCR` — call Tesseract when a page has little native text (default `false`).
 - `PARSER_DEBUG` — write structured JSON debug logs to the standard logger (default `false`).
 
+### Retrieval-augmented specs flags
+
+Phase 2 introduces an opinionated RAG pipeline. The following environment
+variables configure it (all prefixed with `SIMPLS_` when exported globally):
+
+- `RAG_ENABLE` — gate the entire flow (default `true`).
+- `RAG_CHUNK_MODE` — locked to `section`; the app raises if another value is supplied.
+- `RAG_MODEL_PATH` — path to a local sentence-transformer model
+  (`./models/all-MiniLM-L6-v2` by default).
+- `RAG_INDEX_DIR` — directory for persisted indices (default `./.rag_index`).
+- `RAG_LIGHT_MODE` — keep at `1` for offline deterministic hashing stubs during CI.
+- `RAG_HYBRID_ALPHA` — dense/sparse fusion weight (default `0.5`).
+
+> **Important**: section chunking is enforced irrespective of legacy token or
+> overlap toggles. A misconfigured value will raise during settings load so the
+> behaviour is obvious at startup.
+
+#### Local CLI helpers
+
+The deterministic pipeline can be exercised end-to-end without the API:
+
+```bash
+python -m backend.cli.specs_index backend/tests/resources/sample1.pdf --rebuild
+python -m backend.cli.specs_query --file-id sample1 --q "24 VDC safety relay" --k 5
+```
+
+Both commands respect `SIMPLS_RAG_LIGHT_MODE=1`, using hash-based embeddings so
+no external models are required.
+
 For rapid iteration run the CLI entry point directly:
 
 ```bash


### PR DESCRIPTION
## Summary
- add RAG configuration flags and documentation for section chunking
- implement section chunker, rule-based spec atomizer, and hybrid search services with tests
- expose new /api/specs endpoints, CLI helpers, and golden fixtures for the specs RAG workflow

## Testing
- pytest backend/tests/test_chunker.py backend/tests/test_atomizer.py backend/tests/test_search.py backend/tests/test_specs_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68f02f7a0bf48324b6ea16f16ffa56e7