### PR TITLE
Make backend CORS origins configurable

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -46,6 +46,16 @@ class Settings(BaseModel):
             if mime.strip()
         )
     )
+    cors_allow_origins: Tuple[str, ...] = Field(
+        default_factory=lambda: tuple(
+            origin.strip()
+            for origin in os.getenv(
+                "CORS_ALLOW_ORIGINS",
+                "http://localhost:3600,http://127.0.0.1:3600",
+            ).split(",")
+            if origin.strip()
+        )
+    )
     host: str = Field(default_factory=lambda: os.getenv("HOST", "0.0.0.0"))
     port: int = Field(default_factory=lambda: int(os.getenv("PORT", "7600")))
     log_level: str = Field(default_factory=lambda: os.getenv("LOG_LEVEL", "info"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from .database import init_db
 from .routers import api_router
 from .middleware import RequestIdMiddleware, SecurityHeadersMiddleware
 from .observability import RequestMetricsMiddleware
+from .config import get_settings
 
 
 @asynccontextmanager
@@ -23,17 +24,24 @@ async def lifespan(app: FastAPI):
     yield
 
 
+settings = get_settings()
+
+cors_allow_origins = list(settings.cors_allow_origins)
+allow_credentials = True
+if "*" in cors_allow_origins:
+    cors_allow_origins = ["*"]
+    allow_credentials = False
+if not cors_allow_origins:
+    cors_allow_origins = ["http://localhost:3600", "http://127.0.0.1:3600"]
+
 app = FastAPI(title="SimpleSpecs", version="0.1.0", lifespan=lifespan)
 app.add_middleware(RequestIdMiddleware)
 app.add_middleware(RequestMetricsMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3600",
-        "http://127.0.0.1:3600",
-    ],
-    allow_credentials=True,
+    allow_origins=cors_allow_origins,
+    allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- add a configurable CORS allow-origins setting loaded from the environment
- update the FastAPI app to read the configured origins and handle wildcard credentials safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe07a0235c8324a15623e9fb888f46