### PR TITLE
Handle oversized header requests with token chunking

### DIFF
--- a/backend/services/token_chunk.py
+++ b/backend/services/token_chunk.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Iterable, List
+from typing import Iterable, Iterator, List
 
 
 def rough_token_count(text: str) -> int:
@@ -12,6 +12,28 @@ def rough_token_count(text: str) -> int:
     if not text:
         return 1
     return max(1, math.ceil(len(text) / 4))
+
+
+def _split_block(text: str, limit_tokens: int) -> Iterator[str]:
+    """Yield sub-sections of *text* that respect the token limit."""
+
+    if not text:
+        yield ""
+        return
+
+    if rough_token_count(text) <= limit_tokens:
+        yield text
+        return
+
+    # Use the inverse of ``rough_token_count`` to avoid overshooting the limit.
+    char_limit = max(1, limit_tokens * 4)
+    start = 0
+    text_length = len(text)
+
+    while start < text_length:
+        end = min(start + char_limit, text_length)
+        yield text[start:end]
+        start = end
 
 
 def split_by_token_limit(blocks: Iterable[str], limit_tokens: int) -> List[str]:
@@ -26,13 +48,15 @@ def split_by_token_limit(blocks: Iterable[str], limit_tokens: int) -> List[str]:
 
     for block in blocks:
         text = block or ""
-        tokens = rough_token_count(text)
-        if current and current_tokens + tokens > limit_tokens:
-            groups.append(current)
-            current = []
-            current_tokens = 0
-        current.append(text)
-        current_tokens += tokens
+
+        for segment in _split_block(text, limit_tokens):
+            tokens = rough_token_count(segment)
+            if current and current_tokens + tokens > limit_tokens:
+                groups.append(current)
+                current = []
+                current_tokens = 0
+            current.append(segment)
+            current_tokens += tokens
 
     if current:
         groups.append(current)

--- a/backend/tests/test_token_chunk.py
+++ b/backend/tests/test_token_chunk.py
@@ -1,0 +1,29 @@
+from backend.services.token_chunk import rough_token_count, split_by_token_limit
+
+
+def test_split_by_token_limit_splits_large_single_block() -> None:
+    limit = 120
+    # Each token is approx 4 chars. Create a block ~10x the limit.
+    block = "a" * (limit * 4 * 3 + 10)
+
+    parts = split_by_token_limit([block], limit)
+
+    # The joined content should match the original aside from inserted newlines.
+    combined = "".join(part.replace("\n", "") for part in parts)
+    assert combined == block
+
+    for part in parts:
+        assert rough_token_count(part) <= limit
+
+
+def test_split_by_token_limit_handles_mixed_blocks() -> None:
+    limit = 50
+    blocks = ["alpha", "beta" * 80, "gamma"]
+
+    parts = split_by_token_limit(blocks, limit)
+
+    assert len(parts) >= 2
+    for part in parts:
+        assert rough_token_count(part) <= limit
+
+


### PR DESCRIPTION
## Summary
- split oversized text blocks when preparing header extraction prompts so each LLM request stays under the configured token cap
- add tests covering the token chunking utility with large and mixed-size blocks

## Testing
- pytest backend/tests/test_token_chunk.py

------
https://chatgpt.com/codex/tasks/task_e_6900183981608324bd2bcab0623c4399