### PR TITLE
Load .env for OpenRouter configuration

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Tuple
 
+from dotenv import load_dotenv
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -20,8 +21,29 @@ def _env_flag(name: str, default: bool) -> bool:
 
 
 BASE_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = BASE_DIR.parent
 DEFAULT_TERMS_DIR = BASE_DIR / "resources" / "terms"
 DEFAULT_BASELINES_PATH = BASE_DIR / "resources" / "baselines" / "mandatory_clauses.json"
+
+
+def _load_environment() -> None:
+    """Load environment variables from a ``.env`` file if present."""
+
+    explicit_path = os.getenv("SIMPLESPECS_ENV_FILE")
+    candidates = []
+
+    if explicit_path:
+        candidates.append(Path(explicit_path))
+
+    candidates.append(PROJECT_ROOT / ".env")
+
+    for candidate in candidates:
+        try_path = candidate.expanduser()
+        if try_path.exists():
+            load_dotenv(try_path, override=False)
+
+
+_load_environment()
 
 
 def _database_url_default() -> str:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import re
 
-from backend.config import Settings
+import importlib
+
+import backend.config as config
 
 
 def test_default_cors_regex_allows_local_network(monkeypatch):
     """The default regex should allow localhost and local-network origins."""
 
     monkeypatch.delenv("CORS_ALLOW_ORIGIN_REGEX", raising=False)
-    settings = Settings()
+    settings = config.Settings()
 
     assert (
         settings.cors_allow_origin_regex
@@ -23,7 +25,7 @@ def test_default_cors_regex_matches_private_ipv4_origin(monkeypatch):
     """The default regex should match private IPv4 origins with custom ports."""
 
     monkeypatch.delenv("CORS_ALLOW_ORIGIN_REGEX", raising=False)
-    settings = Settings()
+    settings = config.Settings()
 
     pattern = re.compile(settings.cors_allow_origin_regex)
 
@@ -34,6 +36,24 @@ def test_blank_cors_regex_disables_pattern(monkeypatch):
     """Blank regex env vars should be treated as disabled (None)."""
 
     monkeypatch.setenv("CORS_ALLOW_ORIGIN_REGEX", "   ")
-    settings = Settings()
+    settings = config.Settings()
 
     assert settings.cors_allow_origin_regex is None
+
+
+def test_openrouter_api_key_loaded_from_env_file(monkeypatch, tmp_path):
+    """The OPENROUTER_API_KEY should be sourced from a .env file when present."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENROUTER_API_KEY=file-value\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("SIMPLESPECS_ENV_FILE", str(env_file))
+
+    module = importlib.reload(config)
+
+    settings = module.Settings()
+
+    assert settings.openrouter_api_key == "file-value"
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- load environment variables from a .env file before instantiating backend settings
- allow overriding the env file path for tests via a SIMPLESPECS_ENV_FILE variable
- add coverage ensuring OPENROUTER_API_KEY is sourced from the .env file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe31b3cb408324988666a36d3ecfd3