### PR TITLE
Phase 01: implement document upload backend and frontend

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,50 @@
+"""Configuration utilities for the SimpleSpecs backend."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Tuple
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class Settings(BaseModel):
+    """Application configuration loaded from environment variables."""
+
+    database_url: str = Field(default_factory=lambda: os.getenv("DATABASE_URL", "sqlite:///./simplespecs.db"))
+    upload_dir: Path = Field(default_factory=lambda: Path(os.getenv("UPLOAD_DIR", "upload_objects_path")))
+    max_upload_size: int = Field(default_factory=lambda: int(os.getenv("MAX_UPLOAD_SIZE", str(25 * 1024 * 1024))))
+    allowed_mimetypes: Tuple[str, ...] = Field(
+        default_factory=lambda: tuple(
+            mime.strip()
+            for mime in os.getenv("ALLOWED_MIMETYPES", "application/pdf").split(",")
+            if mime.strip()
+        )
+    )
+
+    @field_validator("upload_dir", mode="after")
+    @classmethod
+    def _ensure_upload_dir(cls, value: Path) -> Path:
+        value.mkdir(parents=True, exist_ok=True)
+        return value
+
+    @field_validator("allowed_mimetypes", mode="after")
+    @classmethod
+    def _normalise_mimetypes(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
+        if not value:
+            return ("application/pdf",)
+        return tuple(dict.fromkeys(item.lower() for item in value))
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()
+
+
+def reset_settings_cache() -> None:
+    """Clear the cached settings so that subsequent calls reload from the environment."""
+
+    get_settings.cache_clear()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,45 @@
+"""Database utilities for the SimpleSpecs backend."""
+from __future__ import annotations
+
+from typing import Generator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import get_settings
+
+_engine = None
+
+
+def get_engine():
+    """Return a SQLModel engine using configured settings."""
+
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        connect_args = {"check_same_thread": False} if settings.database_url.startswith("sqlite") else {}
+        _engine = create_engine(settings.database_url, connect_args=connect_args)
+    return _engine
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Provide a SQLModel session for FastAPI dependencies."""
+
+    engine = get_engine()
+    with Session(engine) as session:
+        yield session
+
+
+def init_db() -> None:
+    """Initialise database tables."""
+
+    from .models import document  # noqa: F401  Ensures models are registered with SQLModel metadata.
+
+    engine = get_engine()
+    SQLModel.metadata.create_all(engine)
+
+
+def reset_database_state() -> None:
+    """Reset the cached engine (useful for tests)."""
+
+    global _engine
+    _engine = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,24 @@
 """SimpleSpecs backend entrypoint."""
+from __future__ import annotations
+
 from fastapi import FastAPI
 
