### PR TITLE
Add configurable CORS regex with local network default

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -32,6 +32,19 @@ def _database_url_default() -> str:
     )
 
 
+def _cors_origin_regex_default() -> str | None:
+    """Return the default CORS origin regex allowing local network hosts."""
+
+    raw = os.getenv(
+        "CORS_ALLOW_ORIGIN_REGEX",
+        r"http://(?:localhost|127\.0\.0\.1|0\.0\.0\.0|(?:\d{1,3}\.){3}\d)(?::\d{1,5})?",
+    )
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
 class Settings(BaseModel):
     """Application configuration loaded from environment variables."""
 
@@ -59,6 +72,7 @@ class Settings(BaseModel):
             if origin.strip()
         )
     )
+    cors_allow_origin_regex: str | None = Field(default_factory=_cors_origin_regex_default)
     host: str = Field(default_factory=lambda: os.getenv("HOST", "0.0.0.0"))
     port: int = Field(default_factory=lambda: int(os.getenv("PORT", "7600")))
     log_level: str = Field(default_factory=lambda: os.getenv("LOG_LEVEL", "info"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,7 @@ app.add_middleware(
     allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_origin_regex=settings.cors_allow_origin_regex,
 )
 app.include_router(api_router)
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,26 @@
+"""Tests for backend configuration helpers."""
+
+from __future__ import annotations
+
+from backend.config import Settings
+
+
+def test_default_cors_regex_allows_local_network(monkeypatch):
+    """The default regex should allow localhost and local-network origins."""
+
+    monkeypatch.delenv("CORS_ALLOW_ORIGIN_REGEX", raising=False)
+    settings = Settings()
+
+    assert (
+        settings.cors_allow_origin_regex
+        == r"http://(?:localhost|127\.0\.0\.1|0\.0\.0\.0|(?:\d{1,3}\.){3}\d)(?::\d{1,5})?"
+    )
+
+
+def test_blank_cors_regex_disables_pattern(monkeypatch):
+    """Blank regex env vars should be treated as disabled (None)."""
+
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN_REGEX", "   ")
+    settings = Settings()
+
+    assert settings.cors_allow_origin_regex is None


### PR DESCRIPTION
## Summary
- add a configurable CORS origin regex with a permissive local-network default
- use the configured regex when initialising the FastAPI CORS middleware
- cover the new configuration behaviour with targeted settings tests

## Testing
- pytest backend/tests/test_config.py backend/tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68fe1d7bf6788324ba0437b00696ff3f