### PR TITLE
Ensure OpenRouter client respects configured model

### DIFF
--- a/backend/services/openrouter_client.py
+++ b/backend/services/openrouter_client.py
@@ -15,11 +15,36 @@ OPENROUTER_URL = os.getenv(
     "OPENROUTER_URL", "https://openrouter.ai/api/v1/chat/completions"
 ).strip()
 OPENROUTER_KEY = os.getenv("OPENROUTER_API_KEY", "").strip()
-OPENROUTER_MODEL = os.getenv(
-    "OPENROUTER_MODEL", "deepseek/deepseek-chat-v3-0324:free"
-).strip()
+_DEFAULT_OPENROUTER_MODEL = "deepseek/deepseek-chat-v3-0324:free"
 SITE_URL = os.getenv("OPENROUTER_SITE_URL", "http://localhost:3600").strip()
 X_TITLE = os.getenv("OPENROUTER_X_TITLE", "SimpleSpecs (Dev)").strip()
+
+try:  # Import lazily to avoid optional dependency issues during packaging.
+    from ..config import get_settings
+except Exception:  # pragma: no cover - fallback when config import fails
+    get_settings = None  # type: ignore[assignment]
+
+
+def _resolve_default_model() -> str:
+    """Return the configured default model from settings or environment."""
+
+    env_model = os.getenv("OPENROUTER_MODEL")
+    if env_model and env_model.strip():
+        return env_model.strip()
+
+    if get_settings is not None:
+        try:
+            settings = get_settings()
+        except Exception:  # pragma: no cover - defensive cache failure
+            settings = None
+        if settings:
+            configured = getattr(settings, "openrouter_model", "")
+            if configured and isinstance(configured, str):
+                configured = configured.strip()
+                if configured:
+                    return configured
+
+    return _DEFAULT_OPENROUTER_MODEL
 
 
 class OpenRouterError(RuntimeError):
@@ -54,7 +79,7 @@ def _merge_payload(
     bigger["max_tokens"] = max(_extract_max_tokens(params) or 2048, 4096)
 
     payload: Dict[str, Any] = {
-        "model": model or OPENROUTER_MODEL,
+        "model": model or _resolve_default_model(),
         "messages": messages,
         "temperature": temperature,
     }

--- a/backend/tests/test_openrouter_client.py
+++ b/backend/tests/test_openrouter_client.py
@@ -1,0 +1,58 @@
+"""Unit tests for OpenRouter client helpers."""
+
+from __future__ import annotations
+
+import importlib
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reload_client(monkeypatch):
+    """Ensure the client module is reloaded with a clean environment."""
+
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)
+    monkeypatch.setitem(
+        importlib.import_module("sys").modules,
+        "requests",
+        types.SimpleNamespace(post=None),
+    )
+    module = importlib.import_module("backend.services.openrouter_client")
+    yield module
+
+
+def test_merge_payload_prefers_env_model(monkeypatch, reload_client):
+    """The OPENROUTER_MODEL env var should override other defaults."""
+
+    monkeypatch.setenv("OPENROUTER_MODEL", "openrouter/custom-model")
+    client = importlib.reload(reload_client)
+
+    payload = client._merge_payload(  # type: ignore[attr-defined]
+        messages=[{"role": "user", "content": "ping"}],
+        model=None,
+        temperature=0.5,
+        params={},
+    )
+
+    assert payload["model"] == "openrouter/custom-model"
+
+
+def test_merge_payload_uses_settings_when_env_missing(monkeypatch, reload_client):
+    """If the env var is absent, fall back to the configured settings."""
+
+    class DummySettings:
+        openrouter_model = "openrouter/from-settings"
+
+    client = importlib.reload(reload_client)
+    monkeypatch.setattr(client, "get_settings", lambda: DummySettings(), raising=False)
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)
+
+    payload = client._merge_payload(  # type: ignore[attr-defined]
+        messages=[{"role": "user", "content": "ping"}],
+        model=None,
+        temperature=0.5,
+        params={},
+    )
+
+    assert payload["model"] == "openrouter/from-settings"


### PR DESCRIPTION
## Summary
- resolve the OpenRouter default model using the OPENROUTER_MODEL environment variable or configured settings
- add unit tests covering environment overrides and settings-based fallbacks

## Testing
- pytest backend/tests/test_openrouter_client.py

------
https://chatgpt.com/codex/tasks/task_e_68fe497bd7e48324bff83a5281b39108