### PR TITLE
Add heuristics-based header extraction API

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -36,6 +36,11 @@ class Settings(BaseModel):
     headers_suppress_toc: bool = Field(default_factory=lambda: _env_flag("HEADERS_SUPPRESS_TOC", True))
     headers_suppress_running: bool = Field(default_factory=lambda: _env_flag("HEADERS_SUPPRESS_RUNNING", True))
     mineru_fallback: bool = Field(default_factory=lambda: _env_flag("MINERU_FALLBACK", False))
+    llm_provider: str = Field(default_factory=lambda: os.getenv("LLM_PROVIDER", "openrouter"))
+    openrouter_api_key: str | None = Field(default_factory=lambda: os.getenv("OPENROUTER_API_KEY"))
+    openrouter_model: str = Field(default_factory=lambda: os.getenv("OPENROUTER_MODEL", "openrouter/auto"))
+    openrouter_http_referer: str | None = Field(default_factory=lambda: os.getenv("HTTP_REFERER"))
+    openrouter_title: str | None = Field(default_factory=lambda: os.getenv("X_TITLE"))
 
     @field_validator("upload_dir", mode="after")
     @classmethod

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -2,10 +2,12 @@
 from fastapi import APIRouter
 
 from .files import router as files_router
+from .headers import router as headers_router
 from .parse import router as parse_router
 
 api_router = APIRouter()
 api_router.include_router(files_router)
