### PR TITLE
Add request id context middleware and tighten spec audit logging

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from .database import init_db
 from .routers import api_router
+from .middleware import RequestIdMiddleware
 
 
 @asynccontextmanager
@@ -21,6 +22,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="SimpleSpecs", version="0.1.0", lifespan=lifespan)
+app.add_middleware(RequestIdMiddleware)
 app.include_router(api_router)
 
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"

--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""ASGI middleware utilities for the SimpleSpecs backend."""
+
+from .request_context import RequestIdMiddleware, get_request_id
+
+__all__ = ["RequestIdMiddleware", "get_request_id"]

--- a/backend/middleware/request_context.py
+++ b/backend/middleware/request_context.py
@@ -1,0 +1,53 @@
+"""Request context helpers and middleware for request identifiers."""
+from __future__ import annotations
+
+import contextvars
+import re
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+_REQUEST_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+
+def get_request_id(default: str | None = None) -> str | None:
+    """Return the request identifier stored in the current context."""
+
+    return _REQUEST_ID.get(default)
+
+
+def _normalise_request_id(value: str | None) -> str:
+    """Return a safe request identifier, falling back to a generated token."""
+
+    if value:
+        candidate = value.strip()
+        if _REQUEST_ID_PATTERN.match(candidate):
+            return candidate
+    return uuid.uuid4().hex
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Attach a request identifier header and expose it via a context variable."""
+
+    def __init__(self, app: ASGIApp, header_name: str = "X-Request-ID") -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = _normalise_request_id(request.headers.get(self.header_name))
+        token = _REQUEST_ID.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            _REQUEST_ID.reset(token)
+        response.headers[self.header_name] = request_id
+        return response
+
+
+__all__ = ["RequestIdMiddleware", "get_request_id"]

--- a/backend/services/spec_records.py
+++ b/backend/services/spec_records.py
@@ -14,6 +14,7 @@ from docx import Document as DocxDocument
 from sqlmodel import Session, select
 
 from ..config import Settings
+from ..middleware import get_request_id
 from ..models import Document, SpecAuditEntry, SpecRecord
 
 
