### PR TITLE
Show header extraction mode tag

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,7 +60,10 @@
 
         <section class="panel" id="panel-headers" aria-labelledby="panel-headers-title">
           <div class="panel-header">
-            <h3 id="panel-headers-title">Header outline</h3>
+            <div class="panel-header__title">
+              <h3 id="panel-headers-title">Header outline</h3>
+              <span id="header-mode-tag" class="panel-tag" hidden></span>
+            </div>
             <button type="button" class="ghost-button" data-export="headers">Download JSON</button>
           </div>
           <div class="panel-body" id="headers-content" aria-live="polite"></div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -55,7 +55,41 @@ const elements = {
   approveSpecs: document.querySelector('#approve-specs'),
   approvalStatus: document.querySelector('#approval-status'),
   reviewerInput: document.querySelector('#reviewer-name'),
+  headerModeTag: document.querySelector('#header-mode-tag'),
 };
+
+function updateHeaderModeTag(mode) {
+  const tag = elements.headerModeTag;
+  if (!tag) {
+    return;
+  }
+
+  if (!mode) {
+    tag.hidden = true;
+    tag.textContent = '';
+    tag.removeAttribute('data-variant');
+    tag.removeAttribute('aria-label');
+    tag.removeAttribute('title');
+    return;
+  }
+
+  const normalised = String(mode).toLowerCase();
+  let label = 'Huer';
+  let variant = 'heuristic';
+  let description = 'Headers derived via heuristic extraction.';
+
+  if (normalised === 'llm_full') {
+    label = 'LLM';
+    variant = 'llm';
+    description = 'Headers derived via LLM extraction.';
+  }
+
+  tag.textContent = label;
+  tag.dataset.variant = variant;
+  tag.setAttribute('aria-label', description);
+  tag.setAttribute('title', description);
+  tag.hidden = false;
+}
 
 initDropZone({
   zone: elements.dropZone,
@@ -157,6 +191,7 @@ async function selectDocument(documentId) {
   setPanelLoading(elements.headersContent, 'Generating outline…');
   setPanelLoading(elements.specsContent, 'Classifying specification lines…');
   setPanelLoading(elements.riskContent, 'Computing risk score…');
+  updateHeaderModeTag(null);
   setApprovalStatus('Loading approval status…', 'muted');
   updateApprovalUI({ busy: true });
 
@@ -189,9 +224,11 @@ async function selectDocument(documentId) {
         documentId,
         fetchSection: fetchSectionText,
       });
+      updateHeaderModeTag(state.headers?.mode ?? null);
     } else {
       state.headers = null;
       setPanelError(elements.headersContent, headersResult.reason?.message ?? 'Unable to load headers.');
+      updateHeaderModeTag(null);
     }
 
     if (specsResult.status === 'fulfilled') {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -317,9 +317,43 @@ body {
   gap: 1rem;
 }
 
+.panel-header__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .panel-header h3 {
   margin: 0;
   font-size: 1.1rem;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--accent-strong) 16%, transparent);
+  color: var(--accent-strong);
+}
+
+.panel-tag[data-variant='llm'] {
+  background: color-mix(in srgb, var(--accent-strong) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent-strong) 55%, transparent);
+  color: var(--accent-strong);
+}
+
+.panel-tag[data-variant='heuristic'] {
+  background: color-mix(in srgb, var(--success) 22%, transparent);
+  border-color: color-mix(in srgb, var(--success) 45%, transparent);
+  color: var(--success);
 }
 
 .panel-actions {


### PR DESCRIPTION
## Summary
- surface the header extraction mode in the outline panel header with a compact tag
- style the new header mode tag to match the existing panel header layout
- update the document loading flow to set the tag based on LLM or heuristic results

## Testing
- pytest tests/test_headers_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68fe306e2b8883248e91493301664874