+api_router.include_router(headers_router)
 api_router.include_router(parse_router)
 
 __all__ = ["api_router"]

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,0 +1,80 @@
+"""Endpoints for header extraction and outline delivery."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from ..database import get_session
+from ..models import Document
+from ..services.headers import HeaderExtractionResult, HeaderNode, HeadersLLMClient, extract_headers
+from ..services.pdf_native import parse_pdf
+
+router = APIRouter(prefix="/api", tags=["headers"])
+
+
+class HeaderNodePayload(BaseModel):
+    """Schema for a header node in the outline."""
+
+    title: str
+    numbering: str
+    page: int | None = None
+    children: list["HeaderNodePayload"] = Field(default_factory=list)
+
+    @classmethod
+    def from_node(cls, node: HeaderNode) -> "HeaderNodePayload":
+        return cls(
+            title=node.title,
+            numbering=node.numbering,
+            page=node.page,
+            children=[cls.from_node(child) for child in node.children],
+        )
+
+
+HeaderNodePayload.model_rebuild()
+
+
+class HeadersResponse(BaseModel):
+    """API response structure for header extraction."""
+
+    document_id: int
+    source: str
+    fenced_text: str
+    outline: list[HeaderNodePayload]
+
+    @classmethod
+    def from_result(cls, document_id: int, result: HeaderExtractionResult) -> "HeadersResponse":
+        return cls(
+            document_id=document_id,
+            source=result.source,
+            fenced_text=result.fenced_text,
+            outline=[HeaderNodePayload.from_node(node) for node in result.outline],
+        )
+
+
+@router.post("/headers/{document_id}", response_model=HeadersResponse)
+async def generate_headers(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> HeadersResponse:
+    """Return the hierarchical headers for a stored document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+
+    document_path = settings.upload_dir / str(document.id) / document.filename
+    if not document_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing")
+
+    parse_result = parse_pdf(document_path, settings=settings)
+    llm_client = HeadersLLMClient(settings)
+    result = extract_headers(parse_result, settings=settings, llm_client=llm_client)
+    return HeadersResponse.from_result(document.id, result)
+
+
+__all__ = ["router"]
+

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -1,0 +1,464 @@
+"""Header extraction service combining heuristics with optional LLM refinement."""
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import httpx
+
+from ..config import Settings
+from .pdf_native import ParsedBlock, ParseResult
+
+LOGGER = logging.getLogger(__name__)
+
+NUMBERING_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^(?P<number>\d+(?:\.\d+)*)(?:[.)])?\s+(?P<title>.+)$"),
+    re.compile(r"^(?P<number>[A-Z](?:\.\d+)*)[.)]?\s+(?P<title>.+)$"),
+    re.compile(r"^(?P<number>[IVXLCDM]+(?:\.\d+)*)(?:[.)])?\s+(?P<title>.+)$", re.IGNORECASE),
+)
+
+
+@dataclass(slots=True)
+class HeaderCandidate:
+    """Potential header extracted from PDF text blocks."""
+
+    title: str
+    numbering: str | None
+    page_number: int
+    level_hint: int
+    indent: float
+    top: float
+    score: float
+
+
+@dataclass(slots=True)
+class HeaderNode:
+    """Hierarchical header node returned to clients."""
+
+    title: str
+    numbering: str
+    page: int | None
+    children: list["HeaderNode"] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of the node."""
+
+        return {
+            "title": self.title,
+            "numbering": self.numbering,
+            "page": self.page,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+
+@dataclass(slots=True)
+class HeaderExtractionResult:
+    """Container describing the final outline and metadata."""
+
+    outline: list[HeaderNode]
+    fenced_text: str
+    source: str
+
+    def to_json(self) -> list[dict]:
+        """Return outline as JSON-compatible list."""
+
+        return [node.to_dict() for node in self.outline]
+
+
+def extract_headers(
+    parse_result: ParseResult,
+    *,
+    settings: Settings,
+    llm_client: "HeadersLLMClient | None" = None,
+) -> HeaderExtractionResult:
+    """Extract a hierarchical header outline from a parse result."""
+
+    candidates = _collect_candidates(parse_result)
+    outline = _build_outline(candidates)
+    heuristic_result = HeaderExtractionResult(
+        outline=outline,
+        fenced_text=_outline_to_fenced_text(outline),
+        source="heuristic",
+    )
+
+    if llm_client and llm_client.is_enabled:
+        try:
+            llm_result = llm_client.refine_outline(parse_result, heuristic_result)
+            if llm_result is not None:
+                return llm_result
+        except Exception as exc:  # pragma: no cover - network exceptions
+            LOGGER.warning("LLM refinement failed: %s", exc)
+
+    return heuristic_result
+
+
+def _collect_candidates(parse_result: ParseResult) -> list[HeaderCandidate]:
+    """Return sorted header candidates based on heuristics."""
+
+    font_sizes: list[float] = []
+    for page in parse_result.pages:
+        for block in page.blocks:
+            if block.font_size:
+                font_sizes.append(block.font_size)
+
+    avg_font_size = sum(font_sizes) / len(font_sizes) if font_sizes else 0.0
+
+    candidates: list[HeaderCandidate] = []
+    for page in parse_result.pages:
+        if page.is_toc:
+            continue
+        for block in page.blocks:
+            text = _normalise_text(block.text)
+            if not text:
+                continue
+
+            numbering, title = _split_numbering(text)
+            score = _score_block(block, avg_font_size, bool(numbering))
+            if not numbering and score < 1.5:
+                continue
+
+            level_hint = _infer_level(numbering, block)
+            candidate = HeaderCandidate(
+                title=title,
+                numbering=numbering,
+                page_number=page.page_number,
+                level_hint=level_hint,
+                indent=block.bbox[0],
+                top=block.bbox[1],
+                score=score,
+            )
+            candidates.append(candidate)
+
+    candidates.sort(key=lambda c: (c.page_number, c.top))
+    return candidates
+
+
+def _score_block(block: ParsedBlock, avg_font_size: float, has_numbering: bool) -> float:
+    """Calculate a heuristic score for a block."""
+
+    score = 0.0
+    if has_numbering:
+        score += 2.5
+
+    if block.font_size and avg_font_size:
+        diff = block.font_size - avg_font_size
+        if diff > 1.0:
+            score += 1.5
+        elif diff > 0.5:
+            score += 0.5
+
+    text = _normalise_text(block.text)
+    if text.isupper() and len(text.split()) <= 6:
+        score += 1.0
+    elif text.istitle():
+        score += 0.5
+
+    return score
+
+
+def _infer_level(numbering: str | None, block: ParsedBlock) -> int:
+    """Determine the likely nesting level for a candidate."""
+
+    if numbering:
+        segments = re.split(r"[.]+", numbering.strip(".) "))
+        segments = [seg for seg in segments if seg]
+        if segments:
+            return len(segments)
+
+    indent = block.bbox[0]
+    if indent <= 10:
+        return 1
+    return min(1 + int(math.floor(indent / 40.0)), 6)
+
+
+def _build_outline(candidates: Sequence[HeaderCandidate]) -> list[HeaderNode]:
+    """Build a tree from the candidate list."""
+
+    if not candidates:
+        return []
+
+    indent_buckets = _cluster_indents(candidates)
+    outline: list[HeaderNode] = []
+    stack: list[tuple[int, HeaderNode]] = []
+    counters: dict[int, int] = defaultdict(int)
+
+    for candidate in candidates:
+        level = _resolve_level(candidate, indent_buckets)
+        if candidate.numbering:
+            _sync_counters(candidate.numbering, counters)
+            numbering = candidate.numbering
+        else:
+            numbering = _auto_number(level, counters)
+        node = HeaderNode(title=candidate.title, numbering=numbering, page=candidate.page_number)
+
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+
+        if stack:
+            stack[-1][1].children.append(node)
+        else:
+            outline.append(node)
+
+        stack.append((level, node))
+
+    return outline
+
+
+def _cluster_indents(candidates: Sequence[HeaderCandidate]) -> list[float]:
+    """Group indent values into discrete buckets to stabilise level inference."""
+
+    values = sorted({round(candidate.indent, 2) for candidate in candidates})
+    if not values:
+        return [0.0]
+
+    buckets = [values[0]]
+    for value in values[1:]:
+        if abs(value - buckets[-1]) > 12.0:
+            buckets.append(value)
+    return buckets
+
+
+def _resolve_level(candidate: HeaderCandidate, indent_buckets: Sequence[float]) -> int:
+    """Resolve a final level using indentation and hints."""
+
+    level = candidate.level_hint
+    indent = candidate.indent
+    for index, bucket in enumerate(indent_buckets, start=1):
+        if indent <= bucket + 1e-3:
+            level = min(level, index)
+            break
+    return max(1, level)
+
+
+def _auto_number(level: int, counters: dict[int, int]) -> str:
+    """Assign synthetic numbering for unnumbered headers."""
+
+    counters[level] = counters.get(level, 0) + 1
+    for deeper_level in list(counters.keys()):
+        if deeper_level > level:
+            counters[deeper_level] = 0
+
+    parts: list[str] = []
+    for depth in range(1, level + 1):
+        value = counters.get(depth)
+        if not value:
+            value = 1
+            counters[depth] = value
+        parts.append(str(value))
+    return ".".join(parts)
+
+
+def _sync_counters(numbering: str, counters: dict[int, int]) -> None:
+    """Align numeric counters with explicit numbering from the document."""
+
+    try:
+        parts = [int(part) for part in numbering.split(".")]
+    except ValueError:
+        return
+
+    for index, value in enumerate(parts, start=1):
+        counters[index] = value
+
+    for deeper_level in list(counters.keys()):
+        if deeper_level > len(parts):
+            counters[deeper_level] = 0
+
+
+def _outline_to_fenced_text(nodes: Sequence[HeaderNode]) -> str:
+    """Render the outline as fenced text."""
+
+    lines = ["#headers#"]
+
+    def _emit(node: HeaderNode, depth: int) -> None:
+        indent = "  " * depth
+        label = f"{node.numbering} {node.title}".strip()
+        lines.append(f"{indent}{label}")
+        for child in node.children:
+            _emit(child, depth + 1)
+
+    for node in nodes:
+        _emit(node, 0)
+
+    lines.append("#headers#")
+    return "\n".join(lines)
+
+
+def _normalise_text(text: str) -> str:
+    """Normalise whitespace within a block."""
+
+    cleaned = " ".join(part.strip() for part in text.split())
+    return cleaned.strip()
+
+
+def _split_numbering(text: str) -> tuple[str | None, str]:
+    """Split a heading into numbering and title components."""
+
+    for pattern in NUMBERING_PATTERNS:
+        match = pattern.match(text)
+        if match:
+            number = match.group("number").upper()
+            title = match.group("title").strip(" :")
+            return number, title
+    return None, text.strip(" :")
+
+
+class HeadersLLMClient:
+    """Client responsible for refining outlines with OpenRouter."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return True when LLM refinement should be attempted."""
+
+        return bool(
+            self._settings.llm_provider.lower() == "openrouter"
+            and self._settings.openrouter_api_key
+        )
+
+    def refine_outline(
+        self,
+        parse_result: ParseResult,
+        heuristic_result: HeaderExtractionResult,
+    ) -> HeaderExtractionResult | None:
+        """Call OpenRouter and validate fenced outline output."""
+
+        payload = self._build_payload(parse_result, heuristic_result)
+        if payload is None:
+            return None
+
+        headers = {
+            "Authorization": f"Bearer {self._settings.openrouter_api_key}",
+            "Content-Type": "application/json",
+        }
+        if self._settings.openrouter_http_referer:
+            headers["HTTP-Referer"] = self._settings.openrouter_http_referer
+        if self._settings.openrouter_title:
+            headers["X-Title"] = self._settings.openrouter_title
+
+        response = httpx.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        lines = _parse_llm_headers(content)
+        if not lines:
+            return None
+
+        outline = _build_outline_from_lines(lines)
+        fenced = "\n".join(["#headers#", *lines, "#headers#"])
+        return HeaderExtractionResult(outline=outline, fenced_text=fenced, source="openrouter")
+
+    def _build_payload(
+        self,
+        parse_result: ParseResult,
+        heuristic_result: HeaderExtractionResult,
+    ) -> dict | None:
+        """Assemble the chat completion payload applying hardening rules."""
+
+        prompt_body = _render_prompt(parse_result, heuristic_result)
+        params = {"max_tokens": 4096}
+        payload = {
+            "model": self._settings.openrouter_model,
+            "messages": [
+                {"role": "user", "content": prompt_body},
+            ],
+        }
+        payload.update(_apply_hardening(params))
+        return payload
+
+
+def _apply_hardening(params: dict) -> dict:
+    """Augment params with hardened defaults for OpenRouter."""
+
+    bigger = dict(params)
+    bigger["max_tokens"] = max(int(bigger.get("max_tokens", 2048)), 4096)
+    return bigger
+
+
+def _render_prompt(parse_result: ParseResult, heuristic_result: HeaderExtractionResult) -> str:
+    """Render the header extraction prompt with heuristic hints."""
+
+    sample_lines = [line for line in heuristic_result.fenced_text.splitlines() if line not in {"#headers#"}]
+    sample = "\n".join(sample_lines)
+    pages_summary = []
+    for page in parse_result.pages[:3]:
+        page_lines = [
+            _normalise_text(block.text)
+            for block in page.blocks[:15]
+            if _normalise_text(block.text)
+        ]
+        pages_summary.append(f"Page {page.page_number}:\n" + "\n".join(page_lines))
+
+    context = "\n\n".join(pages_summary)
+    prompt = (
+        "You are a document structure extractor.\n"
+        "Goal: produce a complete numbered nested list of all headers/subheaders.\n\n"
+        "Return ONLY the list enclosed in #headers# fences, e.g.:\n\n"
+        "#headers#\n1. Top Level\n   1.1 Sub\n      1.1.1 Sub-sub\n2. Another Top\n#headers#\n\n"
+        "Rules:\n"
+        "- Include annexes/appendices where relevant.\n"
+        "- Ignore page headers/footers and running titles.\n"
+        "- DO NOT include table-of-contents sections.\n"
+        "- Preserve document-native numbering if present (1, 1.1, I, A, A.1, etc.).\n"
+        "- If unnumbered, infer stable outline numbering.\n\n"
+        "Context extracted from PDF pages:\n"
+        f"{context}\n\n"
+        "Heuristic outline (may be incomplete):\n"
+        f"{sample}"
+    )
+    return prompt
+
+
+def _parse_llm_headers(content: str) -> list[str]:
+    """Validate that the LLM response obeys the #headers# fence."""
+
+    match = re.search(r"#headers#(.*?)#headers#", content, re.DOTALL)
+    if not match:
+        LOGGER.warning("LLM response missing #headers# fence")
+        return []
+
+    body = match.group(1).strip()
+    lines = [line.strip() for line in body.splitlines() if line.strip()]
+    return lines
+
+
+def _build_outline_from_lines(lines: Sequence[str]) -> list[HeaderNode]:
+    """Construct outline nodes from fenced text lines."""
+
+    nodes: list[HeaderNode] = []
+    stack: list[tuple[int, HeaderNode]] = []
+
+    for raw_line in lines:
+        number, title = _split_numbering(raw_line)
+        if not number:
+            continue
+        level = len(number.split("."))
+        node = HeaderNode(title=title, numbering=number, page=None)
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+        if stack:
+            stack[-1][1].children.append(node)
+        else:
+            nodes.append(node)
+        stack.append((level, node))
+
+    return nodes
+
+
+__all__ = [
+    "HeaderExtractionResult",
+    "HeaderNode",
+    "HeadersLLMClient",
+    "extract_headers",
+]
+

