### PR TITLE
Ensure pytest can import backend package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for SimpleSpecs."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root is available on sys.path so tests can import project packages
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- add a pytest conftest that injects the repository root into sys.path so tests can import the backend package during Phase 00 checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fad38ec48c8324b3b0bfe10e595540