### PR TITLE
Fix FastAPI TestClient cleanup warnings

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,6 +1,7 @@
 """Backend package for SimpleSpecs."""
 from __future__ import annotations
 
+from functools import wraps
 import sys
 
 import python_multipart
@@ -14,5 +15,48 @@ import python_multipart.multipart
 # ---------------------------------------------------------------------------
 sys.modules.setdefault("multipart", python_multipart)
 sys.modules.setdefault("multipart.multipart", python_multipart.multipart)
+
+
+def _patch_testclient() -> None:
+    """Apply runtime fixes for FastAPI's synchronous test client."""
+
+    try:
+        from fastapi.testclient import TestClient
+    except Exception:  # pragma: no cover - fastapi is an optional dependency
+        return
+
+    if getattr(TestClient, "_simplespecs_patch", False):  # pragma: no cover - idempotent
+        return
+
+    original_exit = TestClient.__exit__
+    original_wait_shutdown = TestClient.wait_shutdown
+
+    @wraps(original_wait_shutdown)
+    async def patched_wait_shutdown(self: TestClient, *args, **kwargs):
+        try:
+            await original_wait_shutdown(self, *args, **kwargs)
+        finally:
+            stream_receive = getattr(self, "stream_receive", None)
+            if stream_receive is not None:
+                try:
+                    await stream_receive.aclose()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+
+    @wraps(original_exit)
+    def patched_exit(self: TestClient, *args, **kwargs):
+        try:
+            return original_exit(self, *args, **kwargs)
+        finally:
+            for attr in ("stream_send", "stream_receive"):
+                if hasattr(self, attr):
+                    setattr(self, attr, None)
+
+    TestClient.wait_shutdown = patched_wait_shutdown  # type: ignore[assignment]
+    TestClient.__exit__ = patched_exit  # type: ignore[assignment]
+    TestClient._simplespecs_patch = True  # type: ignore[attr-defined]
+
+
+_patch_testclient()
 
 __all__ = ["python_multipart"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,10 +1,9 @@
 from fastapi.testclient import TestClient
 
-from backend.main import app
 
+def test_health_endpoint_returns_ok(client: TestClient) -> None:
+    """The health endpoint should respond with a simple ok payload."""
 
-def test_health_endpoint_returns_ok():
-    client = TestClient(app)
     response = client.get("/api/health")
     assert response.status_code == 200
     assert response.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- patch FastAPI's TestClient at import time to close lifespan memory streams and prevent resource warnings
- update the health check test to reuse the shared TestClient fixture for proper cleanup

## Testing
- PYTHONWARNINGS=error pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68fd7d12c70c832494ec1598448a6aec