### PR TITLE
feat: add spec extraction pipeline and llm integration

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -18,6 +18,10 @@ def _env_flag(name: str, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_TERMS_DIR = BASE_DIR / "resources" / "terms"
+
+
 class Settings(BaseModel):
     """Application configuration loaded from environment variables."""
 
@@ -41,6 +45,13 @@ class Settings(BaseModel):
     openrouter_model: str = Field(default_factory=lambda: os.getenv("OPENROUTER_MODEL", "openrouter/auto"))
     openrouter_http_referer: str | None = Field(default_factory=lambda: os.getenv("HTTP_REFERER"))
     openrouter_title: str | None = Field(default_factory=lambda: os.getenv("X_TITLE"))
+    spec_terms_dir: Path = Field(
+        default_factory=lambda: Path(os.getenv("SPEC_TERMS_DIR", str(DEFAULT_TERMS_DIR)))
+    )
+    spec_rule_min_hits: int = Field(default_factory=lambda: int(os.getenv("SPEC_RULE_MIN_HITS", "1")))
+    spec_multi_label_margin: float = Field(
+        default_factory=lambda: float(os.getenv("SPEC_MULTI_LABEL_MARGIN", "0.0"))
+    )
 
     @field_validator("upload_dir", mode="after")
     @classmethod
@@ -54,6 +65,12 @@ class Settings(BaseModel):
         if not value:
             return ("application/pdf",)
         return tuple(dict.fromkeys(item.lower() for item in value))
+
+    @field_validator("spec_terms_dir", mode="after")
+    @classmethod
+    def _ensure_terms_dir(cls, value: Path) -> Path:
+        value.mkdir(parents=True, exist_ok=True)
+        return value
 
 
 @lru_cache()

--- a/backend/resources/terms/controls.json
+++ b/backend/resources/terms/controls.json
@@ -1,0 +1,18 @@
+{
+  "discipline": "controls",
+  "terms": [
+    "plc",
+    "pid",
+    "controller",
+    "loop",
+    "sensor",
+    "actuator",
+    "hmi",
+    "scada",
+    "control system"
+  ],
+  "boost_terms": [
+    "isa",
+    "iec 61131"
+  ]
+}

--- a/backend/resources/terms/electrical.json
+++ b/backend/resources/terms/electrical.json
@@ -1,0 +1,21 @@
+{
+  "discipline": "electrical",
+  "terms": [
+    "voltage",
+    "current",
+    "amperage",
+    "circuit",
+    "wiring",
+    "breaker",
+    "electrical",
+    "cable",
+    "transformer",
+    "power",
+    "supply",
+    "panel"
+  ],
+  "boost_terms": [
+    "iec",
+    "nfpa"
+  ]
+}

--- a/backend/resources/terms/mechanical.json
+++ b/backend/resources/terms/mechanical.json
@@ -1,0 +1,18 @@
+{
+  "discipline": "mechanical",
+  "terms": [
+    "pressure",
+    "torque",
+    "pump",
+    "bearing",
+    "compressor",
+    "valve",
+    "gear",
+    "flow rate",
+    "mechanical"
+  ],
+  "boost_terms": [
+    "asme",
+    "ansi"
+  ]
+}

--- a/backend/resources/terms/project_management.json
+++ b/backend/resources/terms/project_management.json
@@ -1,0 +1,18 @@
+{
+  "discipline": "project_management",
+  "terms": [
+    "schedule",
+    "milestone",
+    "risk",
+    "deliverable",
+    "report",
+    "budget",
+    "timeline",
+    "meeting",
+    "stakeholder"
+  ],
+  "boost_terms": [
+    "pmi",
+    "iso 21500"
+  ]
+}

--- a/backend/resources/terms/software.json
+++ b/backend/resources/terms/software.json
@@ -1,0 +1,18 @@
+{
+  "discipline": "software",
+  "terms": [
+    "software",
+    "firmware",
+    "api",
+    "version",
+    "code",
+    "repository",
+    "deployment",
+    "update",
+    "patch"
+  ],
+  "boost_terms": [
+    "iec 61508",
+    "iso/iec"
+  ]
+}

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -4,10 +4,12 @@ from fastapi import APIRouter
 from .files import router as files_router
 from .headers import router as headers_router
 from .parse import router as parse_router
+from .specs import router as specs_router
 
 api_router = APIRouter()
 api_router.include_router(files_router)
 api_router.include_router(headers_router)
 api_router.include_router(parse_router)
+api_router.include_router(specs_router)
 
 __all__ = ["api_router"]

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -1,0 +1,98 @@
+"""Specification extraction endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from ..database import get_session
+from ..models import Document
+from ..services.pdf_native import parse_pdf
+from ..services.spec_extraction import (
+    SpecExtractionResult,
+    SpecLine,
+    SpecLLMClient,
+    extract_specifications,
+)
+
+router = APIRouter(prefix="/api", tags=["specifications"])
+
+
+class SpecProvenancePayload(BaseModel):
+    """Provenance metadata for a specification line."""
+
+    page: int
+    block_index: int
+    line_index: int
+    bbox: list[float] | None = None
+
+
+class SpecLinePayload(BaseModel):
+    """Payload describing a classified specification line."""
+
+    text: str
+    page: int
+    header_path: list[str] = Field(default_factory=list)
+    disciplines: list[str] = Field(default_factory=list)
+    scores: dict[str, float] = Field(default_factory=dict)
+    source: str
+    provenance: SpecProvenancePayload
+
+    @classmethod
+    def from_line(cls, line: SpecLine) -> "SpecLinePayload":
+        data = line.to_dict()
+        return cls(
+            text=data["text"],
+            page=data["page"],
+            header_path=list(data.get("header_path", [])),
+            disciplines=list(data.get("disciplines", [])),
+            scores=dict(data.get("scores", {})),
+            source=data.get("source", "rule"),
+            provenance=SpecProvenancePayload(**data.get("provenance", {})),
+        )
+
+
+class SpecExtractionResponse(BaseModel):
+    """API response containing per-discipline specification buckets."""
+
+    document_id: int
+    buckets: dict[str, list[SpecLinePayload]]
+
+    @classmethod
+    def from_result(
+        cls, document_id: int, result: SpecExtractionResult
+    ) -> "SpecExtractionResponse":
+        buckets: dict[str, list[SpecLinePayload]] = {}
+        raw_buckets = result.to_dict()
+        for discipline, items in raw_buckets.items():
+            buckets[discipline] = [SpecLinePayload(**item) for item in items]
+        return cls(document_id=document_id, buckets=buckets)
+
+
+@router.post("/specs/extract/{document_id}", response_model=SpecExtractionResponse)
+async def extract_specs_endpoint(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> SpecExtractionResponse:
+    """Return classified specification lines for a stored document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+
+    document_path = settings.upload_dir / str(document.id) / document.filename
+    if not document_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
+        )
+
+    parse_result = parse_pdf(document_path, settings=settings)
+    llm_client = SpecLLMClient(settings)
+    extraction = extract_specifications(parse_result, settings=settings, llm_client=llm_client)
+    return SpecExtractionResponse.from_result(document.id, extraction)
+
+
+__all__ = ["router"]

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -8,9 +8,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Sequence
 
-import httpx
-
 from ..config import Settings
