### PR TITLE
Add spec approval persistence and exports

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -58,6 +58,12 @@ class Settings(BaseModel):
             os.getenv("RISK_BASELINES_PATH", str(DEFAULT_BASELINES_PATH))
         )
     )
+    export_dir: Path = Field(
+        default_factory=lambda: Path(os.getenv("EXPORT_DIR", "exported_reports"))
+    )
+    export_retention_days: int = Field(
+        default_factory=lambda: int(os.getenv("EXPORT_RETENTION_DAYS", "30"))
+    )
 
     @field_validator("upload_dir", mode="after")
     @classmethod
@@ -83,6 +89,17 @@ class Settings(BaseModel):
     def _ensure_baseline_file(cls, value: Path) -> Path:
         value.parent.mkdir(parents=True, exist_ok=True)
         return value
+
+    @field_validator("export_dir", mode="after")
+    @classmethod
+    def _ensure_export_dir(cls, value: Path) -> Path:
+        value.mkdir(parents=True, exist_ok=True)
+        return value
+
+    @field_validator("export_retention_days", mode="after")
+    @classmethod
+    def _normalise_retention(cls, value: int) -> int:
+        return max(0, value)
 
 
 @lru_cache()

--- a/backend/database.py
+++ b/backend/database.py
@@ -32,7 +32,10 @@ def get_session() -> Generator[Session, None, None]:
 def init_db() -> None:
     """Initialise database tables."""
 
-    from .models import document  # noqa: F401  Ensures models are registered with SQLModel metadata.
+    from .models import (  # noqa: F401  Ensures models are registered with SQLModel metadata.
+        document,
+        spec_record,
+    )
 
     engine = get_engine()
     SQLModel.metadata.create_all(engine)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,5 @@
 """Database models for the SimpleSpecs backend."""
 from .document import Document
+from .spec_record import SpecAuditEntry, SpecRecord
 
-__all__ = ["Document"]
+__all__ = ["Document", "SpecRecord", "SpecAuditEntry"]

--- a/backend/models/spec_record.py
+++ b/backend/models/spec_record.py
@@ -1,0 +1,57 @@
+"""Specification approval persistence models."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Return the current time in UTC."""
+
+    return datetime.now(UTC)
+
+
+class SpecRecord(SQLModel, table=True):
+    """Frozen specification payload for an analysed document."""
+
+    __tablename__ = "spec_records"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    state: str = Field(default="draft", index=True, nullable=False)
+    reviewer: str | None = Field(default=None, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=_utcnow, nullable=False)
+    approved_at: datetime | None = Field(default=None, nullable=True)
+    frozen_at: datetime | None = Field(default=None, nullable=True)
+    content_hash: str | None = Field(default=None, index=True, nullable=True)
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class SpecAuditEntry(SQLModel, table=True):
+    """Audit trail capturing approvals and export actions."""
+
+    __tablename__ = "spec_audit_entries"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    record_id: int | None = Field(
+        default=None, foreign_key="spec_records.id", index=True, nullable=True
+    )
+    action: str = Field(nullable=False, index=True)
+    actor: str | None = Field(default=None, nullable=True)
+    summary: str = Field(default="", nullable=False)
+    detail: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+__all__ = ["SpecRecord", "SpecAuditEntry"]

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -1,8 +1,12 @@
-"""Specification extraction endpoints."""
+"""Specification extraction and approval endpoints."""
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any, Literal
+
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, ConfigDict, Field
 from sqlmodel import Session
 
 from ..config import Settings, get_settings
@@ -14,6 +18,13 @@ from ..services.spec_extraction import (
     SpecLine,
     SpecLLMClient,
     extract_specifications,
+)
+from ..services.spec_records import (
+    SpecRecordError,
+    approve_specifications,
+    ensure_document,
+    export_spec_record,
+    fetch_spec_record,
 )
 
 router = APIRouter(prefix="/api", tags=["specifications"])
