### PR TITLE
Add observability metrics, security hardening, and operational runbooks

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -8,7 +8,7 @@ This archive provides a **complete, actionable build plan** for your SimpleSpecs
 - **Goal:** Parse customer PDFs, extract **full header trees** and **departmental specifications** hardened by **ASME/ISO** terms, produce exports, and track compliance/risk.
 
 ## What’s inside
-- `plan/Phase-00-Foundations.md` through `plan/Phase-10-Deployment.md` — **one file per phase** with objectives, tasks, prompts, endpoints, checklists, and exit criteria.
+- `plan/Phase-00-Foundations.md` through `plan/Phase-13-Operational-Readiness-&-Runbooks.md` — **one file per phase** with objectives, tasks, prompts, endpoints, checklists, and exit criteria.
 - `plan/Standards-ASME-ISO.md` — the standards hardening reference used throughout.
 - `plan/Prompts-Library.md` — canonical LLM prompts (headers, classification, red-team checks).
 - `plan/Testing-Strategy.md` — consolidated test plan across phases.

--- a/agents/Phase-11-Observability-&-Telemetry.agent.md
+++ b/agents/Phase-11-Observability-&-Telemetry.agent.md
@@ -1,0 +1,22 @@
+# Phase 11 — Observability & Telemetry (Agent Script)
+
+## Audit
+- Inspect `plan/Phase-11-Observability-&-Telemetry.md` for scope and acceptance criteria.
+- Confirm `backend/observability/` package exists with registry and middleware modules.
+- Verify `backend/main.py` registers `RequestMetricsMiddleware` after the request-id middleware.
+- Check `/api/metrics` route is included via `backend/routers/observability.py`.
+
+## Patch
+1. Create or update `backend/observability/metrics.py` with a thread-safe `MetricsRegistry` and `RequestMetricsMiddleware`.
+2. Export the registry from `backend/observability/__init__.py`.
+3. Register the middleware in `backend/main.py`.
+4. Add `/api/metrics` route and ensure it is wired in `backend/routers/__init__.py`.
+5. Reset the registry in `tests/conftest.py` and add unit tests under `tests/test_observability.py`.
+
+## Acceptance Checks
+- `pytest tests/test_observability.py`
+- `pytest` (full suite) — optional but recommended.
+
+## Exit Criteria
+- Metrics endpoint reports counts for at least one routed request.
+- Tests covering registry behaviour and endpoint response pass.

--- a/agents/Phase-12-Security-&-Compliance-Hardening.agent.md
+++ b/agents/Phase-12-Security-&-Compliance-Hardening.agent.md
@@ -1,0 +1,20 @@
+# Phase 12 — Security & Compliance Hardening (Agent Script)
+
+## Audit
+- Review `plan/Phase-12-Security-&-Compliance-Hardening.md` for required headers.
+- Ensure `backend/middleware/security.py` exists and exports `SecurityHeadersMiddleware`.
+- Confirm middleware ordering in `backend/main.py` (request-id → metrics → security).
+- Check for regression tests validating header presence.
+
+## Patch
+1. Implement `SecurityHeadersMiddleware` that applies hardened defaults (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, CSP).
+2. Export middleware via `backend/middleware/__init__.py`.
+3. Register middleware in `backend/main.py` after metrics middleware.
+4. Add tests in `tests/test_security_headers.py` asserting headers exist on `/api/health`.
+
+## Acceptance Checks
+- `pytest tests/test_security_headers.py`
+
+## Exit Criteria
+- Hardened headers are present on API responses without duplicate definitions.
+- Security tests pass.

--- a/agents/Phase-13-Operational-Readiness-&-Runbooks.agent.md
+++ b/agents/Phase-13-Operational-Readiness-&-Runbooks.agent.md
@@ -1,0 +1,22 @@
+# Phase 13 — Operational Readiness & Runbooks (Agent Script)
+
+## Audit
+- Study `plan/Phase-13-Operational-Readiness-&-Runbooks.md` for scope.
+- Confirm `backend/__init__.py` exports `__version__`.
+- Ensure `backend/routers/observability.py` exposes both `/api/metrics` and `/api/status`.
+- Verify tests exist covering `/api/status` behaviour.
+
+## Patch
+1. Add `__version__` constant to `backend/__init__.py` and export via `__all__`.
+2. Extend `backend/routers/observability.py` with `_database_ok()` helper and `/api/status` route embedding metrics + version.
+3. Wire router into `backend/routers/__init__.py` if not already present.
+4. Document new phases in `Plan.md` and author plan/agent files for phases 11–13.
+5. Add tests in `tests/test_observability.py` verifying status payload.
+
+## Acceptance Checks
+- `pytest tests/test_observability.py`
+- `pytest` (full suite) to confirm regression safety.
+
+## Exit Criteria
+- `/api/status` returns version string, `database.ok` flag, and metrics snapshot.
+- Documentation lists all thirteen phases with operator guidance.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -7,6 +7,8 @@ import sys
 import python_multipart
 import python_multipart.multipart
 