+from .llm import LLMProviderError, LLMCircuitOpenError, LLMService
 from .pdf_native import ParsedBlock, ParseResult
 
 LOGGER = logging.getLogger(__name__)
@@ -307,82 +306,64 @@ def _split_numbering(text: str) -> tuple[str | None, str]:
 
 
 class HeadersLLMClient:
-    """Client responsible for refining outlines with OpenRouter."""
+    """Client responsible for refining outlines using the shared LLM service."""
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: Settings, llm_service: LLMService | None = None) -> None:
         self._settings = settings
+        self._llm = llm_service or LLMService(settings)
 
     @property
     def is_enabled(self) -> bool:
         """Return True when LLM refinement should be attempted."""
 
-        return bool(
-            self._settings.llm_provider.lower() == "openrouter"
-            and self._settings.openrouter_api_key
-        )
+        return self._llm.is_enabled
 
     def refine_outline(
         self,
         parse_result: ParseResult,
         heuristic_result: HeaderExtractionResult,
     ) -> HeaderExtractionResult | None:
-        """Call OpenRouter and validate fenced outline output."""
+        """Call the LLM service and validate fenced outline output."""
 
-        payload = self._build_payload(parse_result, heuristic_result)
-        if payload is None:
+        if not self.is_enabled:
             return None
 
-        headers = {
-            "Authorization": f"Bearer {self._settings.openrouter_api_key}",
-            "Content-Type": "application/json",
-        }
-        if self._settings.openrouter_http_referer:
-            headers["HTTP-Referer"] = self._settings.openrouter_http_referer
-        if self._settings.openrouter_title:
-            headers["X-Title"] = self._settings.openrouter_title
+        messages = self._build_messages(parse_result, heuristic_result)
+        try:
+            result = self._llm.generate(
+                messages=messages,
+                fence="#headers#",
+                metadata={"task": "headers"},
+            )
+        except (LLMCircuitOpenError, LLMProviderError) as exc:  # pragma: no cover - network path
+            LOGGER.warning("LLM refinement failed: %s", exc)
+            return None
 
-        response = httpx.post(
-            "https://openrouter.ai/api/v1/chat/completions",
-            headers=headers,
-            json=payload,
-            timeout=30.0,
-        )
-        response.raise_for_status()
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        lines = _parse_llm_headers(content)
+        fenced_text = result.fenced or result.content
+        lines = _parse_llm_headers(fenced_text)
         if not lines:
             return None
 
         outline = _build_outline_from_lines(lines)
-        fenced = "\n".join(["#headers#", *lines, "#headers#"])
-        return HeaderExtractionResult(outline=outline, fenced_text=fenced, source="openrouter")
+        cleaned_fenced = "\n".join(["#headers#", *lines, "#headers#"])
+        return HeaderExtractionResult(outline=outline, fenced_text=cleaned_fenced, source=self._llm.get_provider())
 
-    def _build_payload(
+    def _build_messages(
         self,
         parse_result: ParseResult,
         heuristic_result: HeaderExtractionResult,
-    ) -> dict | None:
-        """Assemble the chat completion payload applying hardening rules."""
-
+    ) -> list[dict[str, str]]:
         prompt_body = _render_prompt(parse_result, heuristic_result)
