### PR TITLE
Increase LLM max tokens to 120k

### DIFF
--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -363,7 +363,7 @@ class LLMService:
             numeric = int(value)
         except Exception:
             numeric = 2048
-        return max(numeric, 4096)
+        return max(numeric, 120_000)
 
     def _log_usage(
         self,

--- a/backend/services/openrouter_client.py
+++ b/backend/services/openrouter_client.py
@@ -76,7 +76,7 @@ def _merge_payload(
     params: Mapping[str, Any] | None,
 ) -> Dict[str, Any]:
     bigger: MutableMapping[str, Any] = dict(params or {})
-    bigger["max_tokens"] = max(_extract_max_tokens(params) or 2048, 4096)
+    bigger["max_tokens"] = max(_extract_max_tokens(params) or 2048, 120_000)
 
     payload: Dict[str, Any] = {
         "model": model or _resolve_default_model(),

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -31,7 +31,7 @@ def test_llm_service_uses_cache(tmp_path: Path) -> None:
 
     def fake_transport(request: LLMTransportRequest) -> LLMTransportResponse:
         calls["count"] += 1
-        assert int(request.params["max_tokens"]) >= 4096
+        assert int(request.params["max_tokens"]) >= 120_000
         content = "#headers#\nMechanical\n#headers#"
         usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
         return LLMTransportResponse(content=content, usage=usage)


### PR DESCRIPTION
## Summary
- raise the minimum max_tokens enforced by the OpenRouter client to 120k tokens
- update the LLM service safeguard to ensure at least 120k tokens when parameters are missing or invalid
- adjust unit expectations to reflect the higher token allowance

## Testing
- pytest tests/test_llm_service.py *(fails: missing requests dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe7975bc4883248e6ecce972ca9b76