### PR TITLE
Log OpenRouter API key status during backend startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -25,7 +26,46 @@ async def lifespan(app: FastAPI):
     yield
 
 
+logger = logging.getLogger("uvicorn.error")
+
+
+def _mask_api_key(value: str | None) -> str:
+    """Return a masked representation of the OpenRouter API key."""
+
+    if not value:
+        return "<missing>"
+
+    stripped = value.strip()
+    if not stripped:
+        return "<missing>"
+
+    if len(stripped) <= 8:
+        middle = "…" * max(len(stripped) - 2, 1)
+        return f"{stripped[0]}{middle}{stripped[-1]}"
+
+    return f"{stripped[:4]}…{stripped[-4:]}"
+
+
+def _announce_openrouter_api_key(value: str | None) -> None:
+    """Log the OpenRouter API key status to the command window."""
+
+    if value and value.strip():
+        masked = _mask_api_key(value)
+        message = (
+            "[SimpleSpecs] OpenRouter API key loaded from environment (.env): "
+            f"{masked}"
+        )
+    else:
+        message = (
+            "[SimpleSpecs] OpenRouter API key not found in environment (.env); "
+            "OpenRouter-dependent features are disabled."
+        )
+
+    logger.info(message)
+
+
 settings = get_settings()
+_announce_openrouter_api_key(settings.openrouter_api_key)
 
 cors_allow_origins = list(settings.cors_allow_origins)
 allow_credentials = True

--- a/backend/tests/test_main_startup.py
+++ b/backend/tests/test_main_startup.py
@@ -1,0 +1,44 @@
+"""Tests for startup behaviour defined in ``backend.main``."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _reload(module_name: str):
+    """Import and reload the requested module."""
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        module = importlib.import_module(module_name)
+    return importlib.reload(module)
+
+
+def test_startup_logs_openrouter_api_key(monkeypatch, tmp_path, caplog):
+    """The backend should announce the OpenRouter API key status at startup."""
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENROUTER_API_KEY=sk-test-secret\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("SIMPLESPECS_ENV_FILE", str(env_file))
+
+    _reload("backend.config")
+
+    caplog.clear()
+    with caplog.at_level("INFO", logger="uvicorn.error"):
+        main_module = _reload("backend.main")
+
+    messages = [
+        record.message
+        for record in caplog.records
+        if "OpenRouter API key" in record.message
+    ]
+
+    assert messages, "Expected a startup log message confirming the API key status."
+
+    expected_mask = main_module._mask_api_key("sk-test-secret")
+
+    assert any(expected_mask in message for message in messages)
+    assert all("sk-test-secret" not in message for message in messages)


### PR DESCRIPTION
## Summary
- log the masked OpenRouter API key status during backend startup to confirm the .env file was loaded
- add a regression test that reloads the backend and asserts the startup log reflects the masked key without leaking secrets

## Testing
- pytest backend/tests/test_main_startup.py backend/tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68fe3d4dbb3483249521464e8c181778