--- a/tests/test_headers_golden.py
+++ b/tests/test_headers_golden.py
@@ -1,0 +1,192 @@
+"""Golden tests validating header extraction heuristics and endpoint."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from backend.config import Settings, reset_settings_cache
+from backend.database import get_engine, init_db, reset_database_state
+from backend.models import Document
+from backend.services.headers import extract_headers
+from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
+
+
+def _sample_parse_result() -> ParseResult:
+    page0 = ParsedPage(
+        page_number=0,
+        width=612,
+        height=792,
+        blocks=[
+            ParsedBlock(
+                text="1 General Requirements",
+                bbox=(36.0, 72.0, 400.0, 88.0),
+                font="Helvetica-Bold",
+                font_size=14.0,
+            ),
+            ParsedBlock(
+                text="1.1 Scope",
+                bbox=(54.0, 96.0, 400.0, 110.0),
+                font="Helvetica-Bold",
+                font_size=12.0,
+            ),
+            ParsedBlock(
+                text="1.2 References",
+                bbox=(54.0, 120.0, 400.0, 134.0),
+                font="Helvetica",
+                font_size=12.0,
+            ),
+            ParsedBlock(
+                text="Body text that should be ignored for header extraction.",
+                bbox=(72.0, 144.0, 400.0, 160.0),
+                font="Helvetica",
+                font_size=10.0,
+            ),
+        ],
+    )
+    page1 = ParsedPage(
+        page_number=1,
+        width=612,
+        height=792,
+        blocks=[
+            ParsedBlock(
+                text="2 Materials",
+                bbox=(36.0, 72.0, 400.0, 88.0),
+                font="Helvetica-Bold",
+                font_size=14.0,
+            ),
+            ParsedBlock(
+                text="2.1 Steel Alloys",
+                bbox=(54.0, 96.0, 400.0, 112.0),
+                font="Helvetica",
+                font_size=12.0,
+            ),
+            ParsedBlock(
+                text="2.2 Aluminum",
+                bbox=(54.0, 120.0, 400.0, 134.0),
+                font="Helvetica",
+                font_size=12.0,
+            ),
+        ],
+    )
+    return ParseResult(pages=[page0, page1])
+
+
+def _toc_parse_result() -> ParseResult:
+    toc_page = ParsedPage(
+        page_number=0,
+        width=612,
+        height=792,
+        blocks=[
+            ParsedBlock(
+                text="Table of Contents",
+                bbox=(36.0, 72.0, 400.0, 88.0),
+                font="Helvetica-Bold",
+                font_size=16.0,
+            ),
+            ParsedBlock(
+                text="1 General Requirements",
+                bbox=(54.0, 96.0, 400.0, 112.0),
+                font="Helvetica",
+                font_size=12.0,
+            ),
+        ],
+        is_toc=True,
+    )
+    return ParseResult(pages=[toc_page])
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[None, None, None]:
+    db_path = tmp_path / "headers.db"
+    upload_dir = tmp_path / "uploads"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("LLM_PROVIDER", "disabled")
+    reset_settings_cache()
+    reset_database_state()
+    yield
+    reset_settings_cache()
+    reset_database_state()
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    from backend.main import app
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_extract_headers_generates_expected_outline(tmp_path: Path) -> None:
+    parse_result = _sample_parse_result()
+    settings = Settings(upload_dir=tmp_path)
+    result = extract_headers(parse_result, settings=settings, llm_client=None)
+
+    expected_outline = [
+        {
+            "title": "General Requirements",
+            "numbering": "1",
+            "page": 0,
+            "children": [
+                {"title": "Scope", "numbering": "1.1", "page": 0, "children": []},
+                {"title": "References", "numbering": "1.2", "page": 0, "children": []},
+            ],
+        },
+        {
+            "title": "Materials",
+            "numbering": "2",
+            "page": 1,
+            "children": [
+                {"title": "Steel Alloys", "numbering": "2.1", "page": 1, "children": []},
+                {"title": "Aluminum", "numbering": "2.2", "page": 1, "children": []},
+            ],
+        },
+    ]
+
+    assert result.to_json() == expected_outline
+    assert result.fenced_text.splitlines()[0] == "#headers#"
+    assert result.fenced_text.splitlines()[-1] == "#headers#"
+
+
+def test_toc_pages_are_ignored(tmp_path: Path) -> None:
+    parse_result = _toc_parse_result()
+    settings = Settings(upload_dir=tmp_path)
+    result = extract_headers(parse_result, settings=settings, llm_client=None)
+    assert result.outline == []
+
+
+def test_headers_endpoint_returns_outline(client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = get_engine()
+    init_db()
+
+    with Session(engine) as session:
+        document = Document(filename="sample.pdf", checksum=hashlib.sha256(b"sample").hexdigest())
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+        doc_dir = Path(tmp_path / "uploads" / str(document.id))
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = doc_dir / document.filename
+        pdf_path.write_bytes(b"%PDF-1.4\n%%EOF")
+
+    sample_result = _sample_parse_result()
+
+    def _mock_parse(document_path, *, settings):  # noqa: ANN001 - test helper
+        return sample_result
+
+    monkeypatch.setattr("backend.routers.headers.parse_pdf", _mock_parse)
+
+    response = client.post(f"/api/headers/{document.id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "heuristic"
+    assert payload["document_id"] == document.id
+    assert payload["outline"][0]["title"] == "General Requirements"
+    assert payload["outline"][0]["children"][0]["title"] == "Scope"
+


### PR DESCRIPTION
## Summary
- add a heuristics-driven header extraction service with optional OpenRouter refinement
- expose a new /api/headers/{doc_id} endpoint returning fenced and JSON outlines
- cover the service and endpoint with golden tests and TOC suppression checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc2c338d9083249c69aa801795c785