### PR TITLE
Add document deletion endpoint and cover frontend API wiring

### DIFF
--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, Response, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile, status
 from sqlmodel import Session
 
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
-from ..services.files import handle_upload, list_documents
+from ..services.files import delete_document, handle_upload, list_documents
 
 router = APIRouter(prefix="/api", tags=["files"])
 
@@ -35,3 +35,22 @@ async def get_files(*, session: Session = Depends(get_session)) -> list[Document
     """Return the list of uploaded documents."""
 
     return list_documents(session=session)
+
+
+@router.delete("/files/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_file(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    """Delete a stored document and its associated artifacts."""
+
+    removed = delete_document(
+        session=session, document_id=document_id, settings=settings
+    )
+    if not removed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/services/files.py
+++ b/backend/services/files.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import hashlib
 import re
 import secrets
+import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Tuple
 
 from fastapi import HTTPException, UploadFile, status
 from sqlalchemy import desc
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from ..config import Settings
 from ..models import Document
+from ..models.spec_record import SpecAuditEntry, SpecRecord
 
 CHUNK_SIZE = 1024 * 1024  # 1MB
 
@@ -105,3 +107,36 @@ def list_documents(*, session: Session) -> list[Document]:
         desc(Document.__table__.c.uploaded_at)  # type: ignore[attr-defined]
     )
     return list(session.exec(statement))
+
+
+def delete_document(
+    *, session: Session, document_id: int, settings: Settings
+) -> bool:
+    """Remove a stored document and its related artifacts.
+
+    Returns ``True`` if the document existed and was removed, otherwise ``False``.
+    """
+
+    document = session.get(Document, document_id)
+    if document is None:
+        return False
+
+    session.exec(
+        delete(SpecAuditEntry).where(SpecAuditEntry.document_id == document_id)
+    )
+    session.exec(delete(SpecRecord).where(SpecRecord.document_id == document_id))
+    session.delete(document)
+    session.commit()
+
+    document_dir = settings.upload_dir / str(document_id)
+    shutil.rmtree(document_dir, ignore_errors=True)
+
+    export_dir = settings.export_dir
+    for pattern in (f"spec-{document_id}-*", f"spec-{document_id}.*"):
+        for path in export_dir.glob(pattern):
+            try:
+                path.unlink()
+            except FileNotFoundError:  # pragma: no cover - race condition guard
+                continue
+
+    return True

--- a/tests/test_frontend_api_wiring.py
+++ b/tests/test_frontend_api_wiring.py
@@ -1,0 +1,33 @@
+"""Ensure frontend API helpers map to available backend routes."""
+
+from __future__ import annotations
+
+from backend.main import app
+
+
+EXPECTED_FRONTEND_ROUTES = {
+    ("GET", "/api/files"),
+    ("POST", "/api/upload"),
+    ("DELETE", "/api/files/{document_id}"),
+    ("POST", "/api/parse/{document_id}"),
+    ("POST", "/api/headers/{document_id}"),
+    ("POST", "/api/specs/extract/{document_id}"),
+    ("POST", "/api/specs/compare/{document_id}"),
+    ("GET", "/api/specs/{document_id}"),
+    ("POST", "/api/specs/{document_id}/approve"),
+    ("GET", "/api/specs/{document_id}/export"),
+}
+
+
+def test_frontend_functions_have_matching_routes() -> None:
+    """The backend should expose every route used by the frontend API module."""
+
+    observed_routes = set()
+    for route in app.routes:
+        if not getattr(route, "methods", None):
+            continue
+        for method in route.methods:
+            observed_routes.add((method, route.path))
+
+    missing = EXPECTED_FRONTEND_ROUTES - observed_routes
+    assert not missing, f"Frontend API routes missing from backend: {sorted(missing)}"

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -69,3 +69,32 @@ def test_large_file_is_rejected(client: TestClient) -> None:
 
     upload_dir = Path(os.environ["UPLOAD_DIR"])
     assert not any(upload_dir.rglob("large.pdf"))
+
+
+def test_delete_document_removes_artifacts(client: TestClient) -> None:
+    """Deleting a document should remove database records and stored files."""
+
+    response = _post_pdf(client, PDF_BYTES, filename="delete-me.pdf")
+    assert response.status_code == 201
+    payload = response.json()
+    document_id = payload["id"]
+
+    upload_path = (
+        Path(os.environ["UPLOAD_DIR"]) / str(document_id) / payload["filename"]
+    )
+    assert upload_path.exists()
+
+    delete_response = client.delete(f"/api/files/{document_id}")
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
+
+    assert not upload_path.exists()
+
+    list_response = client.get("/api/files")
+    assert list_response.status_code == 200
+    remaining_ids = {item["id"] for item in list_response.json()}
+    assert document_id not in remaining_ids
+
+    second_delete = client.delete(f"/api/files/{document_id}")
+    assert second_delete.status_code == 404
+    assert second_delete.json()["detail"] == "Document not found"


### PR DESCRIPTION
## Summary
- implement a DELETE /api/files/{document_id} endpoint that removes stored documents and related artifacts
- add service logic to clean up uploads, spec records, and exports when deleting documents
- expand the test suite with frontend wiring validation and deletion coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe0ef09db4832484f8c16a2b603b98