### PR TITLE
Add strict LLM-driven header extraction path

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -110,6 +110,10 @@ class Settings(BaseModel):
     headers_suppress_running: bool = Field(
         default_factory=lambda: _env_flag("HEADERS_SUPPRESS_RUNNING", True)
     )
+    headers_llm_strict: bool = Field(
+        default_factory=lambda: os.getenv("HEADERS_LLM_STRICT", "false").lower()
+        == "true"
+    )
     headers_mode: str = Field(
         default_factory=lambda: os.getenv("HEADERS_MODE", "llm_full")
     )

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -17,8 +17,10 @@ from ..services.headers import (
     extract_headers,
     flatten_outline,
 )
+from ..services.headers_llm_strict import extract_headers_and_sections_strict
 from ..services.headers_orchestrator import extract_headers_and_chunks
-from ..services.pdf_native import parse_pdf
+from ..services.llm import LLMService
+from ..services.pdf_native import collect_line_metrics, parse_pdf
 from ..services.simpleheaders_state import SimpleHeadersState
 
 router = APIRouter(prefix="/api", tags=["headers"])
@@ -132,6 +134,63 @@ async def generate_headers(
         )
 
     document_bytes = document_path.read_bytes()
+
+    if settings.headers_llm_strict:
+        llm_service = LLMService(settings)
+        if llm_service.is_enabled:
+            lines, _, doc_hash = collect_line_metrics(
+                document_bytes,
+                {"filename": document.filename},
+                suppress_toc=settings.headers_suppress_toc,
+                suppress_running=settings.headers_suppress_running,
+            )
+            strict_output = extract_headers_and_sections_strict(
+                llm=llm_service,
+                lines=lines,
+            )
+
+            SimpleHeadersState.set(doc_id, doc_hash, lines)
+
+            simpleheaders_payload = [
+                SimpleHeaderPayload(
+                    text=item.get("text", ""),
+                    number=item.get("number"),
+                    level=int(item.get("level", 1)),
+                    page=int(item.get("start_page", 0)),
+                    line_idx=int(item.get("line_index", 0)),
+                    global_idx=int(item.get("start_global_index", 0)),
+                )
+                for item in strict_output.get("headers", [])
+            ]
+
+            sections_payload = [
+                SectionPayload(
+                    header_text=section.get("text", ""),
+                    header_number=section.get("number"),
+                    level=int(section.get("level", 1)),
+                    start_global_idx=int(section.get("start_global_index", 0)),
+                    end_global_idx=int(
+                        section.get(
+                            "end_global_index", section.get("start_global_index", 0)
+                        )
+                    ),
+                    start_page=int(section.get("start_page", 0)),
+                    end_page=int(
+                        section.get("end_page", section.get("start_page", 0))
+                    ),
+                )
+                for section in strict_output.get("sections", [])
+            ]
+
+            return HeadersResponse(
+                document_id=doc_id,
+                source="llm_strict",
+                fenced_text=strict_output.get("fenced_text", ""),
+                outline=[],
+                simpleheaders=simpleheaders_payload,
+                sections=sections_payload,
+                mode="llm_strict",
+            )
 
     parse_result = parse_pdf(document_path, settings=settings)
     llm_client = HeadersLLMClient(settings)