@@ -93,6 +104,154 @@ async def extract_specs_endpoint(
     llm_client = SpecLLMClient(settings)
     extraction = extract_specifications(parse_result, settings=settings, llm_client=llm_client)
     return SpecExtractionResponse.from_result(document.id, extraction)
+
+
+class SpecAuditEntryPayload(BaseModel):
+    """Serialised audit entry for specification approvals and exports."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    action: str
+    actor: str | None = None
+    summary: str
+    detail: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+
+class SpecRecordPayload(BaseModel):
+    """Serialised view of a frozen specification record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    document_id: int
+    state: str
+    reviewer: str | None = None
+    content_hash: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    approved_at: datetime | None = None
+    frozen_at: datetime | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class SpecRecordEnvelope(BaseModel):
+    """Envelope containing the current record and associated audit trail."""
+
+    document_id: int
+    record: SpecRecordPayload | None = None
+    audit: list[SpecAuditEntryPayload] = Field(default_factory=list)
+
+
+class SpecApprovalRequest(BaseModel):
+    """Request body for approving and freezing specifications."""
+
+    reviewer: str = Field(min_length=1)
+    payload: dict[str, Any]
+    notes: str | None = Field(default=None, max_length=2000)
+
+
+def _serialize_envelope(
+    *, document_id: int, record, audit: list
+) -> SpecRecordEnvelope:
+    record_payload = (
+        SpecRecordPayload.model_validate(record, from_attributes=True)
+        if record is not None
+        else None
+    )
+    if record_payload and record_payload.payload is None:
+        record_payload.payload = {}
+    audit_payload = [
+        SpecAuditEntryPayload.model_validate(entry, from_attributes=True)
+        for entry in audit
+    ]
+    return SpecRecordEnvelope(document_id=document_id, record=record_payload, audit=audit_payload)
+
+
+@router.get("/specs/{document_id}", response_model=SpecRecordEnvelope)
+async def get_spec_record(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+) -> SpecRecordEnvelope:
+    """Return the frozen specification record (if available) and audit trail."""
+
+    try:
+        document = ensure_document(session, document_id)
+    except SpecRecordError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    record, audit_entries = fetch_spec_record(session, document_id=document.id)
+    return _serialize_envelope(document_id=document.id, record=record, audit=audit_entries)
+
+
+@router.post("/specs/{document_id}/approve", response_model=SpecRecordEnvelope)
+async def approve_spec_record(
+    document_id: int,
+    request: SpecApprovalRequest,
+    *,
+    session: Session = Depends(get_session),
+) -> SpecRecordEnvelope:
+    """Freeze specification payload for a document and record an audit entry."""
+
+    try:
+        document = ensure_document(session, document_id)
+    except SpecRecordError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    reviewer = request.reviewer.strip()
+    if not reviewer:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Reviewer is required")
+
+    try:
+        approve_specifications(
+            session,
+            document=document,
+            payload=request.payload,
+            reviewer=reviewer,
+            notes=request.notes.strip() if request.notes else None,
+        )
+    except SpecRecordError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    record, audit_entries = fetch_spec_record(session, document_id=document.id)
+    return _serialize_envelope(document_id=document.id, record=record, audit=audit_entries)
+
+
+@router.get("/specs/{document_id}/export")
+async def export_spec_record_endpoint(
+    document_id: int,
+    *,
+    fmt: Literal["csv", "docx"],
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> FileResponse:
+    """Generate a CSV bundle or DOCX export for an approved specification record."""
+
+    try:
+        document = ensure_document(session, document_id)
+    except SpecRecordError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    record, _ = fetch_spec_record(session, document_id=document.id)
+    if record is None or record.state != "approved":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Document has no approved specification record",
+        )
+
+    try:
+        path, media_type = export_spec_record(
+            session,
+            record=record,
+            settings=settings,
+            fmt=fmt,
+            actor="api",
+        )
+    except SpecRecordError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return FileResponse(path, media_type=media_type, filename=path.name)
 
 
 __all__ = ["router"]

--- a/backend/services/spec_records.py
+++ b/backend/services/spec_records.py
@@ -1,0 +1,292 @@
+"""Services for persisting specification approvals and exports."""
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Tuple
+
+from docx import Document as DocxDocument
+from sqlmodel import Session, select
+
+from ..config import Settings
+from ..models import Document, SpecAuditEntry, SpecRecord
+
+
+class SpecRecordError(RuntimeError):
+    """Base error for spec record operations."""
+
+
+def ensure_document(session: Session, document_id: int) -> Document:
+    """Return the document for the given id or raise an error."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise SpecRecordError(f"Document {document_id} not found")
+    return document
+
+
+def _serialise_payload(payload: Any) -> dict[str, Any]:
+    """Return a JSON-serialisable payload copy."""
+
+    try:
+        serialised = json.loads(json.dumps(payload, ensure_ascii=False))
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+        raise SpecRecordError("Payload is not JSON serialisable") from exc
+    if not isinstance(serialised, dict):
+        raise SpecRecordError("Payload must be a JSON object")
+    return serialised
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    """Return a stable hash for the payload."""
+
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def approve_specifications(
+    session: Session,
+    *,
+    document: Document,
+    payload: Any,
+    reviewer: str,
+    notes: str | None = None,
+) -> SpecRecord:
+    """Create or update the frozen specification payload for a document."""
+
+    data = _serialise_payload(payload)
+    payload_hash = _payload_hash(data)
+    now = datetime.now(UTC)
+
+    record_stmt = select(SpecRecord).where(SpecRecord.document_id == document.id)
+    record = session.exec(record_stmt).first()
+
+    detail: dict[str, Any] = {"content_hash": payload_hash}
+    if notes:
+        detail["notes"] = notes
+
+    if record is None:
+        record = SpecRecord(
+            document_id=document.id,
+            state="approved",
+            reviewer=reviewer,
+            created_at=now,
+            updated_at=now,
+            approved_at=now,
+            frozen_at=now,
+            content_hash=payload_hash,
+            payload=data,
+        )
+        session.add(record)
+        session.flush()
+        summary = "Specifications approved and frozen"
+        detail["changed"] = True
+    else:
+        changed = record.content_hash != payload_hash or record.state != "approved"
+        record.updated_at = now
+        if changed:
+            detail["previous_hash"] = record.content_hash
+            detail["changed"] = True
+            record.payload = data
+            record.content_hash = payload_hash
+            record.state = "approved"
+            record.approved_at = now
+            record.frozen_at = now
+            record.reviewer = reviewer
+            summary = "Specifications re-approved with updates"
+        else:
+            detail["changed"] = False
+            if not record.reviewer:
+                record.reviewer = reviewer
+            summary = "Approval replayed without changes"
+        session.add(record)
+        session.flush()
+
+    audit = SpecAuditEntry(
+        document_id=document.id,
+        record_id=record.id,
+        action="approve",
+        actor=reviewer,
+        summary=summary,
+        detail=detail,
+    )
+    session.add(audit)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def fetch_spec_record(
+    session: Session, *, document_id: int
+) -> Tuple[SpecRecord | None, list[SpecAuditEntry]]:
+    """Return the spec record and audit entries for a document."""
+
+    record_stmt = select(SpecRecord).where(SpecRecord.document_id == document_id)
+    record = session.exec(record_stmt).first()
+
+    audit_stmt = (
+        select(SpecAuditEntry)
+        .where(SpecAuditEntry.document_id == document_id)
+        .order_by(SpecAuditEntry.created_at.asc())
+    )
+    audit_entries = list(session.exec(audit_stmt))
+    return record, audit_entries
+
+
+def export_spec_record(
+    session: Session,
+    *,
+    record: SpecRecord,
+    settings: Settings,
+    fmt: str,
+    actor: str | None = None,
+) -> tuple[Path, str]:
+    """Generate an export artifact for a frozen specification record."""
+
+    export_dir = settings.export_dir
+    export_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_exports(export_dir, settings.export_retention_days)
+
+    suffix = (record.content_hash or "unhashed")[:12]
+    if fmt == "csv":
+        path = export_dir / f"spec-{record.document_id}-{suffix}.zip"
+        media_type = "application/zip"
+        _write_csv_bundle(record, path)
+    elif fmt == "docx":
+        path = export_dir / f"spec-{record.document_id}-{suffix}.docx"
+        media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        _write_docx_report(record, path)
+    else:
+        raise SpecRecordError(f"Unsupported export format: {fmt}")
+
+    audit = SpecAuditEntry(
+        document_id=record.document_id,
+        record_id=record.id,
+        action="export",
+        actor=actor,
+        summary=f"Specification export generated ({fmt})",
+        detail={"format": fmt, "filename": path.name},
+    )
+    session.add(audit)
+    session.commit()
+    return path, media_type
+
+
+def _cleanup_exports(export_dir: Path, retention_days: int) -> None:
+    """Remove export artifacts older than the retention window."""
+
+    if retention_days <= 0:
+        return
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    for item in export_dir.glob("*"):
+        if not item.is_file():
+            continue
+        try:
+            modified = datetime.fromtimestamp(item.stat().st_mtime, UTC)
+        except OSError:  # pragma: no cover - filesystem race
+            continue
+        if modified < cutoff:
+            try:
+                item.unlink()
+            except OSError:  # pragma: no cover - filesystem race
+                continue
+
+
+def _iter_bucket_items(record: SpecRecord) -> Iterable[tuple[str, list[dict[str, Any]]]]:
+    payload = record.payload or {}
+    buckets = payload.get("buckets", {})
+    if not isinstance(buckets, dict):
+        return []
+    return sorted(
+        (
+            (discipline, list(lines) if isinstance(lines, list) else [])
+            for discipline, lines in buckets.items()
+        ),
+        key=lambda item: item[0],
+    )
+
+
+def _write_csv_bundle(record: SpecRecord, target: Path) -> None:
+    """Create a ZIP archive containing per-discipline CSV files."""
+
+    with zipfile.ZipFile(target, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for discipline, lines in _iter_bucket_items(record):
+            buffer = io.StringIO()
+            writer = csv.DictWriter(
+                buffer,
+                fieldnames=["discipline", "text", "page", "header", "source"],
+            )
+            writer.writeheader()
+            for line in lines:
+                page = line.get("page")
+                page_value = page + 1 if isinstance(page, int) else ""
+                header_path = line.get("header_path")
+                if isinstance(header_path, list):
+                    header_value = " > ".join(str(segment) for segment in header_path)
+                else:
+                    header_value = ""
+                writer.writerow(
+                    {
+                        "discipline": discipline,
+                        "text": str(line.get("text", "")),
+                        "page": page_value,
+                        "header": header_value,
+                        "source": str(line.get("source", "")),
+                    }
+                )
+            bundle.writestr(f"{discipline}.csv", buffer.getvalue())
+
+
+def _write_docx_report(record: SpecRecord, target: Path) -> None:
+    """Create a DOCX report with header hierarchy for each discipline."""
+
+    document = DocxDocument()
+    document.add_heading(f"Specifications for Document {record.document_id}", level=1)
+
+    meta_lines = [
+        f"State: {record.state}",
+        f"Reviewer: {record.reviewer or '—'}",
+    ]
+    if record.approved_at:
+        meta_lines.append(f"Approved: {record.approved_at.isoformat()}")
+    document.add_paragraph(" | ".join(meta_lines))
+
+    for discipline, lines in _iter_bucket_items(record):
+        document.add_heading(_humanise_discipline(discipline), level=2)
+        if not lines:
+            document.add_paragraph("No specification lines in this bucket.")
+            continue
+        for line in lines:
+            paragraph = document.add_paragraph(str(line.get("text", "")))
+            page = line.get("page")
+            page_value = page + 1 if isinstance(page, int) else "—"
+            header_path = line.get("header_path")
+            if isinstance(header_path, list) and header_path:
+                header_value = " > ".join(str(segment) for segment in header_path)
+            else:
+                header_value = "No header context"
+            meta_run = paragraph.add_run(
+                f"\nPage {page_value} • Header: {header_value}"
+            )
+            meta_run.italic = True
+
+    document.save(target)
+
+
+def _humanise_discipline(value: str) -> str:
+    return value.replace("_", " ").title()
+
+
+__all__ = [
+    "SpecRecordError",
+    "approve_specifications",
+    "ensure_document",
+    "export_spec_record",
+    "fetch_spec_record",
+]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -71,10 +71,28 @@
             <h3 id="panel-specs-title">Specification buckets</h3>
             <div class="panel-actions">
               <button type="button" class="ghost-button" data-export="specs-json">Export JSON</button>
-              <button type="button" class="ghost-button" data-export="specs-csv">Export CSV</button>
             </div>
           </div>
-          <div class="panel-body" id="specs-content" aria-live="polite"></div>
+          <div class="panel-body">
+            <div class="approval-controls" id="approval-controls">
+              <label class="approval-controls__field" for="reviewer-name">
+                <span class="approval-controls__label">Reviewer</span>
+                <input
+                  id="reviewer-name"
+                  name="reviewer-name"
+                  type="text"
+                  placeholder="Quality engineer"
+                  autocomplete="name"
+                />
+              </label>
+              <button type="button" class="primary-button" id="approve-specs">Approve &amp; Freeze</button>
+              <div class="approval-controls__spacer" aria-hidden="true"></div>
+              <button type="button" class="ghost-button" data-server-export="csv">Download CSV bundle</button>
+              <button type="button" class="ghost-button" data-server-export="docx">Download DOCX</button>
+              <span id="approval-status" class="approval-status" role="status"></span>
+            </div>
+            <div id="specs-content" aria-live="polite"></div>
+          </div>
         </section>
 
         <section class="panel" id="panel-risk" aria-labelledby="panel-risk-title">

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -86,6 +86,48 @@ export async function deleteDocument(documentId) {
   return request(`/files/${documentId}`, { method: 'DELETE' });
 }
 
+export async function fetchSpecRecord(documentId) {
+  return request(`/specs/${documentId}`);
+}
+
+export async function approveSpecRecord(documentId, body) {
+  return request(`/specs/${documentId}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function downloadSpecExport(documentId, format) {
+  const response = await fetch(`${apiBase}/specs/${documentId}/export?fmt=${encodeURIComponent(format)}`);
+  if (!response.ok) {
+    let detail;
+    try {
+      const payload = await response.json();
+      detail = payload?.detail ?? payload?.message;
+    } catch (error) {
+      detail = undefined;
+    }
+    const message = detail || `Export failed (${response.status})`;
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get('content-disposition') ?? '';
+  let filename = `spec-${documentId}.${format === 'csv' ? 'zip' : 'docx'}`;
+  const match = disposition.match(/filename="?([^";]+)"?/i);
+  if (match?.[1]) {
+    filename = decodeURIComponent(match[1]);
+  }
+  return {
+    blob,
+    filename,
+    mediaType: response.headers.get('content-type') ?? 'application/octet-stream',
+  };
+}
+
 export function toCsv(rows) {
   if (!Array.isArray(rows) || !rows.length) {
     return '';
@@ -106,7 +148,7 @@ export function toCsv(rows) {
 }
 
 export function downloadBlob(filename, contents, type = 'application/json') {
-  const blob = new Blob([contents], { type });
+  const blob = contents instanceof Blob ? contents : new Blob([contents], { type });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement('a');
   anchor.href = url;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -5,8 +5,10 @@ import {
   fetchHeaders,
   fetchSpecifications,
   compareSpecifications,
-  toCsv,
   downloadBlob,
+  fetchSpecRecord,
+  approveSpecRecord,
+  downloadSpecExport,
 } from './api.js';
 import {
   initDropZone,
@@ -20,6 +22,7 @@ import {
   renderSpecsBuckets,
   renderRiskPanel,
   showToast,
+  formatDate,
 } from './ui.js';
 
 const state = {
@@ -30,6 +33,8 @@ const state = {
   specs: null,
   risk: null,
   approvedLines: new Set(),
+  specRecord: null,
+  approvalLoading: false,
 };
 
 const elements = {
@@ -46,6 +51,9 @@ const elements = {
   headersContent: document.querySelector('#headers-content'),
   specsContent: document.querySelector('#specs-content'),
   riskContent: document.querySelector('#risk-content'),
+  approveSpecs: document.querySelector('#approve-specs'),
+  approvalStatus: document.querySelector('#approval-status'),
+  reviewerInput: document.querySelector('#reviewer-name'),
 };
 
 initDropZone({
@@ -98,6 +106,14 @@ document.querySelectorAll('[data-export]').forEach((button) => {
   button.addEventListener('click', () => handleExport(button.dataset.export));
 });
 
+document.querySelectorAll('[data-server-export]').forEach((button) => {
+  button.addEventListener('click', () => handleServerExport(button.dataset.serverExport));
+});
+
+elements.approveSpecs?.addEventListener('click', () => {
+  void approveCurrentSpecs();
+});
+
 async function refreshDocuments() {
   try {
     elements.documentsStatus.textContent = 'Loading documents…';
@@ -124,6 +140,8 @@ async function selectDocument(documentId) {
   }
   state.selectedId = documentId;
   state.approvedLines.clear();
+  state.specRecord = null;
+  state.approvalLoading = true;
   renderDocumentList(elements.documentsList, state.documents, documentId);
   elements.documentsList?.setAttribute('aria-activedescendant', `document-${documentId}`);
 
@@ -138,13 +156,22 @@ async function selectDocument(documentId) {
   setPanelLoading(elements.headersContent, 'Generating outline…');
   setPanelLoading(elements.specsContent, 'Classifying specification lines…');
   setPanelLoading(elements.riskContent, 'Computing risk score…');
+  setApprovalStatus('Loading approval status…', 'muted');
+  updateApprovalUI({ busy: true });
 
   try {
-    const [parseResult, headersResult, specsResult, riskResult] = await Promise.allSettled([
+    const [
+      parseResult,
+      headersResult,
+      specsResult,
+      riskResult,
+      recordResult,
+    ] = await Promise.allSettled([
       parseDocument(documentId),
       fetchHeaders(documentId),
       fetchSpecifications(documentId),
       compareSpecifications(documentId),
+      fetchSpecRecord(documentId),
     ]);
 
     if (parseResult.status === 'fulfilled') {
@@ -165,15 +192,7 @@ async function selectDocument(documentId) {
 
     if (specsResult.status === 'fulfilled') {
       state.specs = specsResult.value;
-      renderSpecsBuckets(elements.specsContent, state.specs?.buckets ?? {}, {
-        documentId,
-        approvedLines: state.approvedLines,
-        onApproveToggle: ({ approved }) => {
-          if (approved) {
-            showToast('Specification approved.');
-          }
-        },
-      });
+      renderSpecsView();
     } else {
       state.specs = null;
       setPanelError(elements.specsContent, specsResult.reason?.message ?? 'Unable to classify specifications.');
@@ -185,6 +204,18 @@ async function selectDocument(documentId) {
     } else {
       state.risk = null;
       setPanelError(elements.riskContent, riskResult.reason?.message ?? 'Unable to compute risk score.');
+    }
+
+    if (recordResult.status === 'fulfilled') {
+      state.specRecord = recordResult.value;
+      state.approvalLoading = false;
+      updateApprovalUI();
+      renderSpecsView();
+    } else {
+      state.specRecord = null;
+      state.approvalLoading = false;
+      setApprovalStatus('Unable to load approval status.', 'error');
+      updateApprovalUI({ preserveStatus: true });
     }
   } finally {
     if (elements.workspaceSubtitle) {
@@ -217,24 +248,6 @@ function handleExport(kind) {
         downloadBlob(`specs-${documentId}.json`, JSON.stringify(state.specs, null, 2));
         break;
       }
-      case 'specs-csv': {
-        if (!state.specs?.buckets) throw new Error('No specification buckets to export.');
-        const rows = [];
-        for (const [discipline, lines] of Object.entries(state.specs.buckets)) {
-          lines.forEach((line) => {
-            rows.push({
-              discipline,
-              text: line.text,
-              page: typeof line.page === 'number' ? line.page + 1 : '',
-              header: Array.isArray(line.header_path) ? line.header_path.join(' > ') : '',
-              source: line.source ?? 'rule',
-            });
-          });
-        }
-        const csv = toCsv(rows);
-        downloadBlob(`specs-${documentId}.csv`, csv, 'text/csv');
-        break;
-      }
       case 'risk': {
         if (!state.risk) throw new Error('Risk report unavailable.');
         downloadBlob(`risk-${documentId}.json`, JSON.stringify(state.risk, null, 2));
@@ -247,6 +260,122 @@ function handleExport(kind) {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unable to export data.';
     showToast(message, 'error');
+  }
+}
+
+async function handleServerExport(format) {
+  const documentId = state.selectedId;
+  if (!documentId) {
+    showToast('Select a document first.', 'error');
+    return;
+  }
+  try {
+    const { blob, filename } = await downloadSpecExport(documentId, format);
+    downloadBlob(filename, blob);
+    showToast('Export ready for download.');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to export specifications.';
+    showToast(message, 'error');
+  }
+}
+
+async function approveCurrentSpecs() {
+  const documentId = state.selectedId;
+  if (!documentId) {
+    showToast('Select a document first.', 'error');
+    return;
+  }
+  if (!state.specs) {
+    showToast('Specifications not ready for approval.', 'error');
+    return;
+  }
+
+  const reviewer = elements.reviewerInput?.value?.trim() || 'web-user';
+  state.approvalLoading = true;
+  updateApprovalUI({ busy: true });
+  setApprovalStatus('Submitting approval…', 'muted');
+
+  try {
+    const response = await approveSpecRecord(documentId, {
+      reviewer,
+      payload: state.specs,
+    });
+    state.specRecord = response;
+    state.approvalLoading = false;
+    updateApprovalUI();
+    renderSpecsView();
+    showToast('Specifications approved.');
+  } catch (error) {
+    state.approvalLoading = false;
+    updateApprovalUI();
+    const message = error instanceof Error ? error.message : 'Unable to approve specifications.';
+    setApprovalStatus(message, 'error');
+    showToast(message, 'error');
+  }
+}
+
+function renderSpecsView() {
+  if (!elements.specsContent) {
+    return;
+  }
+  if (!state.specs) {
+    return;
+  }
+  const buckets = state.specs?.buckets ?? {};
+  const readOnly = state.specRecord?.record?.state === 'approved';
+  renderSpecsBuckets(elements.specsContent, buckets, {
+    documentId: state.selectedId,
+    approvedLines: state.approvedLines,
+    readOnly,
+    onApproveToggle: ({ approved }) => {
+      if (approved) {
+        showToast('Specification approved.');
+      }
+    },
+  });
+}
+
+function setApprovalStatus(message, tone = 'muted') {
+  if (!elements.approvalStatus) {
+    return;
+  }
+  elements.approvalStatus.textContent = message;
+  elements.approvalStatus.dataset.tone = tone;
+}
+
+function updateApprovalUI({ busy = false, preserveStatus = false } = {}) {
+  const record = state.specRecord?.record ?? null;
+  const isApproved = record?.state === 'approved';
+  const loading = busy || state.approvalLoading;
+
+  if (elements.approveSpecs) {
+    elements.approveSpecs.disabled = loading || isApproved || !state.specs;
+    if (loading) {
+      elements.approveSpecs.textContent = 'Working…';
+    } else if (isApproved) {
+      elements.approveSpecs.textContent = 'Approved';
+    } else {
+      elements.approveSpecs.textContent = 'Approve & Freeze';
+    }
+  }
+
+  if (elements.reviewerInput) {
+    if (record?.reviewer) {
+      elements.reviewerInput.value = record.reviewer;
+    }
+    elements.reviewerInput.disabled = loading || isApproved;
+  }
+
+  if (loading) {
+    return;
+  }
+
+  if (isApproved) {
+    const approvedDate = record?.approved_at ? formatDate(record.approved_at) : '—';
+    const reviewer = record?.reviewer || '—';
+    setApprovalStatus(`Approved by ${reviewer} on ${approvedDate}.`, 'success');
+  } else if (!preserveStatus) {
+    setApprovalStatus('Awaiting approval.', 'muted');
   }
 }
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -239,7 +239,11 @@ function normaliseDiscipline(value) {
     .join(' ');
 }
 
-export function renderSpecsBuckets(container, buckets, { documentId, approvedLines, onApproveToggle } = {}) {
+export function renderSpecsBuckets(
+  container,
+  buckets,
+  { documentId, approvedLines, onApproveToggle, readOnly = false } = {},
+) {
   if (!container) return;
   const entries = Object.entries(buckets ?? {}).sort((a, b) => {
     const indexA = DISCIPLINE_ORDER.indexOf(a[0]);
@@ -299,7 +303,8 @@ export function renderSpecsBuckets(container, buckets, { documentId, approvedLin
       const item = document.createElement('article');
       item.className = 'spec-line';
       item.dataset.lineKey = key;
-      if (approvedLines?.has(key)) {
+      const initiallyApproved = approvedLines?.has(key) || readOnly;
+      if (initiallyApproved) {
         item.dataset.approved = 'true';
       }
 
@@ -320,8 +325,16 @@ export function renderSpecsBuckets(container, buckets, { documentId, approvedLin
       const approveButton = document.createElement('button');
       approveButton.type = 'button';
       approveButton.className = 'ghost-button';
-      approveButton.textContent = approvedLines?.has(key) ? 'Approved' : 'Approve';
+      if (readOnly) {
+        approveButton.textContent = 'Frozen';
+        approveButton.disabled = true;
+      } else {
+        approveButton.textContent = approvedLines?.has(key) ? 'Approved' : 'Approve';
+      }
       approveButton.addEventListener('click', () => {
+        if (readOnly) {
+          return;
+        }
         const approvedSet = approvedLines ?? null;
         const approved = !approvedSet?.has?.(key);
         if (approved) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -124,6 +124,30 @@ body {
   outline: none;
 }
 
+.ghost-button:disabled,
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.primary-button {
+  border: none;
+  background: var(--accent-strong);
+  color: Canvas;
+  border-radius: 999px;
+  padding: 0.4rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  background: var(--accent);
+  outline: none;
+  transform: translateY(-1px);
+}
+
 .upload-progress {
   list-style: none;
   display: flex;
@@ -191,6 +215,63 @@ body {
   display: flex;
   justify-content: space-between;
   gap: 0.5rem;
+}
+
+.approval-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.approval-controls__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 200px;
+}
+
+.approval-controls__label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.approval-controls__field input {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.95rem;
+  background: color-mix(in srgb, Canvas 96%, CanvasText 4%);
+  color: inherit;
+}
+
+.approval-controls__field input:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.approval-controls__field input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.approval-controls__spacer {
+  flex: 1 1 auto;
+}
+
+.approval-status {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  min-height: 1.25rem;
+}
+
+.approval-status[data-tone='success'] {
+  color: var(--success);
+}
+
+.approval-status[data-tone='error'] {
+  color: var(--danger);
 }
 
 .app-main {

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,3 +9,4 @@ python-dotenv==1.0.1
 python-multipart==0.0.20
 httpx==0.27.0
 pytest==8.2.2
+python-docx==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv==1.0.1
 python-multipart==0.0.20
 httpx==0.27.0
 pytest==8.2.2
+python-docx==1.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,43 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Generator
 
-# Ensure the repository root is available on sys.path so tests can import project packages
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.config import reset_settings_cache
+from backend.database import reset_database_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[None, None, None]:
+    """Provide isolated configuration for each test."""
+
+    db_path = tmp_path / "test.db"
+    upload_dir = tmp_path / "uploads"
+    export_dir = tmp_path / "exports"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("EXPORT_DIR", str(export_dir))
+    monkeypatch.setenv("EXPORT_RETENTION_DAYS", "1")
+    monkeypatch.setenv("MAX_UPLOAD_SIZE", str(1024))
+    reset_settings_cache()
+    reset_database_state()
+    yield
+    reset_settings_cache()
+    reset_database_state()
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Return a test client for the FastAPI application."""
+
+    from backend.main import app
+
+    with TestClient(app) as test_client:
+        yield test_client

--- a/tests/test_spec_approval.py
+++ b/tests/test_spec_approval.py
@@ -1,0 +1,103 @@
+import io
+import os
+import zipfile
+from pathlib import Path
+
+from docx import Document as DocxDocument
+from fastapi.testclient import TestClient
+
+PDF_BYTES = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+    b"trailer\n<< /Root 1 0 R >>\n%%EOF\n"
+)
+
+
+def _upload_sample(client: TestClient) -> int:
+    response = client.post(
+        "/api/upload",
+        files={"file": ("sample.pdf", io.BytesIO(PDF_BYTES), "application/pdf")},
+    )
+    assert response.status_code in {200, 201}
+    payload = response.json()
+    return payload["id"]
+
+
+def _spec_payload(document_id: int) -> dict:
+    return {
+        "document_id": document_id,
+        "buckets": {
+            "mechanical": [
+                {
+                    "text": "Pump shall be rated for 100 psi.",
+                    "page": 0,
+                    "header_path": ["Section 1", "Pumps"],
+                    "source": "rule",
+                    "scores": {"mechanical": 1.0},
+                    "provenance": {
+                        "page": 0,
+                        "block_index": 0,
+                        "line_index": 0,
+                        "bbox": None,
+                    },
+                }
+            ],
+            "unknown": [],
+        },
+    }
+
+
+def test_spec_approval_flow_and_exports(client: TestClient) -> None:
+    document_id = _upload_sample(client)
+
+    payload = _spec_payload(document_id)
+
+    first = client.post(
+        f"/api/specs/{document_id}/approve",
+        json={"reviewer": "qa@example.com", "payload": payload, "notes": "Initial pass"},
+    )
+    assert first.status_code == 200
+    first_data = first.json()
+    assert first_data["record"]["state"] == "approved"
+    assert first_data["record"]["approved_at"] is not None
+    hash_one = first_data["record"]["content_hash"]
+    assert hash_one
+
+    second = client.post(
+        f"/api/specs/{document_id}/approve",
+        json={"reviewer": "qa@example.com", "payload": payload},
+    )
+    assert second.status_code == 200
+    second_data = second.json()
+    assert second_data["record"]["content_hash"] == hash_one
+    assert second_data["record"]["id"] == first_data["record"]["id"]
+
+    status = client.get(f"/api/specs/{document_id}")
+    assert status.status_code == 200
+    snapshot = status.json()
+    assert snapshot["record"]["content_hash"] == hash_one
+    assert len(snapshot["audit"]) >= 2
+    assert snapshot["audit"][0]["action"] == "approve"
+    assert snapshot["audit"][-1]["detail"]["changed"] is False
+
+    csv_response = client.get(f"/api/specs/{document_id}/export", params={"fmt": "csv"})
+    assert csv_response.status_code == 200
+    assert csv_response.headers["content-type"].startswith("application/zip")
+    with zipfile.ZipFile(io.BytesIO(csv_response.content)) as archive:
+        members = archive.namelist()
+        assert "mechanical.csv" in members
+        csv_payload = archive.read("mechanical.csv").decode()
+        assert "Pump shall be rated for 100 psi." in csv_payload
+
+    docx_response = client.get(f"/api/specs/{document_id}/export", params={"fmt": "docx"})
+    assert docx_response.status_code == 200
+    assert docx_response.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    document = DocxDocument(io.BytesIO(docx_response.content))
+    combined_text = "\n".join(paragraph.text for paragraph in document.paragraphs)
+    assert "Pump shall be rated for 100 psi." in combined_text
+
+    export_dir = Path(os.environ["EXPORT_DIR"])
+    saved = list(export_dir.glob("spec-*.docx"))
+    assert saved, "DOCX export should be written to disk"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -2,48 +2,17 @@
 from __future__ import annotations
 
 import io