-        params = {"max_tokens": 4096}
-        payload = {
-            "model": self._settings.openrouter_model,
-            "messages": [
-                {"role": "user", "content": prompt_body},
-            ],
-        }
-        payload.update(_apply_hardening(params))
-        return payload
-
-
-def _apply_hardening(params: dict) -> dict:
-    """Augment params with hardened defaults for OpenRouter."""
-
-    bigger = dict(params)
-    bigger["max_tokens"] = max(int(bigger.get("max_tokens", 2048)), 4096)
-    return bigger
+        return [
+            {
+                "role": "system",
+                "content": (
+                    "You are a document structure extractor. Return a complete numbered outline "
+                    "enclosed in #headers# fences."
+                ),
+            },
+            {"role": "user", "content": prompt_body},
+        ]
 
 
 def _render_prompt(parse_result: ParseResult, heuristic_result: HeaderExtractionResult) -> str:

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,0 +1,390 @@
+"""LLM integration layer providing provider abstraction, caching, and retries."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+import httpx
+
+from ..config import Settings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LLMProviderError(RuntimeError):
+    """Raised when the LLM provider returns an unrecoverable error."""
+
+
+class LLMRetryableError(LLMProviderError):
+    """Raised for retryable provider errors (e.g., rate limits)."""
+
+
+class LLMCircuitOpenError(LLMProviderError):
+    """Raised when the circuit breaker prevents additional calls."""
+
+
+@dataclass(frozen=True)
+class LLMTransportRequest:
+    """Container describing a transport request to a provider."""
+
+    model: str
+    messages: Sequence[Mapping[str, str]]
+    params: Mapping[str, Any]
+    headers: Mapping[str, str]
+    metadata: Mapping[str, Any] | None = None
+
+
+@dataclass
+class LLMTransportResponse:
+    """Response payload returned by a transport implementation."""
+
+    content: str
+    usage: Mapping[str, Any] | None = None
+    raw: Mapping[str, Any] | None = None
+
+
+@dataclass
+class LLMResult:
+    """High-level result returned by :class:`LLMService`."""
+
+    content: str
+    usage: Mapping[str, Any] | None
+    cached: bool
+    fenced: str | None = None
+
+
+class LLMService:
+    """Provide hardened LLM requests with caching, retries, and backoff."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        cache_dir: Path | None = None,
+        transport_overrides: Mapping[str, Callable[[LLMTransportRequest], LLMTransportResponse]] | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        time_func: Callable[[], float] = time.time,
+    ) -> None:
+        self._settings = settings
+        self._cache_dir = cache_dir or settings.upload_dir / ".llm_cache"
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._transports = dict(transport_overrides or {})
+        self._sleep = sleep
+        self._time = time_func
+        self._failure_count = 0
+        self._circuit_open_until: float | None = None
+        self._max_retries = 2
+        self._base_backoff = 1.5
+        self._circuit_threshold = 3
+        self._cooldown_seconds = 30.0
+
+    @property
+    def is_enabled(self) -> bool:
+        provider = self.get_provider()
+        if provider == "openrouter":
+            return bool(self._settings.openrouter_api_key)
+        if provider == "ollama":
+            return True
+        return False
+
+    def get_provider(self) -> str:
+        """Return the configured provider identifier."""
+
+        return (self._settings.llm_provider or "openrouter").lower()
+
+    def generate(
+        self,
+        *,
+        messages: Sequence[Mapping[str, str]],
+        model: str | None = None,
+        fence: str | None = None,
+        params: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LLMResult:
+        """Generate a completion with retries, caching, and fence validation."""
+
+        if not messages:
+            raise ValueError("LLMService.generate requires at least one message")
+
+        provider = self.get_provider()
+        if self._circuit_open_until and self._time() < self._circuit_open_until:
+            raise LLMCircuitOpenError(
+                f"Provider circuit open for another {self._circuit_open_until - self._time():.1f}s"
+            )
+
+        base_model = model or self._settings.openrouter_model
+        base_params: MutableMapping[str, Any] = dict(params or {})
+        base_params["max_tokens"] = self._ensure_max_tokens(base_params.get("max_tokens"))
+
+        cache_key = self._build_cache_key(provider, base_model, messages, base_params)
+        cached = self._read_cache(cache_key)
+        if cached is not None:
+            LOGGER.debug("LLM cache hit provider=%s model=%s", provider, base_model)
+            fenced_text = self._extract_fence(cached["content"], fence) if fence else None
+            if cached.get("usage"):
+                self._log_usage(provider, base_model, cached.get("usage"), cached=True)
+            return LLMResult(
+                content=cached["content"],
+                usage=cached.get("usage"),
+                cached=True,
+                fenced=fenced_text,
+            )
+
+        attempt = 0
+        preamble_added = False
+        last_error: Exception | None = None
+        base_messages = [dict(message) for message in messages]
+
+        while attempt <= self._max_retries:
+            attempt += 1
+            messages_to_send = list(base_messages)
+            if preamble_added:
+                messages_to_send.insert(
+                    0,
+                    {
+                        "role": "system",
+                        "content": f"ONLY FENCED OUTPUT using {fence} fences.",
+                    },
+                )
+
+            request = LLMTransportRequest(
+                model=base_model,
+                messages=messages_to_send,
+                params=dict(base_params),
+                headers=self._build_headers(provider),
+                metadata=metadata or {},
+            )
+
+            try:
+                response = self._call_provider(provider, request)
+            except LLMRetryableError as error:
+                last_error = error
+                self._register_failure()
+                if attempt > self._max_retries:
+                    break
+                self._sleep(self._backoff_seconds(attempt))
+                continue
+            except LLMProviderError as error:
+                last_error = error
+                self._register_failure(trip=True)
+                break
+
+            self._reset_failures()
+            content = response.content
+            fenced_block = self._extract_fence(content, fence) if fence else None
+            if fence and not fenced_block:
+                last_error = LLMProviderError("Response missing fenced output")
+                if attempt > self._max_retries:
+                    self._register_failure(trip=True)
+                    break
+                preamble_added = True
+                continue
+
+            result = {
+                "content": content,
+                "usage": dict(response.usage or {}),
+            }
+            self._write_cache(cache_key, result)
+            if response.usage:
+                self._log_usage(provider, base_model, response.usage, cached=False)
+            return LLMResult(
+                content=content,
+                usage=response.usage,
+                cached=False,
+                fenced=fenced_block,
+            )
+
+        if last_error is None:
+            last_error = LLMProviderError("Unknown LLM failure")
+        raise last_error
+
+    def _register_failure(self, *, trip: bool = False) -> None:
+        self._failure_count += 1
+        if trip or self._failure_count >= self._circuit_threshold:
+            self._circuit_open_until = self._time() + self._cooldown_seconds
+            LOGGER.warning(
+                "LLM circuit opened after %s consecutive failures; cooling down for %.1fs",
+                self._failure_count,
+                self._cooldown_seconds,
+            )
+            self._failure_count = 0
+
+    def _reset_failures(self) -> None:
+        self._failure_count = 0
+        self._circuit_open_until = None
+
+    def _backoff_seconds(self, attempt: int) -> float:
+        return self._base_backoff * max(1, attempt)
+
+    def _build_cache_key(
+        self,
+        provider: str,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        params: Mapping[str, Any],
+    ) -> str:
+        serialisable = {
+            "provider": provider,
+            "model": model,
+            "messages": list(messages),
+            "params": dict(params),
+        }
+        payload = json.dumps(serialisable, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _cache_path(self, cache_key: str) -> Path:
+        return self._cache_dir / f"{cache_key}.json"
+
+    def _read_cache(self, cache_key: str) -> dict[str, Any] | None:
+        cache_path = self._cache_path(cache_key)
+        if not cache_path.exists():
+            return None
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - cache corruption
+            LOGGER.warning("Failed to read LLM cache %s: %s", cache_path, exc)
+            return None
+
+    def _write_cache(self, cache_key: str, payload: Mapping[str, Any]) -> None:
+        cache_path = self._cache_path(cache_key)
+        tmp_path = cache_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp_path, cache_path)
+
+    def _build_headers(self, provider: str) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if provider == "openrouter":
+            if not self._settings.openrouter_api_key:
+                raise LLMProviderError("OPENROUTER_API_KEY is not configured")
+            headers["Authorization"] = f"Bearer {self._settings.openrouter_api_key}"
+            if self._settings.openrouter_http_referer:
+                headers["HTTP-Referer"] = self._settings.openrouter_http_referer.strip()
+            if self._settings.openrouter_title:
+                headers["X-Title"] = self._settings.openrouter_title.strip()
+        return headers
+
+    def _call_provider(self, provider: str, request: LLMTransportRequest) -> LLMTransportResponse:
+        if provider in self._transports:
+            return self._transports[provider](request)
+        if provider == "openrouter":
+            return self.call_openrouter(request)
+        if provider == "ollama":
+            return self.call_ollama(request)
+        raise LLMProviderError(f"Unsupported LLM provider: {provider}")
+
+    def call_openrouter(self, request: LLMTransportRequest) -> LLMTransportResponse:
+        payload = {
+            "model": request.model,
+            "messages": request.messages,
+            "stream": False,
+        }
+        payload.update(request.params)
+
+        try:
+            response = httpx.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers=request.headers,
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status in {429, 500, 502, 503, 504}:
+                raise LLMRetryableError(f"OpenRouter HTTP {status}") from exc
+            raise LLMProviderError(f"OpenRouter HTTP {status}") from exc
+        except httpx.RequestError as exc:  # pragma: no cover - network failure
+            raise LLMRetryableError(f"OpenRouter request failed: {exc}") from exc
+
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        usage = data.get("usage")
+        return LLMTransportResponse(content=content, usage=usage, raw=data)
+
+    def call_ollama(self, request: LLMTransportRequest) -> LLMTransportResponse:
+        payload = {
+            "model": request.model,
+            "messages": list(request.messages),
+            "stream": False,
+        }
+        payload.update(request.params)
+        try:
+            response = httpx.post(
+                "http://127.0.0.1:11434/api/chat",
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status in {408, 429, 500, 502, 503, 504}:
+                raise LLMRetryableError(f"Ollama HTTP {status}") from exc
+            raise LLMProviderError(f"Ollama HTTP {status}") from exc
+        except httpx.RequestError as exc:  # pragma: no cover - network failure
+            raise LLMRetryableError(f"Ollama request failed: {exc}") from exc
+
+        data = response.json()
+        if "message" in data:
+            content = data["message"].get("content", "")
+        else:
+            content = data.get("content", "")
+        usage = data.get("usage")
+        return LLMTransportResponse(content=content, usage=usage, raw=data)
+
+    def _extract_fence(self, content: str, fence: str | None) -> str | None:
+        if not fence:
+            return None
+        pattern = re.compile(rf"{re.escape(fence)}\s*(.*?)\s*{re.escape(fence)}", re.DOTALL)
+        match = pattern.search(content)
+        if not match:
+            return None
+        return match.group(1).strip()
+
+    def _ensure_max_tokens(self, value: Any) -> int:
+        try:
+            numeric = int(value)
+        except Exception:
+            numeric = 2048
+        return max(numeric, 4096)
+
+    def _log_usage(
+        self,
+        provider: str,
+        model: str,
+        usage: Mapping[str, Any] | None,
+        *,
+        cached: bool,
+    ) -> None:
+        if not usage:
+            return
+        prompt = usage.get("prompt_tokens")
+        completion = usage.get("completion_tokens")
+        total = usage.get("total_tokens")
+        LOGGER.info(
+            "LLM usage provider=%s model=%s prompt=%s completion=%s total=%s cached=%s",
+            provider,
+            model,
+            prompt,
+            completion,
+            total,
+            cached,
+        )
+
+
+__all__ = [
+    "LLMCircuitOpenError",
+    "LLMProviderError",
+    "LLMResult",
+    "LLMRetryableError",
+    "LLMService",
+    "LLMTransportRequest",
+    "LLMTransportResponse",
+]

--- a/backend/services/spec_extraction.py
+++ b/backend/services/spec_extraction.py
@@ -1,0 +1,436 @@
+"""Specification extraction service for classifying requirements by discipline."""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from ..config import DEFAULT_TERMS_DIR, Settings
+from .llm import LLMCircuitOpenError, LLMProviderError, LLMService
+from .pdf_native import ParseResult
+
+LOGGER = logging.getLogger(__name__)
+
+LINE_BREAK_RE = re.compile(r"[\r\n]+")
+HEADER_NUMBER_RE = re.compile(r"^(?P<number>(?:\d+|[A-Z])(?:[.][\dA-Z]+)*)[.)]?\s+(?P<title>.+)$")
+WORD_RE = re.compile(r"\w+")
+
+
+@dataclass(slots=True)
+class TermLexicon:
+    """Term lexicon describing seed keywords for a discipline."""
+
+    discipline: str
+    terms: tuple[str, ...]
+    boost_terms: tuple[str, ...] = tuple()
+    term_patterns: tuple[re.Pattern[str], ...] = field(init=False)
+    boost_patterns: tuple[re.Pattern[str], ...] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.term_patterns = tuple(_compile_term(term) for term in self.terms)
+        self.boost_patterns = tuple(_compile_term(term) for term in self.boost_terms)
+
+    def score(self, text: str) -> float:
+        """Return a score based on keyword matches within the text."""
+
+        score = 0.0
+        for pattern in self.term_patterns:
+            if pattern.search(text):
+                score += 1.0
+        for pattern in self.boost_patterns:
+            if pattern.search(text):
+                score += 1.5
+        return score
+
+
+@dataclass(slots=True)
+class SpecLine:
+    """Atomic specification line with provenance and classification metadata."""
+
+    text: str
+    page: int
+    header_path: tuple[str, ...]
+    disciplines: tuple[str, ...]
+    scores: Mapping[str, float]
+    source: str
+    block_index: int
+    line_index: int
+    bbox: tuple[float, float, float, float] | None = None
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of the spec line."""
+
+        return {
+            "text": self.text,
+            "page": self.page,
+            "header_path": list(self.header_path),
+            "disciplines": list(self.disciplines),
+            "scores": dict(self.scores),
+            "source": self.source,
+            "provenance": {
+                "page": self.page,
+                "block_index": self.block_index,
+                "line_index": self.line_index,
+                "bbox": list(self.bbox) if self.bbox is not None else None,
+            },
+        }
+
+
+@dataclass(slots=True)
+class SpecExtractionResult:
+    """Result container aggregating spec lines by discipline."""
+
+    lines: list[SpecLine]
+    disciplines: tuple[str, ...]
+    unknown_label: str = "unknown"
+
+    def to_dict(self) -> dict[str, list[dict]]:
+        """Return the result grouped per discipline plus an unknown bucket."""
+
+        buckets: dict[str, list[dict]] = {discipline: [] for discipline in self.disciplines}
+        buckets[self.unknown_label] = []
+
+        for line in self.lines:
+            if line.disciplines:
+                for discipline in line.disciplines:
+                    buckets.setdefault(discipline, []).append(line.to_dict())
+            else:
+                buckets[self.unknown_label].append(line.to_dict())
+
+        # Ensure every known discipline key exists even if empty
+        for discipline in self.disciplines:
+            buckets.setdefault(discipline, [])
+        if self.unknown_label not in buckets:
+            buckets[self.unknown_label] = []
+        return buckets
+
+    def iter_by_discipline(self, discipline: str) -> Iterable[SpecLine]:
+        """Yield all lines assigned to a given discipline."""
+
+        target = discipline.lower()
+        for line in self.lines:
+            if target in (disc.lower() for disc in line.disciplines):
+                yield line
+
+
+class SpecLLMClient:
+    """LLM-driven classifier for ambiguous specification lines."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        llm_service: LLMService | None = None,
+    ) -> None:
+        self._settings = settings
+        self._llm = llm_service or LLMService(settings)
+
+    @property
+    def is_enabled(self) -> bool:
+        return self._llm.is_enabled
+
+    def classify(
+        self,
+        text: str,
+        header_path: tuple[str, ...],
+        scores: Mapping[str, float],
+        *,
+        candidates: Sequence[str] | None = None,
+    ) -> list[str] | None:
+        """Return LLM-provided disciplines if available."""
+
+        if not self.is_enabled:
+            return None
+
+        prompt_lines = [
+            "Classify the following specification line by discipline.",
+            "Return a JSON array of discipline labels inside #classes# fences.",
+            "Recognised disciplines: mechanical, electrical, controls, software, project_management.",
+            f"Line: {text}",
+        ]
+        if header_path:
+            prompt_lines.append(f"Header path: {' > '.join(header_path)}")
+        if candidates:
+            prompt_lines.append(f"Rule candidates: {', '.join(candidates)}")
+        prompt_lines.append(f"Term scores: {json.dumps(scores, ensure_ascii=False)}")
+        prompt = "\n".join(prompt_lines)
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a quality engineer who assigns specification disciplines. "
+                    "Respond ONLY with a JSON array enclosed in #classes# fences."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+
+        try:
+            result = self._llm.generate(
+                messages=messages,
+                fence="#classes#",
+                metadata={"task": "spec-classification"},
+            )
+        except (LLMCircuitOpenError, LLMProviderError) as exc:  # pragma: no cover - network path
+            LOGGER.warning("Specification classification LLM failed: %s", exc)
+            return None
+
+        fenced = result.fenced or result.content
+        try:
+            parsed = json.loads(fenced)
+        except json.JSONDecodeError:
+            return None
+
+        labels: list[str] = []
+        if isinstance(parsed, list):
+            for item in parsed:
+                if isinstance(item, str) and item.strip():
+                    labels.append(item.strip())
+                elif isinstance(item, Mapping):
+                    label = item.get("label") or item.get("discipline")
+                    if isinstance(label, str) and label.strip():
+                        labels.append(label.strip())
+        elif isinstance(parsed, Mapping):
+            candidates_list = parsed.get("disciplines")
+            if isinstance(candidates_list, list):
+                for value in candidates_list:
+                    if isinstance(value, str) and value.strip():
+                        labels.append(value.strip())
+
+        if not labels:
+            return None
+
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for label in labels:
+            key = label.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(label)
+        return ordered or None
+
+
+def extract_specifications(
+    parse_result: ParseResult,
+    *,
+    settings: Settings,
+    llm_client: SpecLLMClient | None = None,
+    terms_dir: Path | None = None,
+) -> SpecExtractionResult:
+    """Extract and classify specification lines from a parsed document."""
+
+    if llm_client is None:
+        llm_client = SpecLLMClient(settings)
+    lexicons = _load_lexicons(terms_dir or settings.spec_terms_dir)
+    tracker = _HeaderTracker()
+    lines: list[SpecLine] = []
+
+    for page in parse_result.pages:
+        for block_index, block in enumerate(page.blocks):
+            raw_lines = _split_block(block.text)
+            for line_index, raw_line in enumerate(raw_lines):
+                if tracker.consume_header(raw_line):
+                    continue
+                cleaned_line = _normalise_spec_line(raw_line)
+                if not cleaned_line or len(cleaned_line) < 3:
+                    continue
+                disciplines, scores, source = _classify_line(
+                    cleaned_line,
+                    lexicons,
+                    settings,
+                    llm_client,
+                    tracker.path,
+                )
+                spec_line = SpecLine(
+                    text=cleaned_line,
+                    page=page.page_number,
+                    header_path=tracker.path,
+                    disciplines=tuple(disciplines),
+                    scores=scores,
+                    source=source,
+                    block_index=block_index,
+                    line_index=line_index,
+                    bbox=getattr(block, "bbox", None),
+                )
+                lines.append(spec_line)
+
+    disciplines = tuple(lexicon.discipline for lexicon in lexicons)
+    return SpecExtractionResult(lines=lines, disciplines=disciplines)
+
+
+def _split_block(text: str) -> list[str]:
+    """Split a block of text into candidate lines."""
+
+    if not text:
+        return []
+    text = text.replace("•", "\n").replace("\u2022", "\n")
+    raw_lines = LINE_BREAK_RE.split(text)
+    lines = [line.strip() for line in raw_lines if line.strip()]
+    return lines
+
+
+def _normalise_spec_line(line: str) -> str:
+    """Remove bullets, numbering, and collapse whitespace for spec lines."""
+
+    stripped = line.strip()
+    stripped = re.sub(r"^[\-–—*]+\s*", "", stripped)
+    stripped = re.sub(r"^(?:\(?\d+[A-Za-z]?\)|\d+[.)]|[A-Za-z]\))\s+", "", stripped)
+    stripped = re.sub(r"\s+", " ", stripped)
+    return stripped.strip()
+
+
+def _compile_term(term: str) -> re.Pattern[str]:
+    escaped = re.escape(term.strip())
+    if WORD_RE.search(term):
+        return re.compile(rf"\b{escaped}\b", re.IGNORECASE)
+    return re.compile(escaped, re.IGNORECASE)
+
+
+def _looks_like_header(line: str, *, had_trailing_colon: bool = False) -> bool:
+    if not line:
+        return False
+    words = line.split()
+    if had_trailing_colon:
+        return True
+    if len(words) <= 8 and line.isupper():
+        return True
+    if len(words) <= 6 and all(word[:1].isupper() for word in words if word):
+        return True
+    match = HEADER_NUMBER_RE.match(line)
+    if match:
+        title = match.group("title")
+        title_words = title.split()
+        if title_words and all(word[:1].isupper() for word in title_words if word):
+            return True
+    return False
+
+
+class _HeaderTracker:
+    """Maintain the current header path while iterating text blocks."""
+
+    def __init__(self) -> None:
+        self._stack: list[str] = []
+
+    @property
+    def path(self) -> tuple[str, ...]:
+        return tuple(self._stack)
+
+    def consume_header(self, line: str) -> bool:
+        candidate = _normalise_header(line)
+        if candidate is None:
+            return False
+        level = _infer_header_level(candidate)
+        while len(self._stack) >= level:
+            self._stack.pop()
+        self._stack.append(candidate)
+        return True
+
+
+def _normalise_header(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    had_colon = stripped.endswith(":")
+    if had_colon:
+        stripped = stripped[:-1]
+    stripped = re.sub(r"\s+", " ", stripped)
+    if not _looks_like_header(stripped, had_trailing_colon=had_colon):
+        return None
+    return stripped
+
+
+def _infer_header_level(header: str) -> int:
+    match = HEADER_NUMBER_RE.match(header)
+    if not match:
+        return 1
+    numbering = match.group("number")
+    if not numbering:
+        return 1
+    segments = [segment for segment in numbering.replace(" ", "").split(".") if segment]
+    return max(1, len(segments))
+
+
+def _classify_line(
+    text: str,
+    lexicons: Sequence[TermLexicon],
+    settings: Settings,
+    llm_client: SpecLLMClient | None,
+    header_path: tuple[str, ...],
+) -> tuple[list[str], dict[str, float], str]:
+    """Classify a line using rule-based scores with optional LLM tie-breaker."""
+
+    lowered = text.lower()
+    scores = {lexicon.discipline: lexicon.score(lowered) for lexicon in lexicons}
+    top_score = max(scores.values()) if scores else 0.0
+    min_hits = max(settings.spec_rule_min_hits, 0)
+    margin = max(settings.spec_multi_label_margin, 0.0)
+
+    disciplines: list[str] = []
+    source = "rule"
+
+    if top_score >= min_hits:
+        disciplines = [
+            discipline
+            for discipline, score in scores.items()
+            if score > 0 and top_score - score <= margin
+        ]
+
+    if llm_client and llm_client.is_enabled:
+        should_call_llm = False
+        if not disciplines and any(score > 0 for score in scores.values()):
+            should_call_llm = True
+        elif len(disciplines) > 1:
+            should_call_llm = True
+
+        if should_call_llm:
+            candidates = disciplines or [
+                discipline for discipline, score in scores.items() if score > 0
+            ]
+            llm_result = llm_client.classify(text, header_path, scores, candidates=candidates)
+            if llm_result:
+                disciplines = list(llm_result)
+                source = "llm"
+
+    return disciplines, scores, source
+
+
+@lru_cache(maxsize=1)
+def _load_lexicons(path: Path) -> tuple[TermLexicon, ...]:
+    """Load and cache term lexicons from JSON files."""
+
+    if not path.exists():
+        LOGGER.warning("Spec terms directory %s missing; using default %s", path, DEFAULT_TERMS_DIR)
+        path = DEFAULT_TERMS_DIR
+    lexicons: list[TermLexicon] = []
+    for json_path in sorted(path.glob("*.json")):
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - configuration error
+            LOGGER.error("Invalid JSON in %s: %s", json_path, exc)
+            continue
+        discipline = data.get("discipline")
+        terms = tuple(item.strip() for item in data.get("terms", []) if item.strip())
+        boost_terms = tuple(item.strip() for item in data.get("boost_terms", []) if item.strip())
+        if not discipline or not terms:
+            LOGGER.warning("Skipping lexicon %s due to missing discipline/terms", json_path)
+            continue
+        lexicons.append(TermLexicon(discipline=discipline, terms=terms, boost_terms=boost_terms))
+
+    if not lexicons:
+        raise RuntimeError("No specification term lexicons available")
+
+    return tuple(lexicons)
+
+
+__all__ = [
+    "SpecExtractionResult",
+    "SpecLine",
+    "SpecLLMClient",
+    "TermLexicon",
+    "extract_specifications",
+]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,6 +45,29 @@
           </table>
         </div>
       </section>
+
+      <section class="specs" aria-labelledby="specs-title">
+        <h2 id="specs-title">Specification buckets</h2>
+        <form id="specs-form" class="specs-form">
+          <label for="specs-document-id">Document ID</label>
+          <div class="specs-form-inputs">
+            <input
+              id="specs-document-id"
+              name="documentId"
+              type="number"
+              min="1"
+              placeholder="Enter a document ID"
+              required
+            />
+            <button type="submit">Load specifications</button>
+          </div>
+        </form>
+        <p id="specs-status" class="status-message" role="status" aria-live="polite"></p>
+        <div id="specs-tabs" class="specs-tabs" hidden>
+          <nav class="specs-tablist" role="tablist" aria-label="Specification disciplines"></nav>
+          <div class="specs-panels"></div>
+        </div>
+      </section>
     </main>
     <script type="module" src="/main.js"></script>
   </body>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -4,6 +4,19 @@ const browseButton = document.querySelector("#browse-button");
 const uploadList = document.querySelector("#upload-progress");
 const documentsStatus = document.querySelector("#documents-status");
 const filesTableBody = document.querySelector("#files-table tbody");
+const specsForm = document.querySelector("#specs-form");
+const specsStatus = document.querySelector("#specs-status");
+const specsTabs = document.querySelector("#specs-tabs");
+const specsTablist = specsTabs?.querySelector(".specs-tablist") ?? null;
+const specsPanels = specsTabs?.querySelector(".specs-panels") ?? null;
+const DISCIPLINE_ORDER = [
+  "mechanical",
+  "electrical",
+  "controls",
+  "software",
+  "project_management",
+  "unknown",
+];
 
 function formatDate(value) {
   const date = new Date(value);
@@ -46,6 +59,16 @@ function updateDocumentsTable(documents) {
 
   for (const doc of documents) {
     const row = document.createElement("tr");
+    if (typeof doc.id === "number") {
+      row.dataset.documentId = String(doc.id);
+      row.addEventListener("click", () => {
+        const input = document.querySelector("#specs-document-id");
+        if (input) {
+          input.value = String(doc.id);
+          input.focus();
+        }
+      });
+    }
 
     const filenameCell = document.createElement("td");
     filenameCell.textContent = doc.filename;
@@ -136,6 +159,258 @@ function preventDefaults(event) {
   event.preventDefault();
   event.stopPropagation();
 }
+
+function normaliseDisciplineName(value) {
+  if (!value) {
+    return "Unknown";
+  }
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function renderSpecs(buckets, documentId) {
+  if (!specsTabs || !specsTablist || !specsPanels) {
+    return;
+  }
+
+  specsTablist.innerHTML = "";
+  specsPanels.innerHTML = "";
+
+  const entries = Object.entries(buckets ?? {}).sort((a, b) => {
+    const indexA = DISCIPLINE_ORDER.indexOf(a[0]);
+    const indexB = DISCIPLINE_ORDER.indexOf(b[0]);
+    const safeA = indexA === -1 ? DISCIPLINE_ORDER.length : indexA;
+    const safeB = indexB === -1 ? DISCIPLINE_ORDER.length : indexB;
+    if (safeA === safeB) {
+      return a[0].localeCompare(b[0]);
+    }
+    return safeA - safeB;
+  });
+
+  if (!entries.length) {
+    specsTabs.hidden = true;
+    return;
+  }
+
+  entries.forEach(([discipline, lines], index) => {
+    const tabId = `spec-tab-${discipline}`;
+    const panelId = `spec-panel-${discipline}`;
+
+    const tab = document.createElement("button");
+    tab.type = "button";
+    tab.className = "specs-tab";
+    tab.id = tabId;
+    tab.setAttribute("role", "tab");
+    tab.setAttribute("aria-controls", panelId);
+    tab.dataset.discipline = discipline;
+    tab.textContent = `${normaliseDisciplineName(discipline)} (${lines.length})`;
+    tab.setAttribute("aria-selected", index === 0 ? "true" : "false");
+    tab.tabIndex = index === 0 ? 0 : -1;
+    tab.addEventListener("click", () => {
+      activateSpecsTab(discipline);
+    });
+    specsTablist.append(tab);
+
+    const panel = document.createElement("section");
+    panel.id = panelId;
+    panel.className = "specs-panel";
+    panel.setAttribute("role", "tabpanel");
+    panel.setAttribute("aria-labelledby", tabId);
+    panel.hidden = index !== 0;
+    panel.append(createBucketToolbar(discipline, lines, documentId));
+    panel.append(createSpecList(lines));
+    specsPanels.append(panel);
+  });
+
+  specsTabs.hidden = false;
+  activateSpecsTab(entries[0][0]);
+}
+
+function activateSpecsTab(discipline, options = {}) {
+  const { focusTab = false } = options;
+  if (!specsTablist || !specsPanels) {
+    return;
+  }
+
+  const tabs = Array.from(specsTablist.querySelectorAll('[role="tab"]'));
+  const panels = Array.from(specsPanels.querySelectorAll('[role="tabpanel"]'));
+  const activePanelId = `spec-panel-${discipline}`;
+
+  for (const tab of tabs) {
+    const isActive = tab.dataset.discipline === discipline;
+    tab.setAttribute("aria-selected", isActive ? "true" : "false");
+    tab.tabIndex = isActive ? 0 : -1;
+    if (isActive && focusTab) {
+      tab.focus({ preventScroll: true });
+    }
+  }
+
+  for (const panel of panels) {
+    panel.hidden = panel.id !== activePanelId;
+  }
+}
+
+function createBucketToolbar(discipline, lines, documentId) {
+  const toolbar = document.createElement("div");
+  toolbar.className = "specs-panel-toolbar";
+
+  const count = document.createElement("span");
+  count.className = "specs-meta";
+  count.textContent = `${lines.length} line${lines.length === 1 ? "" : "s"}`;
+
+  const downloadButton = document.createElement("button");
+  downloadButton.type = "button";
+  downloadButton.className = "specs-download";
+  downloadButton.textContent = "Download JSON";
+  downloadButton.addEventListener("click", () => {
+    downloadBucket(discipline, lines, documentId);
+  });
+
+  toolbar.append(count, downloadButton);
+  return toolbar;
+}
+
+function createSpecList(lines) {
+  const list = document.createElement("ul");
+  list.className = "specs-list";
+
+  if (!Array.isArray(lines) || !lines.length) {
+    const emptyItem = document.createElement("li");
+    emptyItem.className = "specs-meta";
+    emptyItem.textContent = "No specification lines available.";
+    list.append(emptyItem);
+    return list;
+  }
+
+  for (const line of lines) {
+    const item = document.createElement("li");
+
+    const text = document.createElement("p");
+    text.className = "specs-text";
+    text.textContent = line.text;
+    item.append(text);
+
+    const header = document.createElement("p");
+    header.className = "specs-meta";
+    const headerPath = Array.isArray(line.header_path) && line.header_path.length
+      ? line.header_path.join(" › ")
+      : "(none)";
+    header.textContent = `Header: ${headerPath}`;
+    item.append(header);
+
+    const details = document.createElement("p");
+    details.className = "specs-meta";
+    const pageNumber = typeof line.page === "number" ? line.page + 1 : "—";
+    details.textContent = `Page ${pageNumber} · Source: ${line.source ?? "rule"}`;
+    item.append(details);
+
+    list.append(item);
+  }
+
+  return list;
+}
+
+function downloadBucket(discipline, lines, documentId) {
+  const payload = {
+    document_id: documentId,
+    discipline,
+    generated_at: new Date().toISOString(),
+    count: Array.isArray(lines) ? lines.length : 0,
+    lines,
+  };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `specs-${documentId}-${discipline}.json`;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function loadSpecs(documentId) {
+  if (!specsStatus) {
+    return;
+  }
+
+  specsStatus.textContent = `Loading specifications for document ${documentId}...`;
+  if (specsTabs) {
+    specsTabs.hidden = true;
+  }
+
+  try {
+    const response = await fetch(`/api/specs/extract/${documentId}`, { method: "POST" });
+    if (!response.ok) {
+      let detail;
+      try {
+        detail = (await response.json()).detail;
+      } catch (error) {
+        detail = undefined;
+      }
+      if (response.status === 404) {
+        throw new Error(detail || "Document not found.");
+      }
+      throw new Error(detail || `Failed to load specifications (${response.status})`);
+    }
+
+    const payload = await response.json();
+    renderSpecs(payload.buckets ?? {}, documentId);
+    const bucketValues = Object.values(payload.buckets ?? {});
+    const bucketCount = bucketValues.length;
+    const totalLines = bucketValues.reduce((total, bucket) => total + bucket.length, 0);
+    specsStatus.textContent = totalLines
+      ? `Loaded ${totalLines} line${totalLines === 1 ? "" : "s"} across ${bucketCount} bucket${
+          bucketCount === 1 ? "" : "s"
+        }.`
+      : "No specification lines were found.";
+  } catch (error) {
+    console.error(error);
+    specsStatus.textContent = error instanceof Error ? error.message : "Unable to load specifications.";
+  }
+}
+
+specsForm?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(specsForm);
+  const documentIdRaw = formData.get("documentId");
+  const documentId = Number(documentIdRaw);
+  if (!Number.isFinite(documentId) || documentId <= 0) {
+    if (specsStatus) {
+      specsStatus.textContent = "Enter a valid document ID.";
+    }
+    return;
+  }
+  void loadSpecs(documentId);
+});
+
+specsTablist?.addEventListener("keydown", (event) => {
+  if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+    return;
+  }
+
+  const tabs = Array.from(specsTablist.querySelectorAll('[role="tab"]'));
+  if (!tabs.length) {
+    return;
+  }
+
+  const currentIndex = tabs.findIndex((tab) => tab.getAttribute("aria-selected") === "true");
+  if (currentIndex === -1) {
+    return;
+  }
+
+  event.preventDefault();
+  const delta = event.key === "ArrowRight" ? 1 : -1;
+  const nextIndex = (currentIndex + delta + tabs.length) % tabs.length;
+  const nextDiscipline = tabs[nextIndex]?.dataset.discipline;
+  if (nextDiscipline) {
+    activateSpecsTab(nextDiscipline, { focusTab: true });
+  }
+});
 
 if (dropZone) {
   ["dragenter", "dragover", "dragleave", "drop"].forEach((eventName) => {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -128,3 +128,140 @@ progress.upload-error::-moz-progress-bar {
 .documents-table tbody tr:hover {
   background-color: color-mix(in srgb, CanvasText 6%, transparent);
 }
+
+.specs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.specs-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.specs-form-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.specs-form input[type="number"] {
+  flex: 1 1 160px;
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, CanvasText 25%, transparent);
+  background-color: color-mix(in srgb, Canvas 94%, CanvasText 6%);
+  color: inherit;
+}
+
+.specs-form button {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: none;
+  font-weight: 600;
+  background-color: color-mix(in srgb, CanvasText 10%, Canvas 90%);
+  color: inherit;
+  cursor: pointer;
+}
+
+.specs-form button:hover,
+.specs-form button:focus {
+  background-color: color-mix(in srgb, CanvasText 18%, Canvas 82%);
+}
+
+.specs-tabs {
+  border: 1px solid color-mix(in srgb, CanvasText 15%, transparent);
+  border-radius: 12px;
+  background-color: color-mix(in srgb, Canvas 97%, CanvasText 3%);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.specs-tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.specs-tablist button {
+  border: 1px solid color-mix(in srgb, CanvasText 20%, transparent);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.specs-tablist button[aria-selected="true"] {
+  background-color: color-mix(in srgb, CanvasText 12%, Canvas 88%);
+  border-color: color-mix(in srgb, CanvasText 35%, transparent);
+}
+
+.specs-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.specs-panel {
+  border-top: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.specs-panel-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.specs-download {
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, CanvasText 25%, transparent);
+  background-color: color-mix(in srgb, CanvasText 8%, Canvas 92%);
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.specs-download:hover,
+.specs-download:focus {
+  background-color: color-mix(in srgb, CanvasText 15%, Canvas 85%);
+}
+
+.specs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.specs-list li {
+  border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  background-color: color-mix(in srgb, Canvas 98%, CanvasText 2%);
+}
+
+.specs-text {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+
+.specs-meta {
+  margin: 0;
+  font-size: 0.875rem;
+  color: color-mix(in srgb, CanvasText 65%, transparent);
+}

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,114 @@
+"""Tests for the shared LLM service abstraction."""
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from backend.config import Settings
+from backend.services.llm import (
+    LLMCircuitOpenError,
+    LLMRetryableError,
+    LLMService,
+    LLMTransportRequest,
+    LLMTransportResponse,
+)
+
+
+def build_settings(tmp_path: Path) -> Settings:
+    return Settings(
+        upload_dir=tmp_path,
+        llm_provider="openrouter",
+        openrouter_api_key="test-key",
+        openrouter_model="openrouter/test-model",
+    )
+
+
+def test_llm_service_uses_cache(tmp_path: Path) -> None:
+    """Repeated calls with the same payload should hit the cache."""
+
+    calls: dict[str, int] = {"count": 0}
+
+    def fake_transport(request: LLMTransportRequest) -> LLMTransportResponse:
+        calls["count"] += 1
+        assert int(request.params["max_tokens"]) >= 4096
+        content = "#headers#\nMechanical\n#headers#"
+        usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        return LLMTransportResponse(content=content, usage=usage)
+
+    settings = build_settings(tmp_path)
+    service = LLMService(
+        settings,
+        transport_overrides={"openrouter": fake_transport},
+        sleep=lambda _: None,
+        time_func=lambda: 0.0,
+    )
+
+    result_first = service.generate(messages=[{"role": "user", "content": "hello"}], fence="#headers#")
+    assert result_first.fenced == "Mechanical"
+    assert not result_first.cached
+
+    result_second = service.generate(messages=[{"role": "user", "content": "hello"}], fence="#headers#")
+    assert result_second.cached
+    assert result_second.fenced == "Mechanical"
+    assert calls["count"] == 1
+
+
+def test_llm_service_retries_missing_fence(tmp_path: Path) -> None:
+    """Missing fences should trigger a retry with an explicit preamble."""
+
+    responses = [
+        LLMTransportResponse(content="no fences here"),
+        LLMTransportResponse(content="#classes#\n[\"mechanical\"]\n#classes#"),
+    ]
+    requests: list[LLMTransportRequest] = []
+
+    def fake_transport(request: LLMTransportRequest) -> LLMTransportResponse:
+        requests.append(request)
+        return responses[len(requests) - 1]
+
+    settings = build_settings(tmp_path)
+    service = LLMService(
+        settings,
+        transport_overrides={"openrouter": fake_transport},
+        sleep=lambda _: None,
+        time_func=lambda: 0.0,
+    )
+
+    result = service.generate(messages=[{"role": "user", "content": "classify"}], fence="#classes#")
+    assert result.fenced == "[\"mechanical\"]"
+    assert len(requests) == 2
+    assert "ONLY FENCED OUTPUT" in requests[1].messages[0]["content"]
+
+
+def test_llm_service_circuit_breaker(tmp_path: Path) -> None:
+    """Repeated retryable failures should trip the circuit breaker."""
+
+    attempts: dict[str, int] = {"count": 0}
+    current_time = {"value": 0.0}
+
+    def fake_time() -> float:
+        return current_time["value"]
+
+    def failing_transport(request: LLMTransportRequest) -> LLMTransportResponse:
+        attempts["count"] += 1
+        raise LLMRetryableError("rate limited")
+
+    settings = build_settings(tmp_path)
+    service = LLMService(
+        settings,
+        transport_overrides={"openrouter": failing_transport},
+        sleep=lambda _: None,
+        time_func=fake_time,
+    )
+
+    with pytest.raises(LLMRetryableError):
+        service.generate(messages=[{"role": "user", "content": "outline"}], fence="#headers#")
+    assert attempts["count"] == service._max_retries + 1  # type: ignore[attr-defined]
+
+    with pytest.raises(LLMCircuitOpenError):
+        service.generate(messages=[{"role": "user", "content": "outline"}], fence="#headers#")
+
+    current_time["value"] = 100.0
+    with pytest.raises(LLMRetryableError):
+        service.generate(messages=[{"role": "user", "content": "outline"}], fence="#headers#")
+    assert attempts["count"] == 2 * (service._max_retries + 1)  # type: ignore[attr-defined]

--- a/tests/test_specs_classify.py
+++ b/tests/test_specs_classify.py
@@ -1,0 +1,128 @@
+"""Unit tests for the specification extraction service."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.config import Settings
+from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
+from backend.services.spec_extraction import extract_specifications
+
+TERMS_DIR = Path("backend/resources/terms").resolve()
+
+
+def build_sample_parse_result() -> ParseResult:
+    """Construct an in-memory parse result representing a mini spec document."""
+
+    blocks = [
+        ParsedBlock(
+            text=(
+                "1.0 Mechanical Requirements\n"
+                "- Maintain pressure at 120 psi.\n"
+                "- Motor shall deliver torque not less than 300 Nm.\n"
+                "- Coordinate mechanical and electrical interfaces.\n"
+            ),
+            bbox=(0.0, 0.0, 200.0, 50.0),
+        ),
+        ParsedBlock(
+            text=(
+                "Electrical Requirements:\n"
+                "- Provide 24V supply to the control cabinet.\n"
+                "- Route wiring through shielded cable.\n"
+            ),
+            bbox=(0.0, 60.0, 200.0, 110.0),
+        ),
+        ParsedBlock(
+            text=(
+                "Controls and Software\n"
+                "1) PLC shall coordinate the PID loop.\n"
+                "2) Update firmware and HMI screens quarterly.\n"
+            ),
+            bbox=(0.0, 120.0, 200.0, 170.0),
+        ),
+        ParsedBlock(
+            text=(
+                "Project Management\n"
+                "- Submit monthly progress report to stakeholders.\n"
+                "- Review schedule and risk register.\n"
+            ),
+            bbox=(0.0, 180.0, 200.0, 230.0),
+        ),
+        ParsedBlock(
+            text="- General instructions apply.",
+            bbox=(0.0, 240.0, 200.0, 260.0),
+        ),
+    ]
+
+    page = ParsedPage(page_number=0, width=612.0, height=792.0, blocks=blocks)
+    return ParseResult(pages=[page])
+
+
+def test_spec_extraction_precision_recall(tmp_path) -> None:
+    """The rule-based classifier should achieve a high F1 score on the sample."""
+
+    parse_result = build_sample_parse_result()
+    settings = Settings(
+        upload_dir=tmp_path,
+        spec_terms_dir=TERMS_DIR,
+        spec_rule_min_hits=1,
+        spec_multi_label_margin=0.0,
+    )
+
+    extraction = extract_specifications(parse_result, settings=settings)
+
+    expected_labels = {
+        "Maintain pressure at 120 psi.": {"mechanical"},
+        "Motor shall deliver torque not less than 300 Nm.": {"mechanical"},
+        "Coordinate mechanical and electrical interfaces.": {"mechanical", "electrical"},
+        "Provide 24V supply to the control cabinet.": {"electrical"},
+        "Route wiring through shielded cable.": {"electrical"},
+        "PLC shall coordinate the PID loop.": {"controls"},
+        "Update firmware and HMI screens quarterly.": {"controls", "software"},
+        "Submit monthly progress report to stakeholders.": {"project_management"},
+        "Review schedule and risk register.": {"project_management"},
+    }
+
+    predictions: dict[str, set[str]] = {}
+    for line in extraction.lines:
+        if line.text in expected_labels:
+            predictions[line.text] = set(line.disciplines or {"unknown"})
+
+    missing = set(expected_labels) - set(predictions)
+    assert not missing, f"Expected lines missing from predictions: {missing}"
+
+    tp = fp = fn = 0
+    for text, expected in expected_labels.items():
+        predicted = predictions.get(text, {"unknown"})
+        tp += len(expected & predicted)
+        fp += len(predicted - expected)
+        fn += len(expected - predicted)
+
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if precision + recall else 0.0
+
+    assert precision >= 0.9
+    assert recall >= 0.9
+    assert f1 >= 0.9
+
+    unknown_bucket = extraction.to_dict()["unknown"]
+    unknown_texts = {item["text"] for item in unknown_bucket}
+    assert "General instructions apply." in unknown_texts
+
+
+def test_spec_extraction_cross_discipline(tmp_path) -> None:
+    """Cross-discipline phrases should retain multiple labels when applicable."""
+
+    parse_result = build_sample_parse_result()
+    settings = Settings(
+        upload_dir=tmp_path,
+        spec_terms_dir=TERMS_DIR,
+        spec_rule_min_hits=1,
+        spec_multi_label_margin=0.0,
+    )
+
+    extraction = extract_specifications(parse_result, settings=settings)
+    target_text = "Coordinate mechanical and electrical interfaces."
+    target_line = next(line for line in extraction.lines if line.text == target_text)
+
+    assert {"mechanical", "electrical"}.issubset(set(target_line.disciplines))


### PR DESCRIPTION
## Summary
- add a rule-first specification extraction service with term lexicons and optional LLM disambiguation
- expose a /api/specs/extract/{doc_id} endpoint and update config plus tests for specification buckets
- introduce a hardened LLM service with caching/retries and hook headers/spec extraction into it, including frontend tabs to explore results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fc2e0d064c8324adca9e70736221ed