### PR TITLE
Include appendices in header heuristics and prompts

### DIFF
--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from ..config import Settings
 from .openrouter_client import OpenRouterError, chat as openrouter_chat
-from .pdf_native import ParsedBlock, ParseResult
+from .pdf_native import ParsedBlock, ParsedPage, ParseResult
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,11 @@ NUMBERING_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
         r"^(?P<number>[IVXLCDM]+(?:\.\d+)*)(?:[.)])?\s+(?P<title>.+)$", re.IGNORECASE
     ),
+)
+
+APPENDIX_PATTERN = re.compile(
+    r"^(?P<prefix>appendix|appendices)\s+(?P<identifier>[A-Z0-9]+(?:\.[A-Z0-9]+)*)\b(?P<rest>.*)$",
+    re.IGNORECASE,
 )
 
 
@@ -178,6 +183,11 @@ def _score_block(
             score += 0.5
 
     text = _normalise_text(block.text)
+    lowercase = text.lower()
+
+    if lowercase.startswith("appendix"):
+        score += 1.5
+
     if text.isupper() and len(text.split()) <= 6:
         score += 1.0
     elif text.istitle():
@@ -347,6 +357,18 @@ def _normalise_text(text: str) -> str:
 def _split_numbering(text: str) -> tuple[str | None, str]:
     """Split a heading into numbering and title components."""
 
+    appendix_match = APPENDIX_PATTERN.match(text)
+    if appendix_match:
+        prefix = appendix_match.group("prefix") or "Appendix"
+        identifier = appendix_match.group("identifier") or ""
+        remainder = appendix_match.group("rest") or ""
+        cleaned_remainder = remainder.lstrip(" .:-–—)\t")
+        numbering = f"{prefix.upper()} {identifier.upper()}".strip()
+        title = cleaned_remainder.strip()
+        if not title:
+            title = f"{prefix.title()} {identifier.upper()}".strip()
+        return numbering, title
+
     for pattern in NUMBERING_PATTERNS:
         match = pattern.match(text)
         if match:
@@ -442,19 +464,51 @@ def _render_prompt(
     ]
     heuristic_block = "\n".join(heuristic_lines) or "<no heuristic headers>"
 
+    def _sample_page(page: ParsedPage, *, limit: int = 15) -> list[str]:
+        lines: list[str] = []
+        for block in page.blocks:
+            normalised = _normalise_text(block.text)
+            if normalised:
+                lines.append(normalised)
+            if len(lines) >= limit:
+                break
+        return lines
+
     page_summaries: list[str] = []
+    included_pages: set[int] = set()
     for page in parse_result.pages[:3]:
-        sample_lines = [
-            _normalise_text(block.text)
-            for block in page.blocks[:15]
-            if _normalise_text(block.text)
-        ]
+        sample_lines = _sample_page(page)
         if sample_lines:
             page_summaries.append(
                 f"Page {page.page_number}:\n" + "\n".join(sample_lines)
             )
+            included_pages.add(page.page_number)
 
-    context_block = "\n\n".join(page_summaries) or "(No preview text available)"
+    appendix_summaries: list[str] = []
+    for page in parse_result.pages:
+        if len(appendix_summaries) >= 2:
+            break
+        if page.page_number in included_pages:
+            continue
+        sample_lines = _sample_page(page)
+        if not sample_lines:
+            continue
+        if not any("appendix" in line.lower() for line in sample_lines):
+            continue
+        appendix_summaries.append(
+            f"Appendix preview (Page {page.page_number}):\n" + "\n".join(sample_lines)
+        )
+        included_pages.add(page.page_number)
+
+    context_sections: list[str] = []
+    if page_summaries:
+        context_sections.append("\n\n".join(page_summaries))
+    if appendix_summaries:
+        context_sections.append("\n\n".join(appendix_summaries))
+
+    context_block = (
+        "\n\n".join(context_sections) if context_sections else "(No preview text available)"
+    )
 
     prompt = (
         "Return ONLY this fence:\n\n"
@@ -466,6 +520,7 @@ def _render_prompt(
         "- Every header must include \"title\" and integer \"level\" (1 = top level).\n"
         "- Include \"number\" when the source shows one; otherwise use null.\n"
         "- Preserve document order and exclude tables of contents or running headers.\n"
+        "- Do not omit appendices; include them as headers when present.\n"
         "- If no headers exist, return {\"headers\": []}.\n\n"
         "Heuristic outline (may be incomplete):\n"
         f"{heuristic_block}\n\n"

--- a/backend/tests/test_headers_appendices.py
+++ b/backend/tests/test_headers_appendices.py
@@ -1,0 +1,134 @@
+"""Tests for appendix-aware header extraction heuristics and prompts."""
+
+from backend.config import Settings
+from backend.services.headers import (
+    HeaderExtractionResult,
+    extract_headers,
+    _render_prompt,
+    _split_numbering,
+)
+from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
+
+
+def _settings(tmp_path) -> Settings:
+    """Return settings with isolated filesystem paths for tests."""
+
+    return Settings(
+        upload_dir=tmp_path / "uploads",
+        spec_terms_dir=tmp_path / "terms",
+        risk_baselines_path=tmp_path / "baselines.json",
+        export_dir=tmp_path / "export",
+        headers_llm_cache_dir=tmp_path / "headers-cache",
+    )
+
+
+def test_split_numbering_handles_appendix_label() -> None:
+    """Appendix headings should expose numbering and trimmed titles."""
+
+    number, title = _split_numbering("Appendix A - Data Tables")
+
+    assert number == "APPENDIX A"
+    assert title == "Data Tables"
+
+    number_b, title_b = _split_numbering("Appendix B")
+    assert number_b == "APPENDIX B"
+    assert title_b == "Appendix B"
+
+
+def test_extract_headers_includes_appendix(tmp_path) -> None:
+    """Heuristic extraction should emit appendix headers without LLM help."""
+
+    parse_result = ParseResult(
+        pages=[
+            ParsedPage(
+                page_number=0,
+                width=612,
+                height=792,
+                blocks=[
+                    ParsedBlock(
+                        text="1 Introduction",
+                        bbox=(36.0, 72.0, 540.0, 90.0),
+                        font_size=14.0,
+                    ),
+                ],
+            ),
+            ParsedPage(
+                page_number=5,
+                width=612,
+                height=792,
+                blocks=[
+                    ParsedBlock(
+                        text="Appendix A Data Tables",
+                        bbox=(36.0, 72.0, 540.0, 90.0),
+                        font_size=14.5,
+                    ),
+                    ParsedBlock(
+                        text="Additional context",
+                        bbox=(36.0, 96.0, 540.0, 112.0),
+                        font_size=11.0,
+                    ),
+                ],
+            ),
+        ]
+    )
+
+    settings = _settings(tmp_path)
+    result = extract_headers(parse_result, settings=settings, llm_client=None)
+
+    appendix_nodes = [
+        node
+        for node in result.outline
+        if node.numbering.upper().startswith("APPENDIX")
+    ]
+
+    assert appendix_nodes, "Expected at least one appendix header"
+    assert any("Data Tables" in node.title for node in appendix_nodes)
+
+
+def test_render_prompt_highlights_appendix_context(tmp_path) -> None:
+    """LLM prompt should emphasise appendix handling and context."""
+
+    pages = [
+        ParsedPage(
+            page_number=index,
+            width=612,
+            height=792,
+            blocks=[
+                ParsedBlock(
+                    text=f"{index + 1}. Section {index + 1}",
+                    bbox=(36.0, 72.0, 540.0, 90.0),
+                    font_size=13.0,
+                )
+            ],
+        )
+        for index in range(3)
+    ]
+    pages.append(
+        ParsedPage(
+            page_number=3,
+            width=612,
+            height=792,
+            blocks=[
+                ParsedBlock(
+                    text="Appendix A - Reference Data",
+                    bbox=(36.0, 72.0, 540.0, 90.0),
+                    font_size=14.0,
+                ),
+                ParsedBlock(
+                    text="Detailed appendix material",
+                    bbox=(36.0, 96.0, 540.0, 112.0),
+                    font_size=11.0,
+                ),
+            ],
+        )
+    )
+
+    parse_result = ParseResult(pages=pages)
+    heuristic_result = HeaderExtractionResult(
+        outline=[], fenced_text="#headers#\n#/headers#", source="heuristic"
+    )
+
+    prompt = _render_prompt(parse_result, heuristic_result)
+
+    assert "Do not omit appendices" in prompt
+    assert "Appendix preview (Page 3)" in prompt


### PR DESCRIPTION
## Summary
- detect appendix headings with dedicated heuristics and scoring so they appear in the extracted outline
- update the LLM prompt to emphasise appendix retention and share appendix page previews
- add regression tests covering appendix numbering, heuristic extraction, and prompt rendering

## Testing
- pytest backend/tests/test_headers_appendices.py

------
https://chatgpt.com/codex/tasks/task_e_69001631c1788324b04df60b20e71f05