+__version__ = "0.1.0"
+
 # ---------------------------------------------------------------------------
 # Compatibility shim: Starlette currently imports the legacy ``multipart``
 # package which emits a ``PendingDeprecationWarning``. Register the modern
@@ -59,4 +61,4 @@ def _patch_testclient() -> None:
 
 _patch_testclient()
 
-__all__ = ["python_multipart"]
+__all__ = ["python_multipart", "__version__"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,8 @@ from fastapi.staticfiles import StaticFiles
 
 from .database import init_db
 from .routers import api_router
-from .middleware import RequestIdMiddleware
+from .middleware import RequestIdMiddleware, SecurityHeadersMiddleware
+from .observability import RequestMetricsMiddleware
 
 
 @asynccontextmanager
@@ -23,6 +24,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="SimpleSpecs", version="0.1.0", lifespan=lifespan)
 app.add_middleware(RequestIdMiddleware)
+app.add_middleware(RequestMetricsMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 app.include_router(api_router)
 
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"

--- a/backend/middleware/__init__.py
+++ b/backend/middleware/__init__.py
@@ -1,5 +1,6 @@
 """ASGI middleware utilities for the SimpleSpecs backend."""
 
 from .request_context import RequestIdMiddleware, get_request_id
+from .security import SecurityHeadersMiddleware
 
-__all__ = ["RequestIdMiddleware", "get_request_id"]
+__all__ = ["RequestIdMiddleware", "SecurityHeadersMiddleware", "get_request_id"]

--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -1,0 +1,36 @@
+"""Security related middleware for HTTP responses."""
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach a hardened set of default security headers."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        content_security_policy: str | None = "default-src 'self'; frame-ancestors 'none'; form-action 'self'",
+    ) -> None:
+        super().__init__(app)
+        self._content_security_policy = content_security_policy
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        headers = response.headers
+        headers.setdefault("X-Content-Type-Options", "nosniff")
+        headers.setdefault("X-Frame-Options", "DENY")
+        headers.setdefault("Referrer-Policy", "no-referrer")
+        headers.setdefault(
+            "Permissions-Policy",
+            "geolocation=(), microphone=(), camera=(), fullscreen=()",
+        )
+        headers.setdefault("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+        if self._content_security_policy:
+            headers.setdefault("Content-Security-Policy", self._content_security_policy)
+        return response
+
+
+__all__ = ["SecurityHeadersMiddleware"]

--- a/backend/observability/__init__.py
+++ b/backend/observability/__init__.py
@@ -1,0 +1,8 @@
+"""Observability helpers for SimpleSpecs."""
+from .metrics import MetricsRegistry, RequestMetricsMiddleware, metrics_registry
+
+__all__ = [
+    "MetricsRegistry",
+    "RequestMetricsMiddleware",
+    "metrics_registry",
+]

--- a/backend/observability/metrics.py
+++ b/backend/observability/metrics.py
@@ -1,0 +1,144 @@
+"""Request metrics collection utilities."""
+from __future__ import annotations
+
+from collections import Counter
+from threading import Lock
+from time import perf_counter
+from typing import Dict
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class MetricsRegistry:
+    """In-memory collector for lightweight request metrics."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._in_flight = 0
+        self._requests_total = 0
+        self._status_families: Counter[str] = Counter()
+        self._routes: Dict[str, Dict[str, float | int | None]] = {}
+
+    def reset(self) -> None:
+        """Reset all counters (useful for tests)."""
+
+        with self._lock:
+            self._in_flight = 0
+            self._requests_total = 0
+            self._status_families = Counter()
+            self._routes = {}
+
+    def request_started(self) -> None:
+        """Mark the start of a request."""
+
+        with self._lock:
+            self._in_flight += 1
+
+    def request_finished(
+        self,
+        method: str,
+        path: str,
+        status_code: int,
+        duration_seconds: float,
+    ) -> None:
+        """Record request completion statistics."""
+
+        duration_ms = max(duration_seconds * 1000.0, 0.0)
+        route_key = f"{method.upper()} {path}"
+        status_family = f"{status_code // 100}xx"
+
+        with self._lock:
+            self._in_flight = max(0, self._in_flight - 1)
+            self._requests_total += 1
+            self._status_families[status_family] += 1
+
+            stats = self._routes.setdefault(
+                route_key,
+                {
+                    "count": 0,
+                    "total_duration_ms": 0.0,
+                    "min_duration_ms": None,
+                    "max_duration_ms": None,
+                },
+            )
+            stats["count"] = int(stats["count"]) + 1
+            stats["total_duration_ms"] = float(stats["total_duration_ms"]) + duration_ms
+
+            minimum = stats["min_duration_ms"]
+            maximum = stats["max_duration_ms"]
+            stats["min_duration_ms"] = (
+                duration_ms
+                if minimum is None
+                else min(float(minimum), duration_ms)
+            )
+            stats["max_duration_ms"] = (
+                duration_ms
+                if maximum is None
+                else max(float(maximum), duration_ms)
+            )
+
+    def snapshot(self) -> Dict[str, object]:
+        """Return an immutable view of the current metrics."""
+
+        with self._lock:
+            routes: Dict[str, Dict[str, float | int | None]] = {}
+            for key, value in self._routes.items():
+                count = int(value["count"]) or 1
+                total_duration = float(value["total_duration_ms"])
+                average = total_duration / count
+                routes[key] = {
+                    "count": int(value["count"]),
+                    "avg_duration_ms": average,
+                    "min_duration_ms": value["min_duration_ms"],
+                    "max_duration_ms": value["max_duration_ms"],
+                }
+
+            return {
+                "requests_total": self._requests_total,
+                "in_flight": self._in_flight,
+                "status_codes": dict(self._status_families),
+                "routes": routes,
+            }
+
+
+class RequestMetricsMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware that records request metrics."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        registry: MetricsRegistry | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._registry = registry or metrics_registry
+
+    async def dispatch(self, request: Request, call_next):
+        start = perf_counter()
+        self._registry.request_started()
+        try:
+            response = await call_next(request)
+        except Exception:  # pragma: no cover - re-raise after recording metrics
+            duration = perf_counter() - start
+            self._registry.request_finished(request.method, request.url.path, 500, duration)
+            raise
+        else:
+            duration = perf_counter() - start
+            self._registry.request_finished(
+                request.method,
+                request.url.path,
+                getattr(response, "status_code", 200),
+                duration,
+            )
+            return response
+
+
+metrics_registry = MetricsRegistry()
+
+__all__ = [
+    "MetricsRegistry",
+    "RequestMetricsMiddleware",
+    "metrics_registry",
+]

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 from .compare import router as compare_router
 from .files import router as files_router
 from .headers import router as headers_router
+from .observability import router as observability_router
 from .parse import router as parse_router
 from .specs import router as specs_router
 
@@ -13,5 +14,6 @@ api_router.include_router(headers_router)
 api_router.include_router(parse_router)
 api_router.include_router(specs_router)
 api_router.include_router(compare_router)
+api_router.include_router(observability_router)
 
 __all__ = ["api_router"]

--- a/backend/routers/observability.py
+++ b/backend/routers/observability.py
@@ -1,0 +1,44 @@
+"""Routes that expose operational observability data."""
+from __future__ import annotations
+from fastapi import APIRouter
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session, text
+
+from backend import __version__
+from ..database import get_engine
+from ..observability import metrics_registry
+
+router = APIRouter(prefix="/api", tags=["observability"])
+
+
+def _database_ok() -> bool:
+    """Run a lightweight database check."""
+
+    engine = get_engine()
+    try:
+        with Session(engine) as session:
+            session.exec(text("SELECT 1")).one()
+    except SQLAlchemyError:
+        return False
+    return True
+
+
+@router.get("/metrics")
+def read_metrics() -> dict[str, object]:
+    """Return the current request metrics snapshot."""
+
+    return metrics_registry.snapshot()
+
+
+@router.get("/status")
+def read_status() -> dict[str, object]:
+    """Return an aggregated operational status payload."""
+
+    return {
+        "app": {"version": __version__},
+        "database": {"ok": _database_ok()},
+        "metrics": metrics_registry.snapshot(),
+    }
+
+
+__all__ = ["router"]

--- a/plan/Phase-11-Observability-&-Telemetry.md
+++ b/plan/Phase-11-Observability-&-Telemetry.md
@@ -1,0 +1,50 @@
+# Phase 11 — Observability & Telemetry
+
+## Objectives
+- Instrument the API for lightweight request telemetry.
+- Expose metrics for operational insight and automated checks.
+
+## Scope
+- ASGI middleware for request timings and status counts.
+- `/api/metrics` endpoint returning JSON payload (no Prometheus dependency).
+- Tests verifying aggregation accuracy.
+
+## Architecture/Stack
+- Python 3.12, FastAPI, Starlette middleware.
+- In-memory metrics registry guarded by threading locks.
+
+## Dependencies
+- Phase 10 complete and the FastAPI application bootstraps correctly.
+
+## Tasks
+- Create `MetricsRegistry` with counters for total requests, in-flight count, per-route latency stats, and status families.
+- Add `RequestMetricsMiddleware` leveraging `perf_counter` to measure latency and record success/error codes.
+- Mount middleware in `backend/main.py` after the request-id middleware.
+- Add `/api/metrics` route returning the registry snapshot.
+- Reset registry within tests to avoid cross-test contamination.
+- Provide unit tests confirming metrics increment on health checks and that status families are populated.
+
+## API Endpoints (new/changed)
+- `GET /api/metrics`
+
+## Config & Flags
+- None required; metrics registry is in-process and zero-config.
+
+## Prompts (if applicable)
+_N/A_
+
+## Artifacts & Deliverables
+- Source modules in `backend/observability/`.
+- Tests in `tests/test_observability.py`.
+- Metrics documented in runbooks (see Phase 13).
+
+## Acceptance Criteria / Exit Gates
+- Calling `/api/health` followed by `/api/metrics` shows an incremented count for `GET /api/health`.
+- Automated tests covering registry reset and snapshot accuracy pass.
+
+## Risks & Mitigations
+- **Risk:** Metrics growth leads to large in-memory state.
+  - **Mitigation:** Track counts per route without storing payload bodies; registry can be reset via application restart.
+
+## Rollback
+- Remove middleware registration and delete the observability package; no persistent schema changes.

--- a/plan/Phase-12-Security-&-Compliance-Hardening.md
+++ b/plan/Phase-12-Security-&-Compliance-Hardening.md
@@ -1,0 +1,45 @@
+# Phase 12 — Security & Compliance Hardening
+
+## Objectives
+- Strengthen default HTTP response headers for clickjacking, MIME sniffing, and referrer leakage.
+- Ensure middleware-driven protections are test-covered.
+
+## Scope
+- Security headers middleware with configurable Content-Security-Policy (CSP).
+- Regression tests validating header presence on representative API responses.
+
+## Architecture/Stack
+- Starlette `BaseHTTPMiddleware` stacked on FastAPI application.
+
+## Dependencies
+- Phase 11 complete so middleware ordering is defined.
+
+## Tasks
+- Implement `SecurityHeadersMiddleware` setting `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security`, and CSP.
+- Register middleware after metrics collection to ensure headers decorate final responses.
+- Add unit test asserting headers exist on `/api/health` responses.
+- Document defaults within plan and agent instructions.
+
+## API Endpoints (new/changed)
+- No new endpoints; middleware augments responses globally.
+
+## Config & Flags
+- CSP string configurable via middleware constructor; default denies third-party origins.
+
+## Prompts (if applicable)
+_N/A_
+
+## Artifacts & Deliverables
+- Middleware implementation in `backend/middleware/security.py`.
+- Tests in `tests/test_security_headers.py`.
+
+## Acceptance Criteria / Exit Gates
+- `/api/health` response includes all hardened headers with correct values.
+- Test suite confirms middleware is active.
+
+## Risks & Mitigations
+- **Risk:** Overly strict CSP blocks static assets.
+  - **Mitigation:** Default allows self-hosted resources; adjust in future if bundling external fonts/scripts.
+
+## Rollback
+- Remove middleware registration line from `backend/main.py` and delete middleware file.

--- a/plan/Phase-13-Operational-Readiness-&-Runbooks.md
+++ b/plan/Phase-13-Operational-Readiness-&-Runbooks.md
@@ -1,0 +1,49 @@
+# Phase 13 — Operational Readiness & Runbooks
+
+## Objectives
+- Provide a status endpoint aggregating runtime insights for runbooks.
+- Document operational checks bridging metrics, versioning, and database health.
+
+## Scope
+- `/api/status` endpoint reusing metrics snapshot and probing database connectivity.
+- Plan/agent updates outlining runbook steps for operators.
+
+## Architecture/Stack
+- FastAPI router extension leveraging SQLModel sessions for health probes.
+
+## Dependencies
+- Phase 11 metrics and Phase 12 security middleware registered.
+
+## Tasks
+- Introduce router under `backend/routers/observability.py` exposing `/api/status`.
+- Implement `_database_ok()` helper executing `SELECT 1` via SQLModel session with exception handling.
+- Embed application version sourced from `backend.__version__` into the response payload.
+- Update `backend/__init__.py` to export `__version__` constant.
+- Extend plan index to list new phases and provide operator notes.
+- Add tests asserting `/api/status` returns version string, database ok flag, and metrics payload keys.
+
+## API Endpoints (new/changed)
+- `GET /api/status`
+
+## Config & Flags
+- None; relies on existing database configuration.
+
+## Prompts (if applicable)
+_N/A_
+
+## Artifacts & Deliverables
+- Router logic in `backend/routers/observability.py`.
+- Tests in `tests/test_observability.py`.
+- Updated `Plan.md` enumerating all phases.
+
+## Acceptance Criteria / Exit Gates
+- `/api/status` returns HTTP 200 with `{"database": {"ok": true}}` when SQLite is reachable.
+- Response includes metrics summary and semantic version string.
+- Automated tests pass.
+
+## Risks & Mitigations
+- **Risk:** Status endpoint reveals sensitive configuration.
+  - **Mitigation:** Payload limited to boolean health indicators and version string.
+
+## Rollback
+- Remove `/api/status` route inclusion and delete helper functions; no data migrations involved.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from backend.config import reset_settings_cache
 from backend.database import reset_database_state
+from backend.observability import metrics_registry
 
 
 @pytest.fixture(autouse=True)
@@ -30,9 +31,11 @@ def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Gen
     monkeypatch.setenv("MAX_UPLOAD_SIZE", str(1024))
     reset_settings_cache()
     reset_database_state()
+    metrics_registry.reset()
     yield
     reset_settings_cache()
     reset_database_state()
+    metrics_registry.reset()
 
 
 @pytest.fixture()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,29 @@
+"""Tests for observability endpoints and metrics."""
+from __future__ import annotations
+
+from backend.observability import metrics_registry
+
+
+def test_metrics_endpoint_tracks_requests(client):
+    metrics_registry.reset()
+    response = client.get("/api/health")
+    assert response.status_code == 200
+
+    metrics_response = client.get("/api/metrics")
+    assert metrics_response.status_code == 200
+    payload = metrics_response.json()
+
+    assert payload["requests_total"] >= 1
+    assert payload["status_codes"]["2xx"] >= 1
+    assert payload["routes"]["GET /api/health"]["count"] == 1
+
+
+def test_status_endpoint_reports_database_and_version(client):
+    metrics_registry.reset()
+    status_response = client.get("/api/status")
+    assert status_response.status_code == 200
+    payload = status_response.json()
+
+    assert payload["database"]["ok"] is True
+    assert payload["app"]["version"]
+    assert "requests_total" in payload["metrics"]

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,15 @@
+"""Ensure security middleware applies hardened headers."""
+from __future__ import annotations
+
+
+def test_security_headers_present(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    headers = response.headers
+
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert headers["X-Frame-Options"] == "DENY"
+    assert headers["Referrer-Policy"] == "no-referrer"
+    assert "geolocation=()" in headers["Permissions-Policy"]
+    assert "Strict-Transport-Security" in headers
+    assert "Content-Security-Policy" in headers


### PR DESCRIPTION
## Summary
- add request metrics middleware and expose /api/metrics and /api/status for operational insight
- harden HTTP responses with a dedicated security header middleware and regression tests
- extend the phase plan/agent library to cover phases 11–13 with observability, security, and runbook guidance

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68fdf5d249988324811e7043f3f73e50