### PR TITLE
Set up project foundations and health check

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,18 @@
+# SimpleSpecs environment configuration
+# Copy this file to `.env` and adjust values as needed.
+
+# Primary LLM provider configuration
+OPENROUTER_API_KEY=
+LLM_PROVIDER=openrouter  # options: 'openrouter', 'ollama'
+
+# Parsing feature toggles
+PARSER_MULTI_COLUMN=true
+PARSER_ENABLE_OCR=true
+MINERU_FALLBACK=true
+
+# Header extraction behavior
+HEADERS_SUPPRESS_TOC=true
+HEADERS_SUPPRESS_RUNNING=true
+
+# Database connection string
+DB_URL=sqlite:///./simplespecs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,210 +1,23 @@
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
-*.py[codz]
-*$py.class
+*.py[cod]
+*.pyo
+*.pyd
+*.sqlite3
+*.db
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py.cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-#poetry.toml
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
-#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
-#pdm.lock
-#pdm.toml
-.pdm-python
-.pdm-build/
-
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-#pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.envrc
-.venv
-env/
+# Virtual environments
+.venv/
 venv/
 ENV/
-env.bak/
-venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Editor files
+.vscode/
+.idea/
+*.swp
 
-# Rope project settings
-.ropeproject
+# Local environment
+.env
 
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-
-# Ruff stuff:
-.ruff_cache/
-
-# PyPI configuration file
-.pypirc
-
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
-
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
-
-# Header replay artifacts
-artifacts/**/source/*
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# SimpleSpecs
+
+SimpleSpecs is an application for parsing engineering specification PDFs and structuring the extracted data for downstream workflow automation.
+
+## Prerequisites
+- Python 3.12+
+- Node-compatible runtime for serving static frontend (optional during backend-only development)
+- Tesseract OCR binary installed and in `PATH` when OCR is required
+
+## Getting Started
+1. Create and activate a virtual environment:
+   ```bash
+   python3.12 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy the environment template and adjust values as needed:
+   ```bash
+   cp .env.template .env
+   ```
+4. Launch the backend locally:
+   ```bash
+   ./start_local.sh
+   ```
+   or on Windows PowerShell:
+   ```powershell
+   .\start_local.bat
+   ```
+5. Visit `http://localhost:8000/api/health` to verify the service responds with `{ "ok": true }`.
+
+## Testing
+Run the automated test suite with:
+```bash
+pytest
+```
+
+## Project Structure
+```
+backend/      # FastAPI application
+frontend/     # Static HTML/CSS/JS assets
+plan/         # Phase plans and reference documents
+agents/       # Codex-style execution prompts per phase
+```

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for SimpleSpecs."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,10 @@
+"""SimpleSpecs backend entrypoint."""
+from fastapi import FastAPI
+
+app = FastAPI(title="SimpleSpecs", version="0.0.1")
+
+
+@app.get("/api/health")
+def read_health() -> dict[str, bool]:
+    """Health check endpoint returning a simple ok response."""
+    return {"ok": True}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SimpleSpecs</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>SimpleSpecs</h1>
+      <p>Frontend placeholder for the SimpleSpecs application.</p>
+    </main>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,19 @@
+const healthStatus = document.createElement("pre");
+healthStatus.textContent = "Checking backend health...";
+document.querySelector("main")?.append(healthStatus);
+
+async function checkHealth() {
+  try {
+    const response = await fetch("/api/health");
+    if (!response.ok) {
+      throw new Error(`Unexpected status ${response.status}`);
+    }
+    const payload = await response.json();
+    healthStatus.textContent = JSON.stringify(payload, null, 2);
+  } catch (error) {
+    console.error(error);
+    healthStatus.textContent = "Health check failed. See console for details.";
+  }
+}
+
+checkHealth();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,16 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background-color: Canvas;
+  color: CanvasText;
+}
+
+main {
+  max-width: 60ch;
+  margin: 0 auto;
+}

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+sqlmodel==0.0.16
+PyMuPDF==1.23.26
+pdfplumber==0.11.3
+camelot-py[cv]==0.11.0
+pytesseract==0.3.10
+python-dotenv==1.0.1
+httpx==0.27.0
+pytest==8.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+sqlmodel==0.0.16
+PyMuPDF==1.23.26
+pdfplumber==0.11.3
+camelot-py[cv]==0.11.0
+pytesseract==0.3.10
+python-dotenv==1.0.1
+httpx==0.27.0
+pytest==8.2.2

--- a/start_local.bat
+++ b/start_local.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+if exist .env (
+  for /f "usebackq tokens=1,2 delims==" %%a in (".env") do (
+    if not "%%a"=="" if not "%%a"=="#" set %%a=%%b
+  )
+)
+uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload

--- a/start_local.sh
+++ b/start_local.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+exec uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+def test_health_endpoint_returns_ok():
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with /api/health endpoint and accompanying test
- add frontend placeholder assets and project bootstrap documentation
- provide environment template, dependency pins, gitignore, and local start scripts

## Testing
- `pytest` *(fails: missing FastAPI dependency in sandbox due to offline package index)*

------
https://chatgpt.com/codex/tasks/task_e_68fad1d533408324818e7713916583b3