### PR TITLE
Handle phase 1 warnings

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,18 @@
 """Backend package for SimpleSpecs."""
+from __future__ import annotations
+
+import sys
+
+import python_multipart
+import python_multipart.multipart
+
+# ---------------------------------------------------------------------------
+# Compatibility shim: Starlette currently imports the legacy ``multipart``
+# package which emits a ``PendingDeprecationWarning``. Register the modern
+# ``python_multipart`` modules under the legacy import paths so Starlette can
+# resolve them without triggering the warning while we migrate.
+# ---------------------------------------------------------------------------
+sys.modules.setdefault("multipart", python_multipart)
+sys.modules.setdefault("multipart.multipart", python_multipart.multipart)
+
+__all__ = ["python_multipart"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,20 +1,24 @@
 """SimpleSpecs backend entrypoint."""
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from .database import init_db
 from .routers import api_router
 
-app = FastAPI(title="SimpleSpecs", version="0.1.0")
-app.include_router(api_router)
 
-
-@app.on_event("startup")
-def on_startup() -> None:
-    """Initialise application state."""
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Initialise application state for the FastAPI app."""
 
     init_db()
+    yield
+
+
+app = FastAPI(title="SimpleSpecs", version="0.1.0", lifespan=lifespan)
+app.include_router(api_router)
 
 
 @app.get("/api/health")

--- a/multipart/__init__.py
+++ b/multipart/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility layer that re-exports python_multipart without warnings."""
+from __future__ import annotations
+
+from python_multipart import *  # noqa: F401,F403
+from python_multipart import __all__, __author__, __copyright__, __license__, __version__
+
+__all__ = list(__all__)

--- a/multipart/multipart.py
+++ b/multipart/multipart.py
@@ -1,0 +1,5 @@
+"""Submodule re-export for compatibility with Starlette imports."""
+from __future__ import annotations
+
+from python_multipart.multipart import *  # noqa: F401,F403
+

--- a/requirements.lock
+++ b/requirements.lock
@@ -6,5 +6,6 @@ pdfplumber==0.11.3
 camelot-py[cv]==0.11.0
 pytesseract==0.3.10
 python-dotenv==1.0.1
+python-multipart==0.0.20
 httpx==0.27.0
 pytest==8.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pdfplumber==0.11.3
 camelot-py[cv]==0.11.0
 pytesseract==0.3.10
 python-dotenv==1.0.1
+python-multipart==0.0.20
 httpx==0.27.0
 pytest==8.2.2


### PR DESCRIPTION
## Summary
- switch the FastAPI app to a lifespan context so startup initialization no longer relies on deprecated hooks
- add a python-multipart compatibility shim and dependency to stop PendingDeprecation warnings during file uploads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc1e376a1883249638c4c2cd0afe3b