### PR TITLE
Add full-document header extraction pipeline and UI viewer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -33,6 +33,11 @@ MINERU_FALLBACK=true
 # Header extraction behaviour
 HEADERS_SUPPRESS_TOC=true
 HEADERS_SUPPRESS_RUNNING=true
+HEADERS_MODE=llm_full
+HEADERS_LLM_MODEL=anthropic/claude-3.5-sonnet
+HEADERS_LLM_MAX_INPUT_TOKENS=120000
+HEADERS_LLM_TIMEOUT_S=120
+HEADERS_LLM_CACHE_DIR=./.cache/headers
 
 # Specification extraction tuning
 SPEC_TERMS_DIR=backend/resources/terms

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ SimpleSpecs parses engineering specification PDFs and structures the extracted d
    The helper scripts honour `HOST`, `PORT`, and `LOG_LEVEL` if they are set in your `.env` file.
 5. Visit `http://localhost:8000/api/health` to verify the service responds with `{ "ok": true }`.
 
+### Header extraction configuration
+
+SimpleSpecs can run header detection heuristically or send the full document text to OpenRouter for a high-fidelity outline. Configure behaviour via the following environment variables (also available in `.env.template`):
+
+- `HEADERS_MODE`: set to `llm_full` to enable the OpenRouter pipeline or `native` to force heuristic extraction.
+- `HEADERS_LLM_MODEL`: fully qualified OpenRouter model identifier (default `anthropic/claude-3.5-sonnet`).
+- `HEADERS_LLM_MAX_INPUT_TOKENS`: approximate token budget per request chunk (default `120000`).
+- `HEADERS_LLM_TIMEOUT_S`: request timeout in seconds (default `120`).
+- `HEADERS_LLM_CACHE_DIR`: on-disk cache for previously processed documents.
+
+The pipeline requires `OPENROUTER_API_KEY` and will fall back to the heuristic outline if a call fails. Cached responses avoid repeated model invocations for unchanged documents.
+
 ## Running with Docker
 1. Copy the production environment example and update secrets:
    ```bash

--- a/backend/config.py
+++ b/backend/config.py
@@ -88,6 +88,27 @@ class Settings(BaseModel):
     headers_suppress_running: bool = Field(
         default_factory=lambda: _env_flag("HEADERS_SUPPRESS_RUNNING", True)
     )
+    headers_mode: str = Field(
+        default_factory=lambda: os.getenv("HEADERS_MODE", "llm_full")
+    )
+    headers_llm_model: str = Field(
+        default_factory=lambda: os.getenv(
+            "HEADERS_LLM_MODEL", "anthropic/claude-3.5-sonnet"
+        )
+    )
+    headers_llm_max_input_tokens: int = Field(
+        default_factory=lambda: int(
+            os.getenv("HEADERS_LLM_MAX_INPUT_TOKENS", "120000")
+        )
+    )
+    headers_llm_timeout_s: int = Field(
+        default_factory=lambda: int(os.getenv("HEADERS_LLM_TIMEOUT_S", "120"))
+    )
+    headers_llm_cache_dir: Path = Field(
+        default_factory=lambda: Path(
+            os.getenv("HEADERS_LLM_CACHE_DIR", "./.cache/headers")
+        )
+    )
     mineru_fallback: bool = Field(
         default_factory=lambda: _env_flag("MINERU_FALLBACK", False)
     )
@@ -155,6 +176,12 @@ class Settings(BaseModel):
     @field_validator("export_dir", mode="after")
     @classmethod
     def _ensure_export_dir(cls, value: Path) -> Path:
+        value.mkdir(parents=True, exist_ok=True)
+        return value
+
+    @field_validator("headers_llm_cache_dir", mode="after")
+    @classmethod
+    def _ensure_headers_cache_dir(cls, value: Path) -> Path:
         value.mkdir(parents=True, exist_ok=True)
         return value
 

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
 from sqlmodel import Session
 
@@ -14,8 +15,11 @@ from ..services.headers import (
     HeaderNode,
     HeadersLLMClient,
     extract_headers,
+    flatten_outline,
 )
+from ..services.headers_orchestrator import extract_headers_and_chunks
 from ..services.pdf_native import parse_pdf
+from ..services.simpleheaders_state import SimpleHeadersState
 
 router = APIRouter(prefix="/api", tags=["headers"])
 
@@ -41,6 +45,29 @@ class HeaderNodePayload(BaseModel):
 HeaderNodePayload.model_rebuild()
 
 
+class SimpleHeaderPayload(BaseModel):
+    """Flat header entry mapped to precise line indices."""
+
+    text: str
+    number: str | None = None
+    level: int
+    page: int
+    line_idx: int
+    global_idx: int
+
+
+class SectionPayload(BaseModel):
+    """Chunk describing the line range belonging to a header."""
+
+    header_text: str
+    header_number: str | None = None
+    level: int
+    start_global_idx: int
+    end_global_idx: int
+    start_page: int
+    end_page: int
+
+
 class HeadersResponse(BaseModel):
     """API response structure for header extraction."""
 
@@ -48,16 +75,28 @@ class HeadersResponse(BaseModel):
     source: str
     fenced_text: str
     outline: list[HeaderNodePayload]
+    simpleheaders: list[SimpleHeaderPayload] = Field(default_factory=list)
+    sections: list[SectionPayload] = Field(default_factory=list)
+    mode: str | None = None
 
     @classmethod
     def from_result(
-        cls, document_id: int, result: HeaderExtractionResult
+        cls,
+        document_id: int,
+        result: HeaderExtractionResult,
+        *,
+        simpleheaders: list[SimpleHeaderPayload] | None = None,
+        sections: list[SectionPayload] | None = None,
+        mode: str | None = None,
     ) -> "HeadersResponse":
         return cls(
             document_id=document_id,
             source=result.source,
             fenced_text=result.fenced_text,
             outline=[HeaderNodePayload.from_node(node) for node in result.outline],
+            simpleheaders=simpleheaders or [],
+            sections=sections or [],
+            mode=mode,
         )
 
 
@@ -89,10 +128,93 @@ async def generate_headers(
             status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
         )
 
+    document_bytes = document_path.read_bytes()
+
     parse_result = parse_pdf(document_path, settings=settings)
     llm_client = HeadersLLMClient(settings)
     result = extract_headers(parse_result, settings=settings, llm_client=llm_client)
-    return HeadersResponse.from_result(doc_id, result)
+
+    native_flat = flatten_outline(result.outline)
+    orchestrated = await extract_headers_and_chunks(
+        document_bytes,
+        settings=settings,
+        native_headers=native_flat,
+        metadata={"filename": document.filename},
+    )
+
+    SimpleHeadersState.set(doc_id, orchestrated["doc_hash"], orchestrated["lines"])
+
+    simpleheaders_payload = [
+        SimpleHeaderPayload(
+            text=item.get("text", ""),
+            number=item.get("number"),
+            level=int(item.get("level", 1)),
+            page=int(item.get("page", 0)),
+            line_idx=int(item.get("line_idx", 0)),
+            global_idx=int(item.get("global_idx", 0)),
+        )
+        for item in orchestrated.get("headers", [])
+    ]
+
+    sections_payload = [
+        SectionPayload(
+            header_text=section.get("header_text", ""),
+            header_number=section.get("header_number"),
+            level=int(section.get("level", 1)),
+            start_global_idx=int(section.get("start_global_idx", 0)),
+            end_global_idx=int(section.get("end_global_idx", 0)),
+            start_page=int(section.get("start_page", 0)),
+            end_page=int(section.get("end_page", 0)),
+        )
+        for section in orchestrated.get("sections", [])
+    ]
+
+    return HeadersResponse.from_result(
+        doc_id,
+        result,
+        simpleheaders=simpleheaders_payload,
+        sections=sections_payload,
+        mode=orchestrated.get("mode"),
+    )
+
+
+@router.get("/headers/{document_id}/section-text", response_class=PlainTextResponse)
+async def section_text(
+    document_id: int,
+    start: int,
+    end: int,
+    *,
+    session: Session = Depends(get_session),
+) -> PlainTextResponse:
+    """Return the plain text for a section bounded by global indices."""
+
+    if start < 0 or end < 0 or end < start:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid section bounds",
+        )
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    cached = SimpleHeadersState.get(document_id)
+    if cached is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No section data available for this document",
+        )
+
+    _, lines = cached
+    text_lines = [
+        str(line.get("text", ""))
+        for line in lines
+        if start <= int(line.get("global_idx", -1)) <= end
+    ]
+
+    return PlainTextResponse("\n".join(text_lines))
 
 
 __all__ = ["router"]

--- a/backend/services/fulltext.py
+++ b/backend/services/fulltext.py
@@ -1,0 +1,14 @@
+"""Helpers for rendering full document text from parsed line metrics."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def lines_to_fulltext(lines: Iterable[dict]) -> str:
+    """Join lines into a newline-delimited string preserving order."""
+
+    return "\n".join(str(line.get("text", "")) for line in lines)
+
+
+__all__ = ["lines_to_fulltext"]

--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -1,0 +1,81 @@
+"""Locate LLM derived headers within parsed line metrics."""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from typing import Dict, Iterable, List, Sequence
+
+
+def _normalise(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip()).lower()
+
+
+def locate_headers_in_lines(
+    headers: Sequence[Dict],
+    lines: Sequence[Dict],
+    *,
+    excluded_pages: Iterable[int] = (),
+    similarity_threshold: float = 0.88,
+) -> List[Dict]:
+    """Return located headers with page and line metadata."""
+
+    excluded = set(excluded_pages)
+    usable: list[dict] = []
+    for line in lines:
+        if line.get("page") in excluded:
+            continue
+        if line.get("is_running"):
+            continue
+        copy = dict(line)
+        copy["_norm"] = _normalise(str(line.get("text", "")))
+        usable.append(copy)
+
+    located: list[Dict] = []
+
+    for header in headers:
+        target = _normalise(str(header.get("text", "")))
+        if not target:
+            continue
+        number = (header.get("number") or "").strip()
+        candidates: list[dict] = []
+
+        for line in usable:
+            text = str(line.get("text", ""))
+            if number:
+                if re.match(rf"^\s*{re.escape(number)}(?:\b|[.)\-\s])", text):
+                    candidates.append(line)
+                    continue
+            norm = line.get("_norm", "")
+            if norm == target or target in norm:
+                candidates.append(line)
+
+        if not candidates:
+            for line in usable:
+                norm = line.get("_norm", "")
+                if not norm:
+                    continue
+                similarity = SequenceMatcher(a=target, b=norm).ratio()
+                if similarity >= similarity_threshold:
+                    candidates.append(line)
+
+        if not candidates:
+            continue
+
+        best = max(candidates, key=lambda item: item.get("global_idx", -1))
+        located.append(
+            {
+                "text": str(header.get("text", "")).strip(),
+                "number": number or None,
+                "level": int(header.get("level") or 1),
+                "page": int(best.get("page") or 0),
+                "line_idx": int(best.get("line_idx") or 0),
+                "global_idx": int(best.get("global_idx") or 0),
+            }
+        )
+
+    located.sort(key=lambda item: item.get("global_idx", 0))
+    return located
+
+
+__all__ = ["locate_headers_in_lines"]

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -293,6 +293,28 @@ def _outline_to_fenced_text(nodes: Sequence[HeaderNode]) -> str:
     return "\n".join(lines)
 
 
+def flatten_outline(nodes: Sequence[HeaderNode]) -> list[dict[str, object]]:
+    """Flatten a header outline into a list suitable for LLM alignment."""
+
+    flattened: list[dict[str, object]] = []
+
+    def _walk(node: HeaderNode, depth: int) -> None:
+        flattened.append(
+            {
+                "text": node.title,
+                "number": node.numbering or None,
+                "level": max(1, depth),
+            }
+        )
+        for child in node.children:
+            _walk(child, depth + 1)
+
+    for root in nodes:
+        _walk(root, 1)
+
+    return flattened
+
+
 def _normalise_text(text: str) -> str:
     """Normalise whitespace within a block."""
 
@@ -461,4 +483,5 @@ __all__ = [
     "HeaderNode",
     "HeadersLLMClient",
     "extract_headers",
+    "flatten_outline",
 ]

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -1,0 +1,76 @@
+"""Coordinator for LLM-backed and native header extraction flows."""
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping, Sequence
+
+from backend.config import Settings
+
+from .header_locator import locate_headers_in_lines
+from .pdf_headers_llm_full import get_headers_llm_full
+from .pdf_native import collect_line_metrics
+from .section_chunking import single_chunks_from_headers
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def extract_headers_and_chunks(
+    document_bytes: bytes,
+    *,
+    settings: Settings,
+    native_headers: Sequence[Mapping[str, object]] | None = None,
+    metadata: Mapping[str, object] | None = None,
+) -> dict:
+    """Return located headers and section ranges for the provided document."""
+
+    lines, excluded_pages, doc_hash = collect_line_metrics(
+        document_bytes,
+        metadata,
+        suppress_toc=settings.headers_suppress_toc,
+        suppress_running=settings.headers_suppress_running,
+    )
+
+    located_headers: list[dict] = []
+    mode_used = "native"
+
+    if settings.headers_mode.lower() == "llm_full":
+        try:
+            llm_headers = await get_headers_llm_full(
+                lines,
+                doc_hash,
+                settings=settings,
+                excluded_pages=excluded_pages,
+            )
+            located_headers = locate_headers_in_lines(
+                llm_headers,
+                lines,
+                excluded_pages=excluded_pages,
+            )
+            if located_headers:
+                mode_used = "llm_full"
+        except Exception as exc:  # pragma: no cover - network/runtime dependent
+            LOGGER.warning("LLM header extraction failed: %s", exc)
+            located_headers = []
+
+    if not located_headers and native_headers:
+        located_headers = locate_headers_in_lines(
+            native_headers,
+            lines,
+            excluded_pages=excluded_pages,
+        )
+        mode_used = "native"
+
+    sections = single_chunks_from_headers(located_headers, lines)
+
+    return {
+        "headers": located_headers,
+        "sections": sections,
+        "mode": mode_used,
+        "lines": lines,
+        "doc_hash": doc_hash,
+        "excluded_pages": sorted(excluded_pages),
+    }
+
+
+__all__ = ["extract_headers_and_chunks"]

--- a/backend/services/openrouter_client.py
+++ b/backend/services/openrouter_client.py
@@ -1,0 +1,84 @@
+"""Thin OpenRouter chat client with hardened parameter handling."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Sequence
+
+import httpx
+
+BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def _extract_max_tokens(params: Mapping[str, Any] | None) -> int | None:
+    """Return an integer max token value from the provided params mapping."""
+
+    if not params:
+        return None
+    for key in ("max_tokens", "max_new_tokens"):
+        value = params.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+async def openrouter_chat(
+    *,
+    api_key: str,
+    model: str,
+    messages: Sequence[Mapping[str, str]],
+    timeout: float,
+    params: Mapping[str, Any] | None = None,
+) -> str:
+    """Send a chat completion request to OpenRouter and return the response text."""
+
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY not set")
+
+    headers: MutableMapping[str, str] = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    bigger: MutableMapping[str, Any] = dict(params or {})
+    bigger["max_tokens"] = max(_extract_max_tokens(params) or 2048, 4096)
+
+    if params:
+        referer = params.get("http_referer") or params.get("HTTP-Referer")
+        if isinstance(referer, str) and referer.strip():
+            headers["HTTP-Referer"] = referer.strip()
+        x_title = params.get("x_title") or params.get("X-Title")
+        if isinstance(x_title, str) and x_title.strip():
+            headers["X-Title"] = x_title.strip()
+
+    payload_params = {
+        key: value
+        for key, value in bigger.items()
+        if key not in {"http_referer", "HTTP-Referer", "x_title", "X-Title"}
+        and value is not None
+    }
+
+    payload = {
+        "model": model,
+        "messages": [dict(message) for message in messages],
+        **payload_params,
+    }
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(BASE_URL, headers=headers, json=payload)
+        response.raise_for_status()
+        data = response.json()
+        choices = data.get("choices") or []
+        if not choices:
+            raise RuntimeError("OpenRouter response missing choices array")
+        message = choices[0].get("message") or {}
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError("OpenRouter response missing message content")
+        return content
+
+
+__all__ = ["openrouter_chat"]

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -1,0 +1,159 @@
+"""LLM-backed header extraction pipeline using full-document prompts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+from backend.config import Settings
+
+from .openrouter_client import openrouter_chat
+from .token_chunk import split_by_token_limit
+
+FENCE_START = "-----BEGIN SIMPLEHEADERS JSON-----"
+FENCE_END = "-----END SIMPLEHEADERS JSON-----"
+
+
+def _cache_path(cache_dir: Path, doc_hash: str) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{doc_hash}.simpleheaders.json"
+
+
+def _extract_fenced_json(content: str) -> Dict:
+    match = re.search(
+        re.escape(FENCE_START) + r"(.*?)" + re.escape(FENCE_END), content, re.S
+    )
+    if not match:
+        raise ValueError("LLM response missing fenced SIMPLEHEADERS JSON")
+    payload = match.group(1)
+    return json.loads(payload)
+
+
+def _build_text_blocks(
+    lines: Sequence[Dict], excluded_pages: Iterable[int]
+) -> List[str]:
+    excluded = set(int(page) for page in excluded_pages)
+    filtered = [
+        line
+        for line in lines
+        if line.get("page") not in excluded and not line.get("is_running")
+    ]
+    if not filtered:
+        return [""]
+
+    blocks: list[str] = []
+    current_page = filtered[0].get("page")
+    buffer: list[str] = []
+
+    for line in filtered:
+        page = line.get("page")
+        if page != current_page:
+            blocks.append("\n".join(buffer))
+            buffer = []
+            current_page = page
+        buffer.append(str(line.get("text", "")))
+
+    if buffer:
+        blocks.append("\n".join(buffer))
+
+    return blocks
+
+
+async def get_headers_llm_full(
+    lines: Sequence[Dict],
+    doc_hash: str,
+    *,
+    settings: Settings,
+    excluded_pages: Iterable[int] = (),
+) -> List[Dict]:
+    """Return LLM extracted headers for a document."""
+
+    cache_file = _cache_path(settings.headers_llm_cache_dir, doc_hash)
+    if cache_file.exists():
+        cached = json.loads(cache_file.read_text(encoding="utf-8"))
+        headers = cached.get("headers")
+        if isinstance(headers, list):
+            return headers  # type: ignore[return-value]
+
+    text_blocks = _build_text_blocks(lines, excluded_pages)
+    parts = split_by_token_limit(
+        text_blocks, settings.headers_llm_max_input_tokens
+    )
+    if not parts:
+        parts = ["\n".join(text_blocks)]
+
+    client_params: dict[str, str] = {}
+    if settings.openrouter_http_referer:
+        client_params["http_referer"] = settings.openrouter_http_referer
+    if settings.openrouter_title:
+        client_params["x_title"] = settings.openrouter_title
+
+    merged: list[Dict] = []
+    total_parts = len(parts)
+
+    for index, part in enumerate(parts, start=1):
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a technical document structure expert. Identify headings and "
+                    "their nesting levels from the full document text."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Goal: Return every heading and subheading that appears in the MAIN BODY of the document.\n"
+                    "Hard rules:\n"
+                    "- EXCLUDE any content in a Table of Contents, Index, or Glossary.\n"
+                    "- Preserve the original document order.\n"
+                    "- If a heading has a visible numbering label (e.g., \"1\", \"1.2\", \"A.3.4\"), include it as \"number\"; otherwise set \"number\": null.\n"
+                    "- Assign a positive integer \"level\" (1 = top-level).\n"
+                    "- Do NOT invent headings; only list those present.\n"
+                    "- Output EXACTLY the fenced JSON:\n\n"
+                    f"{FENCE_START}\n"
+                    "{ \"headers\": [ { \"text\": \"...\", \"number\": \"...\" | null, \"level\": 1 }, ... ] }\n"
+                    f"{FENCE_END}\n\n"
+                    f"Document part {index}/{total_parts}:\n<BEGIN DOCUMENT>\n{part}\n<END DOCUMENT>\n"
+                ),
+            },
+        ]
+
+        content = await openrouter_chat(
+            api_key=settings.openrouter_api_key or "",
+            model=settings.headers_llm_model,
+            messages=messages,
+            timeout=settings.headers_llm_timeout_s,
+            params=client_params,
+        )
+        data = _extract_fenced_json(content)
+        merged.extend(data.get("headers", []))
+
+    deduped: list[Dict] = []
+    seen: set[tuple[str, str]] = set()
+    for header in merged:
+        text = str(header.get("text", "")).strip()
+        number = (header.get("number") or "").strip()
+        key = (text.lower(), number.lower())
+        if key in seen or not text:
+            continue
+        seen.add(key)
+        deduped.append(
+            {
+                "text": text,
+                "number": number or None,
+                "level": int(header.get("level") or 1),
+            }
+        )
+
+    cache_file.write_text(
+        json.dumps({"headers": deduped}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return deduped
+
+
+__all__ = ["get_headers_llm_full", "FENCE_START", "FENCE_END"]

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import hashlib
 
 import logging
 import re
@@ -351,6 +352,140 @@ def _is_toc_page(page: ParsedPage) -> bool:
         1 for block in page.blocks if re.search(r"\.{2,}\s*\d+$", block.text)
     )
     return dotted_entries >= max(4, len(page.blocks) // 2)
+
+
+_INDEX_ENTRY_RE = re.compile(
+    r"^[A-Z][A-Za-z0-9\s'’\-(),/]+\s+\.{2,}\s*\d+(?:\s*,\s*\d+)*$"
+)
+
+
+def _is_toc_like(lines: list[str], page_number: int) -> bool:
+    if page_number > 4 or not lines:
+        return False
+    blob = " ".join(line.lower() for line in lines)
+    if "table of contents" in blob or blob.strip().startswith("contents"):
+        return True
+    dotted_entries = sum(1 for line in lines if re.search(r"\.{2,}\s*\d+$", line))
+    return dotted_entries >= max(4, len(lines) // 2)
+
+
+def _is_index_like(lines: list[str]) -> bool:
+    cleaned = [line.strip() for line in lines if line.strip()]
+    if not cleaned:
+        return False
+    first = cleaned[0].lower()
+    if first in {"index", "glossary"}:
+        return True
+    hits = sum(1 for line in cleaned if _INDEX_ENTRY_RE.match(line))
+    return hits >= max(6, len(cleaned) // 2)
+
+
+def collect_line_metrics(
+    document_bytes: bytes,
+    metadata: dict | None,
+    *,
+    suppress_toc: bool = True,
+    suppress_running: bool = True,
+) -> tuple[list[dict], set[int], str]:
+    """Return flattened line metrics for the provided PDF bytes."""
+
+    doc_hash = hashlib.sha256(document_bytes).hexdigest()
+    excluded_pages: set[int] = set()
+    pages: list[dict] = []
+    header_counter: Counter[str] = Counter()
+    footer_counter: Counter[str] = Counter()
+
+    with fitz.open(stream=document_bytes, filetype="pdf") as pdf_document:
+        for page in pdf_document:
+            page_number = int(page.number)
+            text_dict = page.get_text("dict") or {}
+            raw_blocks = text_dict.get("blocks") or []
+            page_lines: list[dict] = []
+
+            for block in raw_blocks:
+                if block.get("type", 0) != 0:
+                    continue
+                for line in block.get("lines", []):
+                    spans = line.get("spans", [])
+                    text = "".join(span.get("text", "") for span in spans).replace("\r", "")
+                    if not text or not text.strip():
+                        continue
+                    bbox = line.get("bbox") or block.get("bbox")
+                    if not bbox:
+                        continue
+                    left, top, right, bottom = (float(value) for value in bbox)
+                    sizes = [float(span.get("size", 0.0)) for span in spans if span.get("size")]
+                    size = sum(sizes) / len(sizes) if sizes else 0.0
+                    fonts = [str(span.get("font", "")) for span in spans if span.get("font")]
+                    bold = any("bold" in font.lower() for font in fonts)
+                    is_caps = text.strip().isupper()
+                    entry = {
+                        "global_idx": -1,
+                        "page": page_number,
+                        "line_idx": len(page_lines),
+                        "text": text,
+                        "size": size,
+                        "bold": bold,
+                        "is_caps": is_caps,
+                        "left": left,
+                        "right": right,
+                        "top": top,
+                        "bottom": bottom,
+                        "is_toc": False,
+                        "is_index": False,
+                        "is_running": False,
+                    }
+                    page_lines.append(entry)
+
+            height = float(page.rect.height)
+            top_threshold = height * 0.18
+            bottom_threshold = height * 0.85
+            for entry in page_lines:
+                normalised = _normalise_text(entry.get("text", ""))
+                if not normalised:
+                    continue
+                if entry["top"] <= top_threshold:
+                    header_counter[normalised] += 1
+                elif entry["bottom"] >= bottom_threshold:
+                    footer_counter[normalised] += 1
+
+            pages.append(
+                {
+                    "number": page_number,
+                    "height": height,
+                    "lines": page_lines,
+                }
+            )
+
+    running_markers: set[str] = set()
+    if suppress_running:
+        running_markers = {
+            text for text, count in header_counter.items() if count > 1
+        } | {text for text, count in footer_counter.items() if count > 1}
+
+    all_lines: list[dict] = []
+    global_idx = 0
+
+    for page in pages:
+        page_number = page["number"]
+        page_lines = page["lines"]
+        texts = [line.get("text", "") for line in page_lines]
+        is_toc_page = _is_toc_like(texts, page_number)
+        is_index_page = _is_index_like(texts)
+        if suppress_toc and (is_toc_page or is_index_page):
+            excluded_pages.add(page_number)
+
+        for entry in page_lines:
+            normalised = _normalise_text(entry.get("text", ""))
+            if suppress_running and normalised in running_markers:
+                entry["is_running"] = True
+            entry["is_toc"] = is_toc_page
+            entry["is_index"] = is_index_page
+            entry["global_idx"] = global_idx
+            all_lines.append(entry)
+            global_idx += 1
+
+    return all_lines, excluded_pages, doc_hash
 
 
 def _detect_tables(

--- a/backend/services/section_chunking.py
+++ b/backend/services/section_chunking.py
@@ -1,0 +1,50 @@
+"""Helpers for constructing section chunks from located headers."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+
+def single_chunks_from_headers(
+    headers: Sequence[Dict], lines: Sequence[Dict]
+) -> List[Dict]:
+    """Return contiguous line ranges for each header."""
+
+    if not headers:
+        return []
+
+    index_by_global = {int(line.get("global_idx", -1)): idx for idx, line in enumerate(lines)}
+    chunks: list[Dict] = []
+
+    for position, header in enumerate(headers):
+        current_idx = index_by_global.get(int(header.get("global_idx", -1)))
+        if current_idx is None:
+            continue
+        if position < len(headers) - 1:
+            next_header = headers[position + 1]
+            next_idx = index_by_global.get(int(next_header.get("global_idx", -1)), len(lines))
+            end_index = max(current_idx, next_idx - 1)
+        else:
+            end_index = len(lines) - 1
+
+        if end_index < current_idx:
+            continue
+
+        start_line = lines[current_idx]
+        end_line = lines[end_index]
+        chunks.append(
+            {
+                "header_text": header.get("text"),
+                "header_number": header.get("number"),
+                "level": int(header.get("level") or 1),
+                "start_global_idx": int(start_line.get("global_idx", 0)),
+                "end_global_idx": int(end_line.get("global_idx", 0)),
+                "start_page": int(start_line.get("page", 0)),
+                "end_page": int(end_line.get("page", 0)),
+            }
+        )
+
+    return chunks
+
+
+__all__ = ["single_chunks_from_headers"]

--- a/backend/services/simpleheaders_state.py
+++ b/backend/services/simpleheaders_state.py
@@ -1,0 +1,31 @@
+"""In-memory cache for simple header line metrics."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Iterable, Tuple
+
+
+class SimpleHeadersState:
+    """Store recently computed line metrics for section retrieval."""
+
+    _max_entries = 6
+    _store: "OrderedDict[int, Tuple[str, list[dict]]]" = OrderedDict()
+
+    @classmethod
+    def set(cls, document_id: int, doc_hash: str, lines: Iterable[dict]) -> None:
+        cls._store.pop(document_id, None)
+        cls._store[document_id] = (doc_hash, list(lines))
+        while len(cls._store) > cls._max_entries:
+            cls._store.popitem(last=False)
+
+    @classmethod
+    def get(cls, document_id: int) -> tuple[str, list[dict]] | None:
+        value = cls._store.get(document_id)
+        if value is None:
+            return None
+        cls._store.move_to_end(document_id)
+        return value
+
+
+__all__ = ["SimpleHeadersState"]

--- a/backend/services/token_chunk.py
+++ b/backend/services/token_chunk.py
@@ -1,0 +1,43 @@
+"""Utility helpers for rough token counting and chunking."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, List
+
+
+def rough_token_count(text: str) -> int:
+    """Return a rough token count using a conservative 4 char/token estimate."""
+
+    if not text:
+        return 1
+    return max(1, math.ceil(len(text) / 4))
+
+
+def split_by_token_limit(blocks: Iterable[str], limit_tokens: int) -> List[str]:
+    """Split a sequence of text blocks into groups under the token limit."""
+
+    if limit_tokens <= 0:
+        raise ValueError("limit_tokens must be a positive integer")
+
+    groups: list[list[str]] = []
+    current: list[str] = []
+    current_tokens = 0
+
+    for block in blocks:
+        text = block or ""
+        tokens = rough_token_count(text)
+        if current and current_tokens + tokens > limit_tokens:
+            groups.append(current)
+            current = []
+            current_tokens = 0
+        current.append(text)
+        current_tokens += tokens
+
+    if current:
+        groups.append(current)
+
+    return ["\n".join(group) for group in groups]
+
+
+__all__ = ["rough_token_count", "split_by_token_limit"]

--- a/backend/tests/test_llm_full_headers.py
+++ b/backend/tests/test_llm_full_headers.py
@@ -1,0 +1,128 @@
+import asyncio
+import json
+
+from backend.config import Settings
+from backend.services.header_locator import locate_headers_in_lines
+from backend.services.pdf_headers_llm_full import get_headers_llm_full
+from backend.services.section_chunking import single_chunks_from_headers
+
+
+def test_locate_headers_prefers_last_match_and_skips_excluded() -> None:
+    headers = [{"text": "Overview", "number": None, "level": 1}]
+    lines = [
+        {
+            "text": "Overview",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+        },
+        {
+            "text": "Overview",
+            "page": 1,
+            "line_idx": 5,
+            "global_idx": 5,
+            "is_running": True,
+        },
+        {
+            "text": "Overview",
+            "page": 2,
+            "line_idx": 3,
+            "global_idx": 8,
+            "is_running": False,
+        },
+    ]
+
+    located = locate_headers_in_lines(
+        headers,
+        lines,
+        excluded_pages={0},
+    )
+
+    assert len(located) == 1
+    assert located[0]["global_idx"] == 8
+    assert located[0]["page"] == 2
+
+
+def test_single_chunks_from_headers_produces_ranges() -> None:
+    headers = [
+        {"text": "Intro", "number": "1", "level": 1, "global_idx": 0},
+        {"text": "Details", "number": "1.1", "level": 2, "global_idx": 2},
+    ]
+    lines = [
+        {"global_idx": 0, "page": 0},
+        {"global_idx": 1, "page": 0},
+        {"global_idx": 2, "page": 0},
+        {"global_idx": 3, "page": 1},
+    ]
+
+    chunks = single_chunks_from_headers(headers, lines)
+    assert len(chunks) == 2
+    assert chunks[0]["start_global_idx"] == 0
+    assert chunks[0]["end_global_idx"] == 1
+    assert chunks[1]["start_global_idx"] == 2
+    assert chunks[1]["end_global_idx"] == 3
+
+
+def test_get_headers_llm_full_uses_cache(monkeypatch, tmp_path) -> None:
+    calls = 0
+
+    async def _fake_chat(**kwargs):  # noqa: ANN001 - test stub
+        nonlocal calls
+        calls += 1
+        payload = {
+            "headers": [
+                {"text": "Alpha", "number": None, "level": 1},
+                {"text": "Beta", "number": "1.1", "level": 2},
+            ]
+        }
+        return (
+            "stub\n"
+            "-----BEGIN SIMPLEHEADERS JSON-----\n"
+            f"{json.dumps(payload)}\n"
+            "-----END SIMPLEHEADERS JSON-----"
+        )
+
+    monkeypatch.setattr(
+        "backend.services.pdf_headers_llm_full.openrouter_chat", _fake_chat
+    )
+
+    settings = Settings(
+        upload_dir=tmp_path,
+        headers_llm_cache_dir=tmp_path / "cache",
+        headers_llm_model="test-model",
+        headers_llm_timeout_s=5,
+        openrouter_api_key="sk-test",
+    )
+
+    lines = [
+        {
+            "text": "Alpha",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+        }
+    ]
+
+    async def _run() -> None:
+        headers = await get_headers_llm_full(
+            lines,
+            "hash-value",
+            settings=settings,
+            excluded_pages=set(),
+        )
+
+        assert headers[0]["text"] == "Alpha"
+
+        cached_headers = await get_headers_llm_full(
+            lines,
+            "hash-value",
+            settings=settings,
+            excluded_pages=set(),
+        )
+
+        assert calls == 1
+        assert cached_headers == headers
+
+    asyncio.run(_run())

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -91,6 +91,18 @@ export async function fetchHeaders(documentId) {
   return request(`/headers/${documentId}`, { method: 'POST' });
 }
 
+export async function fetchSectionText(documentId, start, end) {
+  const params = new URLSearchParams({ start: String(start), end: String(end) });
+  const response = await fetch(`${apiBase}/headers/${documentId}/section-text?${params}`);
+  if (!response.ok) {
+    const message = `Section fetch failed (${response.status})`;
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
+  }
+  return response.text();
+}
+
 export async function fetchSpecifications(documentId) {
   return request(`/specs/extract/${documentId}`, { method: 'POST' });
 }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -3,6 +3,7 @@ import {
   uploadDocument,
   parseDocument,
   fetchHeaders,
+  fetchSectionText,
   fetchSpecifications,
   compareSpecifications,
   downloadBlob,
@@ -184,7 +185,10 @@ async function selectDocument(documentId) {
 
     if (headersResult.status === 'fulfilled') {
       state.headers = headersResult.value;
-      renderHeaderOutline(elements.headersContent, state.headers);
+      renderHeaderOutline(elements.headersContent, state.headers, {
+        documentId,
+        fetchSection: fetchSectionText,
+      });
     } else {
       state.headers = null;
       setPanelError(elements.headersContent, headersResult.reason?.message ?? 'Unable to load headers.');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -195,8 +195,12 @@ export function renderParseSummary(container, payload) {
   container.append(grid);
 }
 
-export function renderHeaderOutline(container, payload) {
+export function renderHeaderOutline(container, payload, options = {}) {
   if (!container) return;
+  if (Array.isArray(payload?.simpleheaders) && payload.simpleheaders.length && Array.isArray(payload.sections) && payload.sections.length) {
+    renderSimpleHeaders(container, payload, options);
+    return;
+  }
   if (!payload?.outline?.length) {
     setPanelError(container, 'No headers detected.');
     return;
@@ -208,6 +212,95 @@ export function renderHeaderOutline(container, payload) {
 
   container.innerHTML = '';
   container.append(list);
+}
+
+function renderSimpleHeaders(container, payload, { documentId, fetchSection } = {}) {
+  const headers = Array.isArray(payload.simpleheaders) ? payload.simpleheaders : [];
+  const sections = Array.isArray(payload.sections) ? payload.sections : [];
+  if (!headers.length || !sections.length) {
+    setPanelError(container, 'No headers detected.');
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'simpleheaders';
+
+  const list = document.createElement('div');
+  list.className = 'simpleheaders__list';
+  const viewer = document.createElement('pre');
+  viewer.className = 'simpleheaders__viewer';
+  viewer.textContent = 'Select a section to preview its text.';
+
+  let activeIndex = -1;
+  let requestToken = 0;
+
+  const items = headers.map((header, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'simpleheaders__item';
+    button.dataset.index = String(index);
+    const label = header.number ? `${header.number} ${header.text}` : header.text;
+    button.textContent = label;
+    button.style.paddingLeft = `${Math.max(0, Number(header.level || 1) - 1) * 12}px`;
+    button.title = `Page ${Number(header.page ?? 0) + 1}`;
+    button.addEventListener('click', () => selectIndex(index));
+    list.append(button);
+    return button;
+  });
+
+  async function selectIndex(index) {
+    if (index === activeIndex) return;
+    activeIndex = index;
+    const section = sections[index];
+    items.forEach((item, idx) => {
+      if (idx === index) {
+        item.dataset.active = 'true';
+        item.setAttribute('aria-current', 'true');
+      } else {
+        delete item.dataset.active;
+        item.removeAttribute('aria-current');
+      }
+    });
+
+    if (!section || typeof fetchSection !== 'function' || !documentId) {
+      viewer.textContent = 'Section data unavailable.';
+      return;
+    }
+
+    const token = ++requestToken;
+    viewer.dataset.loading = 'true';
+    viewer.textContent = 'Loading section…';
+
+    try {
+      const text = await fetchSection(
+        documentId,
+        section.start_global_idx,
+        section.end_global_idx,
+      );
+      if (token !== requestToken) {
+        return;
+      }
+      viewer.textContent = text?.trim() ? text : '(Empty section)';
+    } catch (error) {
+      if (token !== requestToken) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Unable to load section.';
+      viewer.textContent = message;
+    } finally {
+      if (token === requestToken) {
+        delete viewer.dataset.loading;
+      }
+    }
+  }
+
+  wrapper.append(list, viewer);
+  container.innerHTML = '';
+  container.append(wrapper);
+
+  if (headers.length) {
+    selectIndex(0);
+  }
 }
 
 function renderTreeNode(node) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -335,6 +335,77 @@ body {
   min-height: 120px;
 }
 
+.simpleheaders {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(200px, 260px) 1fr;
+  align-items: start;
+}
+
+.simpleheaders__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 0.75rem;
+  background: color-mix(in srgb, var(--bg-panel) 92%, CanvasText 8%);
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.simpleheaders__item {
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+  border-radius: 10px;
+  padding: 0.45rem 0.65rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.simpleheaders__item:hover,
+.simpleheaders__item:focus-visible {
+  background: color-mix(in srgb, var(--accent) 35%, transparent);
+  outline: none;
+}
+
+.simpleheaders__item[data-active='true'] {
+  background: color-mix(in srgb, var(--accent) 55%, transparent);
+  transform: translateX(2px);
+}
+
+.simpleheaders__viewer {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  background: color-mix(in srgb, var(--bg-panel) 98%, CanvasText 2%);
+  min-height: 240px;
+  max-height: 480px;
+  overflow-y: auto;
+  margin: 0;
+  font-family: 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.simpleheaders__viewer[data-loading='true'] {
+  opacity: 0.75;
+}
+
+@media (max-width: 960px) {
+  .simpleheaders {
+    grid-template-columns: 1fr;
+  }
+
+  .simpleheaders__viewer {
+    max-height: none;
+  }
+}
+
 .panel-status {
   margin: 0;
   color: var(--text-muted);

--- a/tests/test_headers_golden.py
+++ b/tests/test_headers_golden.py
@@ -192,7 +192,83 @@ def test_headers_endpoint_returns_outline(
     def _mock_parse(document_path, *, settings):  # noqa: ANN001 - test helper
         return sample_result
 
+    async def _mock_extract_headers_and_chunks(
+        document_bytes: bytes,
+        *,
+        settings,
+        native_headers,
+        metadata,
+    ) -> dict:
+        lines = [
+            {
+                "text": "General Requirements",
+                "page": 0,
+                "line_idx": 0,
+                "global_idx": 0,
+                "is_running": False,
+                "is_toc": False,
+                "is_index": False,
+            },
+            {
+                "text": "Scope",
+                "page": 0,
+                "line_idx": 1,
+                "global_idx": 1,
+                "is_running": False,
+                "is_toc": False,
+                "is_index": False,
+            },
+        ]
+        return {
+            "headers": [
+                {
+                    "text": "General Requirements",
+                    "number": "1",
+                    "level": 1,
+                    "page": 0,
+                    "line_idx": 0,
+                    "global_idx": 0,
+                },
+                {
+                    "text": "Scope",
+                    "number": "1.1",
+                    "level": 2,
+                    "page": 0,
+                    "line_idx": 1,
+                    "global_idx": 1,
+                },
+            ],
+            "sections": [
+                {
+                    "header_text": "General Requirements",
+                    "header_number": "1",
+                    "level": 1,
+                    "start_global_idx": 0,
+                    "end_global_idx": 0,
+                    "start_page": 0,
+                    "end_page": 0,
+                },
+                {
+                    "header_text": "Scope",
+                    "header_number": "1.1",
+                    "level": 2,
+                    "start_global_idx": 1,
+                    "end_global_idx": 1,
+                    "start_page": 0,
+                    "end_page": 0,
+                },
+            ],
+            "mode": "llm_full",
+            "lines": lines,
+            "doc_hash": "abc123",
+            "excluded_pages": [],
+        }
+
     monkeypatch.setattr("backend.routers.headers.parse_pdf", _mock_parse)
+    monkeypatch.setattr(
+        "backend.routers.headers.extract_headers_and_chunks",
+        _mock_extract_headers_and_chunks,
+    )
 
     response = client.post(f"/api/headers/{document.id}")
     assert response.status_code == 200
@@ -201,3 +277,6 @@ def test_headers_endpoint_returns_outline(
     assert payload["document_id"] == document.id
     assert payload["outline"][0]["title"] == "General Requirements"
     assert payload["outline"][0]["children"][0]["title"] == "Scope"
+    assert payload["mode"] == "llm_full"
+    assert payload["simpleheaders"][0]["text"] == "General Requirements"
+    assert payload["sections"][0]["start_global_idx"] == 0


### PR DESCRIPTION
## Summary
- add a full-document header extraction mode backed by OpenRouter with caching, line metrics, and native fallbacks
- expose located headers and section ranges through the headers API and cache their line text for section previews
- refresh the frontend to render a SimpleHeaders sidebar and section viewer alongside documentation updates and env settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe288d4afc8324841f8bb74e772a5b