### PR TITLE
Surface LLM fallback notices when OpenRouter fails

### DIFF
--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -78,6 +78,7 @@ class HeadersResponse(BaseModel):
     simpleheaders: list[SimpleHeaderPayload] = Field(default_factory=list)
     sections: list[SectionPayload] = Field(default_factory=list)
     mode: str | None = None
+    messages: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_result(
@@ -88,6 +89,7 @@ class HeadersResponse(BaseModel):
         simpleheaders: list[SimpleHeaderPayload] | None = None,
         sections: list[SectionPayload] | None = None,
         mode: str | None = None,
+        messages: list[str] | None = None,
     ) -> "HeadersResponse":
         return cls(
             document_id=document_id,
@@ -97,6 +99,7 @@ class HeadersResponse(BaseModel):
             simpleheaders=simpleheaders or [],
             sections=sections or [],
             mode=mode,
+            messages=list(messages or []),
         )
 
 
@@ -175,6 +178,7 @@ async def generate_headers(
         simpleheaders=simpleheaders_payload,
         sections=sections_payload,
         mode=orchestrated.get("mode"),
+        messages=orchestrated.get("messages"),
     )
 
 

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Mapping, Sequence
 
 from backend.config import Settings
@@ -13,6 +14,34 @@ from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _format_llm_failure(exc: Exception) -> str:
+    """Return a concise message describing an LLM extraction failure."""
+
+    text = str(exc).strip()
+    if not text:
+        text = exc.__class__.__name__
+
+    match = re.search(r"\b(\d{3})\b", text)
+    if match:
+        code = match.group(1)
+        if code in {"401", "403"}:
+            return (
+                "LLM header extraction unavailable (HTTP {code}). "
+                "Using heuristic results. Verify the OpenRouter API key and referer configuration."
+            ).format(code=code)
+        if code == "429":
+            return (
+                "LLM header extraction temporarily unavailable (HTTP 429). "
+                "Rate limit exceeded; retry later. Falling back to heuristic results."
+            )
+        return (
+            "LLM header extraction unavailable (HTTP {code}). "
+            "Using heuristic results."
+        ).format(code=code)
+
+    return "LLM header extraction unavailable. Using heuristic results."
 
 
 async def extract_headers_and_chunks(
@@ -33,6 +62,7 @@ async def extract_headers_and_chunks(
 
     located_headers: list[dict] = []
     mode_used = "native"
+    messages: list[str] = []
 
     if settings.headers_mode.lower() == "llm_full":
         try:
@@ -52,6 +82,7 @@ async def extract_headers_and_chunks(
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []
+            messages.append(_format_llm_failure(exc))
 
     if not located_headers and native_headers:
         located_headers = locate_headers_in_lines(
@@ -70,6 +101,7 @@ async def extract_headers_and_chunks(
         "lines": lines,
         "doc_hash": doc_hash,
         "excluded_pages": sorted(excluded_pages),
+        "messages": messages,
     }
 
 

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -1,0 +1,94 @@
+import asyncio
+
+from backend.config import Settings
+from backend.services import headers_orchestrator
+
+
+async def _run_extract(monkeypatch, tmp_path, *, llm_exception: Exception | None = None):
+    lines = [
+        {
+            "text": "Intro",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+        }
+    ]
+
+    def _fake_collect(*args, **kwargs):  # noqa: ANN001 - test stub
+        return lines, set(), "hash-value"
+
+    async def _fake_llm(*args, **kwargs):  # noqa: ANN001 - test stub
+        if llm_exception is not None:
+            raise llm_exception
+        return [
+            {"text": "Intro", "number": "1", "level": 1},
+        ]
+
+    def _fake_locate(headers, *_args, **_kwargs):  # noqa: ANN001 - test stub
+        return [
+            {
+                "text": headers[0]["text"],
+                "number": headers[0]["number"],
+                "level": headers[0]["level"],
+                "page": 0,
+                "line_idx": 0,
+                "global_idx": 0,
+            }
+        ]
+
+    def _fake_chunks(headers, _lines):  # noqa: ANN001 - test stub
+        return [
+            {
+                "header_text": headers[0]["text"],
+                "header_number": headers[0]["number"],
+                "level": headers[0]["level"],
+                "start_global_idx": 0,
+                "end_global_idx": 0,
+                "start_page": 0,
+                "end_page": 0,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.collect_line_metrics", _fake_collect
+    )
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.get_headers_llm_full", _fake_llm
+    )
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.locate_headers_in_lines", _fake_locate
+    )
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.single_chunks_from_headers", _fake_chunks
+    )
+
+    settings = Settings(upload_dir=tmp_path, headers_mode="llm_full")
+
+    return await headers_orchestrator.extract_headers_and_chunks(
+        b"pdf-bytes",
+        settings=settings,
+        native_headers=[{"text": "Intro", "number": "1", "level": 1}],
+        metadata={"filename": "doc.pdf"},
+    )
+
+
+def test_extract_headers_llm_failure_emits_message(monkeypatch, tmp_path) -> None:
+    result = asyncio.run(
+        _run_extract(
+            monkeypatch,
+            tmp_path,
+            llm_exception=RuntimeError("OpenRouter HTTP 403: Forbidden"),
+        )
+    )
+
+    assert result["mode"] == "native"
+    assert result["messages"]
+    assert "HTTP 403" in result["messages"][0]
+
+
+def test_extract_headers_llm_success_has_no_messages(monkeypatch, tmp_path) -> None:
+    result = asyncio.run(_run_extract(monkeypatch, tmp_path))
+
+    assert result["mode"] == "llm_full"
+    assert result["messages"] == []

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -74,7 +74,7 @@ function updateHeaderModeTag(mode) {
   }
 
   const normalised = String(mode).toLowerCase();
-  let label = 'Huer';
+  let label = 'Heur';
   let variant = 'heuristic';
   let description = 'Headers derived via heuristic extraction.';
 
@@ -225,6 +225,14 @@ async function selectDocument(documentId) {
         fetchSection: fetchSectionText,
       });
       updateHeaderModeTag(state.headers?.mode ?? null);
+      if (Array.isArray(state.headers?.messages)) {
+        state.headers.messages.forEach((message) => {
+          if (!message) {
+            return;
+          }
+          showToast(message, 'warning', 6000);
+        });
+      }
     } else {
       state.headers = null;
       setPanelError(elements.headersContent, headersResult.reason?.message ?? 'Unable to load headers.');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -602,6 +602,8 @@ export function showToast(message, variant = 'info', timeout = 3500) {
   toast.className = 'toast';
   if (variant === 'error') {
     toast.classList.add('toast--error');
+  } else if (variant === 'warning') {
+    toast.classList.add('toast--warning');
   }
   toast.textContent = message;
   region.append(toast);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -614,6 +614,11 @@ body {
   color: var(--danger);
 }
 
+.toast--warning {
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
+}
+
 @media (max-width: 1024px) {
   .app-shell {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- capture OpenRouter header extraction failures and return a user-facing notice alongside heuristic fallbacks
- expose the notice in the headers API response and surface it in the UI with a warning toast and mode tag fix
- style warning toasts and cover the new behaviour with unit tests for the orchestrator

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68fe3ed56280832481c55f93ddc42914