+import io
 import os
 from pathlib import Path
-from typing import Generator
 
-import pytest
 from fastapi.testclient import TestClient
-
-from backend.config import reset_settings_cache
-from backend.database import reset_database_state
 
 PDF_BYTES = (
     b"%PDF-1.4\n"
     b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
     b"trailer\n<< /Root 1 0 R >>\n%%EOF\n"
 )
-
-
-@pytest.fixture(autouse=True)
-def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[None, None, None]:
-    """Provide isolated database and upload directories per test."""
-
-    db_path = tmp_path / "test.db"
-    upload_dir = tmp_path / "uploads"
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
-    monkeypatch.setenv("MAX_UPLOAD_SIZE", str(1024))
-    reset_settings_cache()
-    reset_database_state()
-    yield
-    reset_settings_cache()
-    reset_database_state()
-
-
-@pytest.fixture()
-def client() -> Generator[TestClient, None, None]:
-    """Return a test client for the FastAPI application."""
-
-    from backend.main import app
-
-    with TestClient(app) as test_client:
-        yield test_client
-
 
 def _post_pdf(client: TestClient, content: bytes, filename: str = "sample.pdf"):
     return client.post(


### PR DESCRIPTION
## Summary
- add spec record and audit models with persistence services
- expose endpoints to approve specs, fetch audit status, and stream CSV/DOCX exports
- update the frontend workflow to manage approvals and server-side exports and add regression coverage for the flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc44df72e88324b3f08390908eff3d