--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -1,0 +1,234 @@
+"""Strict header extraction path using a single fenced LLM call."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Protocol, Sequence, Tuple
+
+log = logging.getLogger(__name__)
+
+FENCE = "#headers#"
+
+PROMPT_TEMPLATE = """Return ONLY the fenced JSON below.
+
+{fence}
+{{
+  "headers": [
+    {{"text":"<exact printed heading text>","number": "<printed number like 1, 1.2.3, A, A.1 or null>", "level": <positive integer>}}
+  ]
+}}
+{fence}
+
+Rules (non-negotiable):
+- Include ONLY headings/subheadings that appear in the MAIN BODY.
+- EXCLUDE anything from a Contents/Table of Contents, any Index, any Glossary, and any running headers/footers.
+- Copy numbering EXACTLY as printed when present; if none, set "number": null. Do not infer or normalize.
+- Preserve the original document order.
+- No prose outside the fenced JSON.
+- If unsure, omit the item.
+
+Document:
+<BEGIN>
+{doc_text}
+<END>
+"""
+
+
+BodyLine = Dict[str, Any]
+
+
+def _is_toc_or_index_line(text: str) -> bool:
+    trimmed = text.strip()
+    if not trimmed:
+        return False
+    upper = trimmed.upper()
+    if upper in {"CONTENTS", "TABLE OF CONTENTS", "INDEX"}:
+        return True
+    if re.search(r"\.{2,}\s*\d+\s*$", trimmed):
+        return True
+    return False
+
+
+def _normalise(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def _is_body_candidate(line: BodyLine) -> bool:
+    text = str(line.get("text", ""))
+    if not text.strip():
+        return False
+    if line.get("is_toc") or line.get("is_index"):
+        return False
+    if line.get("is_running"):
+        return False
+    if _is_toc_or_index_line(text):
+        return False
+    return True
+
+
+def _find_header_line(
+    header_text: str,
+    lines: Sequence[BodyLine],
+) -> Tuple[int, int, int] | None:
+    """Return (list_index, global_idx, page) for the header text."""
+
+    target = _normalise(header_text)
+    candidates: List[Tuple[int, int, int]] = []
+
+    for idx, line in enumerate(lines):
+        if not _is_body_candidate(line):
+            continue
+        text = str(line.get("text", ""))
+        if _normalise(text) == target:
+            candidates.append(
+                (
+                    idx,
+                    int(line.get("global_idx", idx)),
+                    int(line.get("page", 0)),
+                )
+            )
+
+    if not candidates:
+        for idx, line in enumerate(lines):
+            if not _is_body_candidate(line):
+                continue
+            text = str(line.get("text", ""))
+            if _normalise(text).startswith(target):
+                candidates.append(
+                    (
+                        idx,
+                        int(line.get("global_idx", idx)),
+                        int(line.get("page", 0)),
+                    )
+                )
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[1])
+    return candidates[-1]
+
+
+def _coerce_level(value: Any) -> int:
+    try:
+        level = int(value)
+    except Exception:
+        level = 1
+    return max(1, level)
+
+
+def _extract_headers(payload: Mapping[str, Any]) -> Iterable[Dict[str, Any]]:
+    headers = payload.get("headers")
+    if not isinstance(headers, list):
+        return []
+    for entry in headers:
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        number = entry.get("number")
+        if isinstance(number, str):
+            number = number.strip() or None
+        elif number is None:
+            number = None
+        else:
+            number = str(number).strip() or None
+        yield {
+            "text": text,
+            "number": number,
+            "level": _coerce_level(entry.get("level")),
+        }
+
+
+class _SupportsGenerate(Protocol):
+    def generate(
+        self,
+        *,
+        messages: Sequence[Mapping[str, str]],
+        fence: str | None = None,
+        params: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any:
+        ...
+
+
+def extract_headers_and_sections_strict(
+    *,
+    llm: _SupportsGenerate,
+    lines: Sequence[BodyLine],
+) -> Dict[str, Any]:
+    """Locate headers and construct contiguous section ranges."""
+
+    full_text = "\n".join(str(line.get("text", "")) for line in lines)
+
+    prompt = PROMPT_TEMPLATE.format(fence=FENCE, doc_text=full_text)
+    result = llm.generate(messages=[{"role": "user", "content": prompt}], fence=FENCE)
+
+    if not result.fenced:
+        raise RuntimeError("LLM response missing fenced JSON")
+
+    try:
+        payload = json.loads(result.fenced)
+    except json.JSONDecodeError as exc:
+        log.error("Failed to decode headers JSON: %s", exc)
+        payload = {}
+
+    located: List[Dict[str, Any]] = []
+
+    for header in _extract_headers(payload):
+        position = _find_header_line(header["text"], lines)
+        if not position:
+            log.debug("Header not located in body: %s", header["text"])
+            continue
+        list_index, global_idx, page = position
+        located.append(
+            {
+                "text": header["text"],
+                "number": header["number"],
+                "level": header["level"],
+                "line_index": list_index,
+                "start_global_index": global_idx,
+                "start_page": page,
+            }
+        )
+
+    located.sort(key=lambda item: item["start_global_index"])
+
+    sections: List[Dict[str, Any]] = []
+    if lines:
+        for idx, header in enumerate(located):
+            start_line_index = header["line_index"]
+            if idx + 1 < len(located):
+                next_line_index = located[idx + 1]["line_index"] - 1
+            else:
+                next_line_index = len(lines) - 1
+            if next_line_index < start_line_index:
+                next_line_index = start_line_index
+            end_line = lines[next_line_index]
+            sections.append(
+                {
+                    "text": header["text"],
+                    "number": header.get("number"),
+                    "level": header["level"],
+                    "start_line_index": start_line_index,
+                    "end_line_index": next_line_index,
+                    "start_global_index": header["start_global_index"],
+                    "end_global_index": int(
+                        end_line.get("global_idx", header["start_global_index"])
+                    ),
+                    "start_page": header["start_page"],
+                    "end_page": int(end_line.get("page", header["start_page"])),
+                }
+            )
+
+    return {
+        "headers": located,
+        "sections": sections,
+        "fenced_text": result.fenced,
+    }
+
+
+__all__ = ["extract_headers_and_sections_strict", "FENCE"]

--- a/backend/tests/test_headers_llm_strict.py
+++ b/backend/tests/test_headers_llm_strict.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+
+from backend.services.headers_llm_strict import extract_headers_and_sections_strict
+
+
+class DummyLLMResult:
+    def __init__(self, content: str, fenced: str) -> None:
+        self.content = content
+        self.fenced = fenced
+        self.usage = None
+        self.cached = False
+
+
+class DummyLLM:
+    def __init__(self, payload: dict) -> None:
+        self._payload = json.dumps(payload)
+
+    def generate(self, *, messages, fence):  # type: ignore[override]
+        content = f"{fence}\n{self._payload}\n{fence}"
+        return DummyLLMResult(content=content, fenced=self._payload)
+
+
+def test_strict_headers_skip_toc_lines() -> None:
+    lines = [
+        {
+            "text": "1 OVERVIEW ........ 3",
+            "global_idx": 0,
+            "page": 0,
+            "line_idx": 0,
+            "is_toc": True,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "1 OVERVIEW",
+            "global_idx": 2,
+            "page": 1,
+            "line_idx": 5,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "Overview details",
+            "global_idx": 3,
+            "page": 1,
+            "line_idx": 6,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "1.1 Scope",
+            "global_idx": 4,
+            "page": 1,
+            "line_idx": 7,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "Scope details",
+            "global_idx": 5,
+            "page": 1,
+            "line_idx": 8,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+    ]
+
+    payload = {
+        "headers": [
+            {"text": "1 OVERVIEW", "number": "1", "level": 1},
+            {"text": "1.1 Scope", "number": "1.1", "level": 2},
+        ]
+    }
+    llm = DummyLLM(payload)
+
+    result = extract_headers_and_sections_strict(llm=llm, lines=lines)
+
+    assert [header["start_global_index"] for header in result["headers"]] == [2, 4]
+    assert result["sections"][0]["start_global_index"] == 2
+    assert result["sections"][0]["end_global_index"] == 3
+    assert result["sections"][1]["start_global_index"] == 4
+    assert result["sections"][1]["end_global_index"] == 5


### PR DESCRIPTION
## Summary
- wire the HEADERS_LLM_STRICT flag into the backend settings
- add a strict headers extraction service that queries the LLM once and maps headers to body sections
- integrate the strict path into the headers API and cover it with a focused unit test

## Testing
- pytest backend/tests/test_headers_llm_strict.py

------
https://chatgpt.com/codex/tasks/task_e_68fe75368ed48324b3aed5f5d7bf1802