@@ -67,6 +68,9 @@ def approve_specifications(
     record = session.exec(record_stmt).first()
 
     detail: dict[str, Any] = {"content_hash": payload_hash}
+    request_id = get_request_id()
+    if request_id:
+        detail["request_id"] = request_id
     if notes:
         detail["notes"] = notes
 
@@ -107,13 +111,14 @@ def approve_specifications(
         session.add(record)
         session.flush()
 
+    audit_detail = detail.copy()
     audit = SpecAuditEntry(
         document_id=document.id,
         record_id=record.id,
         action="approve",
         actor=reviewer,
         summary=summary,
-        detail=detail,
+        detail=audit_detail,
     )
     session.add(audit)
     session.commit()
@@ -153,6 +158,7 @@ def export_spec_record(
     _cleanup_exports(export_dir, settings.export_retention_days)
 
     suffix = (record.content_hash or "unhashed")[:12]
+    request_id = get_request_id()
     if fmt == "csv":
         path = export_dir / f"spec-{record.document_id}-{suffix}.zip"
         media_type = "application/zip"
@@ -164,13 +170,17 @@ def export_spec_record(
     else:
         raise SpecRecordError(f"Unsupported export format: {fmt}")
 
+    detail = {"format": fmt, "filename": path.name}
+    if request_id:
+        detail["request_id"] = request_id
+
     audit = SpecAuditEntry(
         document_id=record.document_id,
         record_id=record.id,
         action="export",
         actor=actor,
         summary=f"Specification export generated ({fmt})",
-        detail={"format": fmt, "filename": path.name},
+        detail=detail,
     )
     session.add(audit)
     session.commit()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -7,3 +7,14 @@ def test_health_endpoint_returns_ok(client: TestClient) -> None:
     response = client.get("/api/health")
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+    assert "X-Request-ID" in response.headers
+    assert response.headers["X-Request-ID"]
+
+
+def test_health_request_id_header_is_sanitised(client: TestClient) -> None:
+    """Middleware should normalise inbound request ids before echoing them back."""
+
+    response = client.get("/api/health", headers={"X-Request-ID": "  weird id "})
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] != "  weird id "
+    assert response.headers["X-Request-ID"].strip() == response.headers["X-Request-ID"]

--- a/tests/test_spec_approval.py
+++ b/tests/test_spec_approval.py
@@ -55,8 +55,10 @@ def test_spec_approval_flow_and_exports(client: TestClient) -> None:
     first = client.post(
         f"/api/specs/{document_id}/approve",
         json={"reviewer": "qa@example.com", "payload": payload, "notes": "Initial pass"},
+        headers={"X-Request-ID": "approve-1"},
     )
     assert first.status_code == 200
+    assert first.headers["X-Request-ID"] == "approve-1"
     first_data = first.json()
     assert first_data["record"]["state"] == "approved"
     assert first_data["record"]["approved_at"] is not None
@@ -66,34 +68,50 @@ def test_spec_approval_flow_and_exports(client: TestClient) -> None:
     second = client.post(
         f"/api/specs/{document_id}/approve",
         json={"reviewer": "qa@example.com", "payload": payload},
+        headers={"X-Request-ID": "approve-2"},
     )
     assert second.status_code == 200
+    assert second.headers["X-Request-ID"] == "approve-2"
     second_data = second.json()
     assert second_data["record"]["content_hash"] == hash_one
     assert second_data["record"]["id"] == first_data["record"]["id"]
 
-    status = client.get(f"/api/specs/{document_id}")
+    status = client.get(
+        f"/api/specs/{document_id}", headers={"X-Request-ID": "status-1"}
+    )
     assert status.status_code == 200
     snapshot = status.json()
     assert snapshot["record"]["content_hash"] == hash_one
     assert len(snapshot["audit"]) >= 2
     assert snapshot["audit"][0]["action"] == "approve"
     assert snapshot["audit"][-1]["detail"]["changed"] is False
+    assert snapshot["audit"][0]["detail"]["request_id"] == "approve-1"
+    assert snapshot["audit"][1]["detail"]["request_id"] == "approve-2"
 
-    csv_response = client.get(f"/api/specs/{document_id}/export", params={"fmt": "csv"})
+    csv_response = client.get(
+        f"/api/specs/{document_id}/export",
+        params={"fmt": "csv"},
+        headers={"X-Request-ID": "export-csv"},
+    )
     assert csv_response.status_code == 200
     assert csv_response.headers["content-type"].startswith("application/zip")
+    assert csv_response.headers["X-Request-ID"] == "export-csv"
     with zipfile.ZipFile(io.BytesIO(csv_response.content)) as archive:
         members = archive.namelist()
         assert "mechanical.csv" in members
         csv_payload = archive.read("mechanical.csv").decode()
         assert "Pump shall be rated for 100 psi." in csv_payload
 
-    docx_response = client.get(f"/api/specs/{document_id}/export", params={"fmt": "docx"})
+    docx_response = client.get(
+        f"/api/specs/{document_id}/export",
+        params={"fmt": "docx"},
+        headers={"X-Request-ID": "export-docx"},
+    )
     assert docx_response.status_code == 200
     assert docx_response.headers["content-type"].startswith(
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     )
+    assert docx_response.headers["X-Request-ID"] == "export-docx"
     document = DocxDocument(io.BytesIO(docx_response.content))
     combined_text = "\n".join(paragraph.text for paragraph in document.paragraphs)
     assert "Pump shall be rated for 100 psi." in combined_text
@@ -101,3 +119,12 @@ def test_spec_approval_flow_and_exports(client: TestClient) -> None:
     export_dir = Path(os.environ["EXPORT_DIR"])
     saved = list(export_dir.glob("spec-*.docx"))
     assert saved, "DOCX export should be written to disk"
+
+    final_status = client.get(
+        f"/api/specs/{document_id}", headers={"X-Request-ID": "status-2"}
+    )
+    assert final_status.status_code == 200
+    audit_entries = final_status.json()["audit"]
+    export_entries = [entry for entry in audit_entries if entry["action"] == "export"]
+    assert export_entries[-2]["detail"]["request_id"] == "export-csv"
+    assert export_entries[-1]["detail"]["request_id"] == "export-docx"


### PR DESCRIPTION
## Summary
- add a reusable request-id middleware that normalises inbound IDs and exposes them via context
- attach request identifiers to approval and export audit records to improve traceability
- extend integration tests to assert request-id propagation and sanitisation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd80788fb8832488a1fe31ab2a1de7