-app = FastAPI(title="SimpleSpecs", version="0.0.1")
+from .database import init_db
+from .routers import api_router
+
+app = FastAPI(title="SimpleSpecs", version="0.1.0")
+app.include_router(api_router)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialise application state."""
+
+    init_db()
 
 
 @app.get("/api/health")
 def read_health() -> dict[str, bool]:
     """Health check endpoint returning a simple ok response."""
+
     return {"ok": True}

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,4 @@
+"""Database models for the SimpleSpecs backend."""
+from .document import Document
+
+__all__ = ["Document"]

--- a/backend/models/document.py
+++ b/backend/models/document.py
@@ -1,0 +1,20 @@
+"""Document model definition."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Document(SQLModel, table=True):
+    """Represents an uploaded document tracked by the system."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    filename: str = Field(index=True, description="Original filename of the uploaded document.")
+    checksum: str = Field(unique=True, index=True, description="SHA-256 checksum for deduplication.")
+    uploaded_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp indicating when the file was uploaded.",
+    )
+    status: str = Field(default="uploaded", description="Processing status for the document.")

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,9 @@
+"""API router package."""
+from fastapi import APIRouter
+
+from .files import router as files_router
+
+api_router = APIRouter()
+api_router.include_router(files_router)
+
+__all__ = ["api_router"]

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -1,0 +1,34 @@
+"""File upload and listing endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Response, UploadFile, status
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from ..database import get_session
+from ..models import Document
+from ..services.files import handle_upload, list_documents
+
+router = APIRouter(prefix="/api", tags=["files"])
+
+
+@router.post("/upload", response_model=Document)
+async def upload_file(
+    *,
+    file: UploadFile = File(...),
+    response: Response,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> Document:
+    """Handle PDF uploads and return the stored document."""
+
+    document, created = await handle_upload(session=session, upload=file, settings=settings)
+    response.status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    return document
+
+
+@router.get("/files", response_model=list[Document])
+async def get_files(*, session: Session = Depends(get_session)) -> list[Document]:
+    """Return the list of uploaded documents."""
+
+    return list_documents(session=session)

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer package."""

--- a/backend/services/files.py
+++ b/backend/services/files.py
@@ -1,0 +1,96 @@
+"""File service helpers for uploads and listings."""
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Tuple
+
+from fastapi import HTTPException, UploadFile, status
+from sqlmodel import Session, select
+
+from ..config import Settings
+from ..models import Document
+
+CHUNK_SIZE = 1024 * 1024  # 1MB
+
+
+def _secure_filename(filename: str) -> str:
+    """Return a filesystem-safe version of the provided filename."""
+
+    if not filename:
+        return f"document-{secrets.token_hex(8)}.pdf"
+    name = Path(filename).name
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", name)
+    return cleaned or f"document-{secrets.token_hex(8)}.pdf"
+
+
+async def handle_upload(
+    *, session: Session, upload: UploadFile, settings: Settings
+) -> Tuple[Document, bool]:
+    """Persist an uploaded file and return the stored document with a creation flag."""
+
+    if upload.content_type and upload.content_type.lower() not in settings.allowed_mimetypes:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+
+    filename = _secure_filename(upload.filename or "")
+    temp_dir = settings.upload_dir / "_incoming"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = temp_dir / f"{secrets.token_hex(16)}.tmp"
+
+    file_hash = hashlib.sha256()
+    total_bytes = 0
+
+    try:
+        with temp_path.open("wb") as buffer:
+            while True:
+                chunk = await upload.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                total_bytes += len(chunk)
+                if total_bytes > settings.max_upload_size:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="File exceeds maximum allowed size",
+                    )
+                file_hash.update(chunk)
+                buffer.write(chunk)
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise
+    finally:
+        await upload.close()
+
+    checksum = file_hash.hexdigest()
+    existing_document = session.exec(select(Document).where(Document.checksum == checksum)).first()
+    if existing_document:
+        if temp_path.exists():
+            temp_path.unlink()
+        return existing_document, False
+
+    document = Document(
+        filename=filename,
+        checksum=checksum,
+        uploaded_at=datetime.now(UTC),
+        status="uploaded",
+    )
+    session.add(document)
+    session.commit()
+    session.refresh(document)
+
+    document_dir = settings.upload_dir / str(document.id)
+    document_dir.mkdir(parents=True, exist_ok=True)
+    final_path = document_dir / filename
+    temp_path.replace(final_path)
+
+    return document, True
+
+
+def list_documents(*, session: Session) -> list[Document]:
+    """Return a list of stored documents ordered by upload date (newest first)."""
+
+    statement = select(Document).order_by(Document.uploaded_at.desc())
+    return list(session.exec(statement))

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,8 +8,43 @@
   </head>
   <body>
     <main>
-      <h1>SimpleSpecs</h1>
-      <p>Frontend placeholder for the SimpleSpecs application.</p>
+      <header class="page-header">
+        <h1>SimpleSpecs</h1>
+        <p>Upload specification PDFs and manage them in one place.</p>
+      </header>
+
+      <section class="uploader" aria-labelledby="uploader-title">
+        <h2 id="uploader-title">Upload documents</h2>
+        <div id="drop-zone" class="drop-zone" role="button" tabindex="0">
+          <p>Drag and drop PDF files here or <button id="browse-button" type="button">browse</button>.</p>
+          <input
+            id="file-input"
+            type="file"
+            accept="application/pdf"
+            multiple
+            aria-label="Select PDF files to upload"
+            hidden
+          />
+        </div>
+        <ul id="upload-progress" class="upload-progress" aria-live="polite"></ul>
+      </section>
+
+      <section class="documents" aria-labelledby="documents-title">
+        <h2 id="documents-title">Uploaded files</h2>
+        <p id="documents-status" class="status-message" role="status">Fetching files...</p>
+        <div class="table-wrapper">
+          <table id="files-table" class="documents-table">
+            <thead>
+              <tr>
+                <th scope="col">Filename</th>
+                <th scope="col">Status</th>
+                <th scope="col">Uploaded</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
     </main>
     <script type="module" src="/main.js"></script>
   </body>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,19 +1,181 @@
-const healthStatus = document.createElement("pre");
-healthStatus.textContent = "Checking backend health...";
-document.querySelector("main")?.append(healthStatus);
+const dropZone = document.querySelector("#drop-zone");
+const fileInput = document.querySelector("#file-input");
+const browseButton = document.querySelector("#browse-button");
+const uploadList = document.querySelector("#upload-progress");
+const documentsStatus = document.querySelector("#documents-status");
+const filesTableBody = document.querySelector("#files-table tbody");
 
-async function checkHealth() {
-  try {
-    const response = await fetch("/api/health");
-    if (!response.ok) {
-      throw new Error(`Unexpected status ${response.status}`);
-    }
-    const payload = await response.json();
-    healthStatus.textContent = JSON.stringify(payload, null, 2);
-  } catch (error) {
-    console.error(error);
-    healthStatus.textContent = "Health check failed. See console for details.";
+function formatDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return date.toLocaleString();
+}
+
+function createProgressItem(filename) {
+  const item = document.createElement("li");
+  item.className = "upload-item";
+
+  const nameSpan = document.createElement("span");
+  nameSpan.textContent = filename;
+  nameSpan.className = "upload-name";
+
+  const progress = document.createElement("progress");
+  progress.max = 100;
+  progress.value = 0;
+
+  const statusSpan = document.createElement("span");
+  statusSpan.className = "upload-status";
+  statusSpan.textContent = "Starting...";
+
+  item.append(nameSpan, progress, statusSpan);
+  uploadList.prepend(item);
+
+  return { item, progress, statusSpan };
+}
+
+function updateDocumentsTable(documents) {
+  filesTableBody.innerHTML = "";
+  if (!documents.length) {
+    documentsStatus.textContent = "No files uploaded yet.";
+    return;
+  }
+
+  documentsStatus.textContent = `Showing ${documents.length} document${documents.length > 1 ? "s" : ""}.`;
+
+  for (const doc of documents) {
+    const row = document.createElement("tr");
+
+    const filenameCell = document.createElement("td");
+    filenameCell.textContent = doc.filename;
+
+    const statusCell = document.createElement("td");
+    statusCell.textContent = doc.status;
+
+    const uploadedCell = document.createElement("td");
+    uploadedCell.textContent = formatDate(doc.uploaded_at);
+
+    row.append(filenameCell, statusCell, uploadedCell);
+    filesTableBody.append(row);
   }
 }
 
-checkHealth();
+async function fetchDocuments() {
+  try {
+    const response = await fetch("/api/files");
+    if (!response.ok) {
+      throw new Error(`Failed to fetch files (${response.status})`);
+    }
+    const documents = await response.json();
+    updateDocumentsTable(documents);
+  } catch (error) {
+    console.error(error);
+    documentsStatus.textContent = "Unable to fetch files.";
+  }
+}
+
+function uploadFile(file) {
+  const { progress, statusSpan } = createProgressItem(file.name);
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "/api/upload");
+    xhr.responseType = "json";
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        progress.value = Math.round((event.loaded / event.total) * 100);
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status === 200 || xhr.status === 201) {
+        progress.value = 100;
+        statusSpan.textContent = xhr.status === 201 ? "Uploaded" : "Already uploaded";
+        resolve(xhr.response);
+      } else {
+        const detail = xhr.response?.detail || `Upload failed (${xhr.status})`;
+        statusSpan.textContent = detail;
+        progress.classList.add("upload-error");
+        reject(new Error(detail));
+      }
+    };
+
+    xhr.onerror = () => {
+      statusSpan.textContent = "Network error";
+      progress.classList.add("upload-error");
+      reject(new Error("Network error"));
+    };
+
+    const formData = new FormData();
+    formData.append("file", file);
+    xhr.send(formData);
+  });
+}
+
+async function handleFiles(files) {
+  const pdfFiles = Array.from(files).filter((file) => file.type === "application/pdf" || file.name.endsWith(".pdf"));
+  if (!pdfFiles.length) {
+    window.alert("Only PDF files can be uploaded.");
+    return;
+  }
+
+  for (const file of pdfFiles) {
+    try {
+      await uploadFile(file);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  await fetchDocuments();
+}
+
+function preventDefaults(event) {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+if (dropZone) {
+  ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {
+    dropZone.addEventListener(eventName, preventDefaults, false);
+  });
+
+  dropZone.addEventListener("dragover", () => {
+    dropZone.classList.add("is-dragging");
+  });
+
+  dropZone.addEventListener("dragleave", () => {
+    dropZone.classList.remove("is-dragging");
+  });
+
+  dropZone.addEventListener("drop", (event) => {
+    dropZone.classList.remove("is-dragging");
+    const files = event.dataTransfer?.files;
+    if (files?.length) {
+      void handleFiles(files);
+    }
+  });
+
+  dropZone.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      fileInput?.click();
+    }
+  });
+}
+
+browseButton?.addEventListener("click", () => {
+  fileInput?.click();
+});
+
+fileInput?.addEventListener("change", (event) => {
+  const target = event.target;
+  if (target.files?.length) {
+    void handleFiles(target.files);
+    target.value = "";
+  }
+});
+
+void fetchDocuments();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -11,6 +11,120 @@ body {
 }
 
 main {
-  max-width: 60ch;
+  max-width: 960px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.page-header p {
+  margin-top: 0;
+  color: color-mix(in srgb, CanvasText 70%, transparent);
+}
+
+.uploader {
+  border: 1px solid color-mix(in srgb, CanvasText 15%, transparent);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background-color: color-mix(in srgb, Canvas 96%, CanvasText 4%);
+}
+
+.drop-zone {
+  border: 2px dashed color-mix(in srgb, CanvasText 35%, transparent);
+  border-radius: 12px;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+  cursor: pointer;
+}
+
+.drop-zone button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.drop-zone.is-dragging {
+  border-color: color-mix(in srgb, CanvasText 65%, transparent);
+  background-color: color-mix(in srgb, CanvasText 8%, transparent);
+}
+
+.upload-progress {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.upload-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.upload-name {
+  flex: 1 1 auto;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.upload-status {
+  min-width: 9rem;
+  text-align: right;
+}
+
+progress {
+  width: 200px;
+  height: 0.75rem;
+}
+
+progress.upload-error::-webkit-progress-value {
+  background-color: #d14343;
+}
+
+progress.upload-error::-moz-progress-bar {
+  background-color: #d14343;
+}
+
+.documents {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.status-message {
+  margin: 0;
+  color: color-mix(in srgb, CanvasText 60%, transparent);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.documents-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.documents-table th,
+.documents-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, CanvasText 15%, transparent);
+  text-align: left;
+}
+
+.documents-table tbody tr:hover {
+  background-color: color-mix(in srgb, CanvasText 6%, transparent);
 }

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,99 @@
+"""Tests covering document upload functionality."""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.config import reset_settings_cache
+from backend.database import reset_database_state
+
+PDF_BYTES = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+    b"trailer\n<< /Root 1 0 R >>\n%%EOF\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[None, None, None]:
+    """Provide isolated database and upload directories per test."""
+
+    db_path = tmp_path / "test.db"
+    upload_dir = tmp_path / "uploads"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("MAX_UPLOAD_SIZE", str(1024))
+    reset_settings_cache()
+    reset_database_state()
+    yield
+    reset_settings_cache()
+    reset_database_state()
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Return a test client for the FastAPI application."""
+
+    from backend.main import app
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _post_pdf(client: TestClient, content: bytes, filename: str = "sample.pdf"):
+    return client.post(
+        "/api/upload",
+        files={"file": (filename, io.BytesIO(content), "application/pdf")},
+    )
+
+
+def test_upload_creates_document_and_persists_file(client: TestClient) -> None:
+    """Uploading a PDF should create a document entry and save the file on disk."""
+
+    response = _post_pdf(client, PDF_BYTES)
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["filename"] == "sample.pdf"
+    assert "checksum" in payload
+    assert "uploaded_at" in payload
+
+    document_id = payload["id"]
+    stored_path = Path(os.environ["UPLOAD_DIR"]) / str(document_id) / payload["filename"]
+    assert stored_path.exists()
+    assert stored_path.read_bytes() == PDF_BYTES
+
+    list_response = client.get("/api/files")
+    assert list_response.status_code == 200
+    documents = list_response.json()
+    assert any(doc["id"] == document_id for doc in documents)
+
+
+def test_duplicate_upload_returns_existing_document(client: TestClient) -> None:
+    """Uploading the same file twice should reuse the original document record."""
+
+    first = _post_pdf(client, PDF_BYTES)
+    assert first.status_code == 201
+    first_payload = first.json()
+
+    second = _post_pdf(client, PDF_BYTES)
+    assert second.status_code == 200
+    second_payload = second.json()
+    assert second_payload["id"] == first_payload["id"]
+
+
+def test_large_file_is_rejected(client: TestClient) -> None:
+    """Files exceeding the configured size limit should be rejected."""
+
+    oversized_content = PDF_BYTES + b"A" * 1500
+    response = _post_pdf(client, oversized_content, filename="large.pdf")
+    assert response.status_code == 413
+    payload = response.json()
+    assert payload["detail"] == "File exceeds maximum allowed size"
+
+    upload_dir = Path(os.environ["UPLOAD_DIR"])
+    assert not any(upload_dir.rglob("large.pdf"))


### PR DESCRIPTION
## Summary
- add SQLModel document model, database utilities, and file service endpoints for uploading and listing PDFs
- store uploaded files on disk with checksum-based deduplication and expose REST API plus frontend drag-and-drop uploader
- cover the upload flow with tests for success, deduplication, and size limits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fadacb7134832480fa152f1cdc81bf