### PR TITLE
Silence pytesseract deprecation warning

### DIFF
--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -1,12 +1,13 @@
 """Native PDF parsing service with multi-column and suppression heuristics."""
 from __future__ import annotations
 
-from collections import Counter
-from dataclasses import dataclass, field
 import io
 import logging
 import re
 from pathlib import Path
+import warnings
+from collections import Counter
+from dataclasses import dataclass, field
 
 import fitz  # type: ignore
 import pdfplumber  # type: ignore
@@ -15,6 +16,8 @@ try:  # pragma: no cover - optional dependency
     import camelot  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     camelot = None  # type: ignore
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="pytesseract")
 
 try:  # pragma: no cover - optional dependency
     import pytesseract  # type: ignore


### PR DESCRIPTION
## Summary
- filter pytesseract DeprecationWarnings during the native PDF parsing import path to keep the phase 2 check clean

## Testing
- pytest tests/test_parse_samples.py

------
https://chatgpt.com/codex/tasks/task_e_68fc2b639f6c83249517f7872cf975d6