### PR TITLE
Remove heuristic header extraction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ SimpleSpecs parses engineering specification PDFs and structures the extracted d
 
 ### Header extraction configuration
 
-SimpleSpecs can run header detection heuristically or send the full document text to OpenRouter for a high-fidelity outline. Configure behaviour via the following environment variables (also available in `.env.template`):
+SimpleSpecs sends the full document text to OpenRouter for a high-fidelity outline. Configure behaviour via the following environment variables (also available in `.env.template`):
 
-- `HEADERS_MODE`: set to `llm_full` to enable the OpenRouter pipeline or `native` to force heuristic extraction.
+- `HEADERS_MODE`: keep `llm_full` to enable the OpenRouter pipeline.
 - `HEADERS_LLM_MODEL`: fully qualified OpenRouter model identifier (default `anthropic/claude-3.5-sonnet`).
 - `HEADERS_LLM_MAX_INPUT_TOKENS`: approximate token budget per request chunk (default `120000`).
 - `HEADERS_LLM_TIMEOUT_S`: request timeout in seconds (default `120`).
 - `HEADERS_LLM_CACHE_DIR`: on-disk cache for previously processed documents.
 
-The pipeline requires `OPENROUTER_API_KEY` and will fall back to the heuristic outline if a call fails. Cached responses avoid repeated model invocations for unchanged documents.
+The pipeline requires `OPENROUTER_API_KEY`. Cached responses avoid repeated model invocations for unchanged documents.
 
 ## Running with Docker
 1. Copy the production environment example and update secrets:

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -1,18 +1,16 @@
-"""Header extraction service combining heuristics with optional LLM refinement."""
+"""Header extraction service backed exclusively by the LLM pipeline."""
 
 from __future__ import annotations
 
 import json
 import logging
-import math
 import re
-from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping, Sequence
 
 from ..config import Settings
 from .openrouter_client import OpenRouterError, chat as openrouter_chat
-from .pdf_native import ParsedBlock, ParsedPage, ParseResult
+from .pdf_native import ParsedPage, ParseResult
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,25 +37,12 @@ def _format_openrouter_error(exc: OpenRouterError) -> str:
     if status == 403:
         return "LLM unavailable (403). Check API key / Referer headers."
     if status == 429:
-        return "LLM unavailable (429). Rate limit exceeded; using heuristics."
+        return "LLM unavailable (429). Rate limit exceeded; retry later."
     if status == 500:
-        return "LLM unavailable (500). OpenRouter server error; using heuristics."
+        return "LLM unavailable (500). OpenRouter server error."
     if isinstance(status, int):
-        return f"LLM unavailable ({status}). Using heuristic headers."
-    return "LLM unavailable. Using heuristic headers."
-
-
-@dataclass(slots=True)
-class HeaderCandidate:
-    """Potential header extracted from PDF text blocks."""
-
-    title: str
-    numbering: str | None
-    page_number: int
-    level_hint: int
-    indent: float
-    top: float
-    score: float
+        return f"LLM unavailable ({status})."
+    return "LLM unavailable."
 
 
 @dataclass(slots=True)
@@ -101,228 +86,32 @@ def extract_headers(
     settings: Settings,
     llm_client: "HeadersLLMClient | None" = None,
 ) -> HeaderExtractionResult:
-    """Extract a hierarchical header outline from a parse result."""
+    """Extract a hierarchical header outline using the configured LLM."""
 
-    candidates = _collect_candidates(parse_result)
-    outline = _build_outline(candidates)
-    heuristic_result = HeaderExtractionResult(
-        outline=outline,
-        fenced_text=_outline_to_fenced_text(outline),
-        source="heuristic",
+    fenced_empty = "\n".join(["#headers#", "#/headers#"])
+    default_result = HeaderExtractionResult(
+        outline=[],
+        fenced_text=fenced_empty,
+        source="openrouter",
     )
 
-    if llm_client and llm_client.is_enabled:
-        try:
-            llm_result = llm_client.refine_outline(parse_result, heuristic_result)
-            if llm_result is not None:
-                return llm_result
-        except OpenRouterError as exc:  # pragma: no cover - network path
-            LOGGER.warning("LLM refinement failed: %s", exc)
-            heuristic_result.messages.append(_format_openrouter_error(exc))
-        except Exception as exc:  # pragma: no cover - other runtime issues
-            LOGGER.warning("LLM refinement failed: %s", exc)
-
-    return heuristic_result
-
-
-def _collect_candidates(parse_result: ParseResult) -> list[HeaderCandidate]:
-    """Return sorted header candidates based on heuristics."""
-
-    font_sizes: list[float] = []
-    for page in parse_result.pages:
-        for block in page.blocks:
-            if block.font_size:
-                font_sizes.append(block.font_size)
-
-    avg_font_size = sum(font_sizes) / len(font_sizes) if font_sizes else 0.0
-
-    candidates: list[HeaderCandidate] = []
-    for page in parse_result.pages:
-        if page.is_toc:
-            continue
-        for block in page.blocks:
-            text = _normalise_text(block.text)
-            if not text:
-                continue
-
-            numbering, title = _split_numbering(text)
-            score = _score_block(block, avg_font_size, bool(numbering))
-            if not numbering and score < 1.5:
-                continue
-
-            level_hint = _infer_level(numbering, block)
-            candidate = HeaderCandidate(
-                title=title,
-                numbering=numbering,
-                page_number=page.page_number,
-                level_hint=level_hint,
-                indent=block.bbox[0],
-                top=block.bbox[1],
-                score=score,
-            )
-            candidates.append(candidate)
-
-    candidates.sort(key=lambda c: (c.page_number, c.top))
-    return candidates
-
-
-def _score_block(
-    block: ParsedBlock, avg_font_size: float, has_numbering: bool
-) -> float:
-    """Calculate a heuristic score for a block."""
-
-    score = 0.0
-    if has_numbering:
-        score += 2.5
-
-    if block.font_size and avg_font_size:
-        diff = block.font_size - avg_font_size
-        if diff > 1.0:
-            score += 1.5
-        elif diff > 0.5:
-            score += 0.5
-
-    text = _normalise_text(block.text)
-    lowercase = text.lower()
-
-    if lowercase.startswith("appendix"):
-        score += 1.5
-
-    if text.isupper() and len(text.split()) <= 6:
-        score += 1.0
-    elif text.istitle():
-        score += 0.5
-
-    return score
-
-
-def _infer_level(numbering: str | None, block: ParsedBlock) -> int:
-    """Determine the likely nesting level for a candidate."""
-
-    if numbering:
-        segments = re.split(r"[.]+", numbering.strip(".) "))
-        segments = [seg for seg in segments if seg]
-        if segments:
-            return len(segments)
-
-    indent = block.bbox[0]
-    if indent <= 10:
-        return 1
-    return min(1 + int(math.floor(indent / 40.0)), 6)
-
-
-def _build_outline(candidates: Sequence[HeaderCandidate]) -> list[HeaderNode]:
-    """Build a tree from the candidate list."""
-
-    if not candidates:
-        return []
-
-    indent_buckets = _cluster_indents(candidates)
-    outline: list[HeaderNode] = []
-    stack: list[tuple[int, HeaderNode]] = []
-    counters: dict[int, int] = defaultdict(int)
-
-    for candidate in candidates:
-        level = _resolve_level(candidate, indent_buckets)
-        if candidate.numbering:
-            _sync_counters(candidate.numbering, counters)
-            numbering = candidate.numbering
-        else:
-            numbering = _auto_number(level, counters)
-        node = HeaderNode(
-            title=candidate.title, numbering=numbering, page=candidate.page_number
-        )
-
-        while stack and stack[-1][0] >= level:
-            stack.pop()
-
-        if stack:
-            stack[-1][1].children.append(node)
-        else:
-            outline.append(node)
-
-        stack.append((level, node))
-
-    return outline
-
-
-def _cluster_indents(candidates: Sequence[HeaderCandidate]) -> list[float]:
-    """Group indent values into discrete buckets to stabilise level inference."""
-
-    values = sorted({round(candidate.indent, 2) for candidate in candidates})
-    if not values:
-        return [0.0]
-
-    buckets = [values[0]]
-    for value in values[1:]:
-        if abs(value - buckets[-1]) > 12.0:
-            buckets.append(value)
-    return buckets
-
-
-def _resolve_level(candidate: HeaderCandidate, indent_buckets: Sequence[float]) -> int:
-    """Resolve a final level using indentation and hints."""
-
-    level = candidate.level_hint
-    indent = candidate.indent
-    for index, bucket in enumerate(indent_buckets, start=1):
-        if indent <= bucket + 1e-3:
-            level = min(level, index)
-            break
-    return max(1, level)
-
-
-def _auto_number(level: int, counters: dict[int, int]) -> str:
-    """Assign synthetic numbering for unnumbered headers."""
-
-    counters[level] = counters.get(level, 0) + 1
-    for deeper_level in list(counters.keys()):
-        if deeper_level > level:
-            counters[deeper_level] = 0
-
-    parts: list[str] = []
-    for depth in range(1, level + 1):
-        value = counters.get(depth)
-        if not value:
-            value = 1
-            counters[depth] = value
-        parts.append(str(value))
-    return ".".join(parts)
-
-
-def _sync_counters(numbering: str, counters: dict[int, int]) -> None:
-    """Align numeric counters with explicit numbering from the document."""
+    if not llm_client or not llm_client.is_enabled:
+        default_result.messages.append("LLM header extraction is disabled.")
+        return default_result
 
     try:
-        parts = [int(part) for part in numbering.split(".")]
-    except ValueError:
-        return
+        llm_result = llm_client.refine_outline(parse_result)
+        if llm_result is not None:
+            return llm_result
+        default_result.messages.append("LLM did not return any headers.")
+    except OpenRouterError as exc:  # pragma: no cover - network path
+        LOGGER.warning("LLM extraction failed: %s", exc)
+        default_result.messages.append(_format_openrouter_error(exc))
+    except Exception as exc:  # pragma: no cover - other runtime issues
+        LOGGER.warning("LLM extraction failed: %s", exc)
+        default_result.messages.append("LLM header extraction failed.")
 
-    for index, value in enumerate(parts, start=1):
-        counters[index] = value
-
-    for deeper_level in list(counters.keys()):
-        if deeper_level > len(parts):
-            counters[deeper_level] = 0
-
-
-def _outline_to_fenced_text(nodes: Sequence[HeaderNode]) -> str:
-    """Render the outline as fenced text."""
-
-    lines = ["#headers#"]
-
-    def _emit(node: HeaderNode, depth: int) -> None:
-        indent = "  " * depth
-        label = f"{node.numbering} {node.title}".strip()
-        lines.append(f"{indent}{label}")
-        for child in node.children:
-            _emit(child, depth + 1)
-
-    for node in nodes:
-        _emit(node, 0)
-
-    lines.append("#/headers#")
-    return "\n".join(lines)
+    return default_result
 
 
 def flatten_outline(nodes: Sequence[HeaderNode]) -> list[dict[str, object]]:
@@ -379,7 +168,7 @@ def _split_numbering(text: str) -> tuple[str | None, str]:
 
 
 class HeadersLLMClient:
-    """Client responsible for refining outlines using the OpenRouter chat API."""
+    """Client responsible for extracting outlines using the OpenRouter chat API."""
 
     def __init__(
         self,
@@ -399,14 +188,13 @@ class HeadersLLMClient:
     def refine_outline(
         self,
         parse_result: ParseResult,
-        heuristic_result: HeaderExtractionResult,
     ) -> HeaderExtractionResult | None:
-        """Call OpenRouter and merge the returned headers with heuristics."""
+        """Call OpenRouter and return the extracted headers."""
 
         if not self.is_enabled:
             return None
 
-        prompt = _render_prompt(parse_result, heuristic_result)
+        prompt = _render_prompt(parse_result)
         messages = [{"role": "user", "content": prompt}]
 
         headers: dict[str, str] = {}
@@ -453,16 +241,9 @@ class HeadersLLMClient:
 
 
 def _render_prompt(
-    parse_result: ParseResult, heuristic_result: HeaderExtractionResult
+    parse_result: ParseResult,
 ) -> str:
-    """Render the header extraction prompt with heuristic hints."""
-
-    heuristic_lines = [
-        line
-        for line in heuristic_result.fenced_text.splitlines()
-        if line not in {"#headers#", "#/headers#"}
-    ]
-    heuristic_block = "\n".join(heuristic_lines) or "<no heuristic headers>"
+    """Render the header extraction prompt using parse context only."""
 
     def _sample_page(page: ParsedPage, *, limit: int = 15) -> list[str]:
         lines: list[str] = []
@@ -522,8 +303,6 @@ def _render_prompt(
         "- Preserve document order and exclude tables of contents or running headers.\n"
         "- Do not omit appendices; include them as headers when present.\n"
         "- If no headers exist, return {\"headers\": []}.\n\n"
-        "Heuristic outline (may be incomplete):\n"
-        f"{heuristic_block}\n\n"
         "Context:\n"
         f"{context_block}"
     )

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -29,19 +29,16 @@ def _format_llm_failure(exc: Exception) -> str:
         if code in {"401", "403"}:
             return (
                 "LLM header extraction unavailable (HTTP {code}). "
-                "Using heuristic results. Verify the OpenRouter API key and referer configuration."
+                "Verify the OpenRouter API key and referer configuration."
             ).format(code=code)
         if code == "429":
             return (
                 "LLM header extraction temporarily unavailable (HTTP 429). "
-                "Rate limit exceeded; retry later. Falling back to heuristic results."
+                "Rate limit exceeded; retry later."
             )
-        return (
-            "LLM header extraction unavailable (HTTP {code}). "
-            "Using heuristic results."
-        ).format(code=code)
+        return "LLM header extraction unavailable (HTTP {code}).".format(code=code)
 
-    return "LLM header extraction unavailable. Using heuristic results."
+    return "LLM header extraction unavailable."
 
 
 async def extract_headers_and_chunks(
@@ -61,7 +58,7 @@ async def extract_headers_and_chunks(
     )
 
     located_headers: list[dict] = []
-    mode_used = "native"
+    mode_used = "llm_full"
     messages: list[str] = []
 
     if settings.headers_mode.lower() == "llm_full":
@@ -77,20 +74,14 @@ async def extract_headers_and_chunks(
                 lines,
                 excluded_pages=excluded_pages,
             )
-            if located_headers:
-                mode_used = "llm_full"
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []
             messages.append(_format_llm_failure(exc))
-
-    if not located_headers and native_headers:
-        located_headers = locate_headers_in_lines(
-            native_headers,
-            lines,
-            excluded_pages=excluded_pages,
-        )
-        mode_used = "native"
+            mode_used = "llm_full_error"
+    else:
+        mode_used = "llm_disabled"
+        messages.append("LLM header extraction is disabled by configuration.")
 
     sections = single_chunks_from_headers(located_headers, lines)
 

--- a/backend/tests/test_headers_appendices.py
+++ b/backend/tests/test_headers_appendices.py
@@ -1,8 +1,9 @@
-"""Tests for appendix-aware header extraction heuristics and prompts."""
+"""Tests for appendix-aware header extraction prompts and helpers."""
 
 from backend.config import Settings
 from backend.services.headers import (
     HeaderExtractionResult,
+    HeaderNode,
     extract_headers,
     _render_prompt,
     _split_numbering,
@@ -35,8 +36,8 @@ def test_split_numbering_handles_appendix_label() -> None:
     assert title_b == "Appendix B"
 
 
-def test_extract_headers_includes_appendix(tmp_path) -> None:
-    """Heuristic extraction should emit appendix headers without LLM help."""
+def test_extract_headers_returns_llm_outline(tmp_path) -> None:
+    """The extractor should return outlines supplied by the LLM client."""
 
     parse_result = ParseResult(
         pages=[
@@ -52,37 +53,26 @@ def test_extract_headers_includes_appendix(tmp_path) -> None:
                     ),
                 ],
             ),
-            ParsedPage(
-                page_number=5,
-                width=612,
-                height=792,
-                blocks=[
-                    ParsedBlock(
-                        text="Appendix A Data Tables",
-                        bbox=(36.0, 72.0, 540.0, 90.0),
-                        font_size=14.5,
-                    ),
-                    ParsedBlock(
-                        text="Additional context",
-                        bbox=(36.0, 96.0, 540.0, 112.0),
-                        font_size=11.0,
-                    ),
-                ],
-            ),
         ]
     )
 
+    appendix_node = HeaderNode(title="Appendix A", numbering="APPENDIX A", page=5)
+    llm_result = HeaderExtractionResult(
+        outline=[appendix_node],
+        fenced_text="#headers#\n{\"headers\": []}\n#/headers#",
+        source="openrouter",
+    )
+
+    class StubClient:
+        is_enabled = True
+
+        def refine_outline(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return llm_result
+
     settings = _settings(tmp_path)
-    result = extract_headers(parse_result, settings=settings, llm_client=None)
+    result = extract_headers(parse_result, settings=settings, llm_client=StubClient())
 
-    appendix_nodes = [
-        node
-        for node in result.outline
-        if node.numbering.upper().startswith("APPENDIX")
-    ]
-
-    assert appendix_nodes, "Expected at least one appendix header"
-    assert any("Data Tables" in node.title for node in appendix_nodes)
+    assert result is llm_result
 
 
 def test_render_prompt_highlights_appendix_context(tmp_path) -> None:
@@ -124,11 +114,8 @@ def test_render_prompt_highlights_appendix_context(tmp_path) -> None:
     )
 
     parse_result = ParseResult(pages=pages)
-    heuristic_result = HeaderExtractionResult(
-        outline=[], fenced_text="#headers#\n#/headers#", source="heuristic"
-    )
 
-    prompt = _render_prompt(parse_result, heuristic_result)
+    prompt = _render_prompt(parse_result)
 
     assert "Do not omit appendices" in prompt
     assert "Appendix preview (Page 3)" in prompt

--- a/backend/tests/test_headers_llm_client.py
+++ b/backend/tests/test_headers_llm_client.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 import pytest
 
 from backend.config import Settings
-from backend.services.headers import (
-    HeaderExtractionResult,
-    HeaderNode,
-    HeadersLLMClient,
-    extract_headers,
-)
+from backend.services.headers import HeadersLLMClient, extract_headers
 from backend.services.openrouter_client import OpenRouterError
 from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
 
@@ -22,14 +17,6 @@ def _sample_parse_result() -> ParseResult:
     )
     page = ParsedPage(page_number=1, width=612.0, height=792.0, blocks=[block])
     return ParseResult(pages=[page])
-
-
-def _heuristic_result() -> HeaderExtractionResult:
-    node = HeaderNode(title="Scope", numbering="1", page=1)
-    fenced = "\n".join(["#headers#", "1 Scope", "#/headers#"])
-    return HeaderExtractionResult(outline=[node], fenced_text=fenced, source="heuristic")
-
-
 def test_llm_client_parses_json_fallback(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -44,7 +31,7 @@ def test_llm_client_parses_json_fallback(
     settings = Settings(upload_dir=tmp_path)
     client = HeadersLLMClient(settings, chat_func=fake_chat)
 
-    result = client.refine_outline(_sample_parse_result(), _heuristic_result())
+    result = client.refine_outline(_sample_parse_result())
 
     assert result is not None
     assert result.outline[0].title == "Scope"
@@ -60,7 +47,7 @@ def test_extract_headers_includes_message_on_openrouter_error(
     class FailingClient:
         is_enabled = True
 
-        def refine_outline(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        def refine_outline(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
             raise OpenRouterError("403 Forbidden", status_code=403)
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
@@ -71,5 +58,5 @@ def test_extract_headers_includes_message_on_openrouter_error(
         llm_client=FailingClient(),
     )
 
-    assert result.source == "heuristic"
+    assert result.source == "openrouter"
     assert any("403" in message for message in result.messages)

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -38,6 +38,8 @@ async def _run_extract(monkeypatch, tmp_path, *, llm_exception: Exception | None
         ]
 
     def _fake_chunks(headers, _lines):  # noqa: ANN001 - test stub
+        if not headers:
+            return []
         return [
             {
                 "header_text": headers[0]["text"],
@@ -82,7 +84,7 @@ def test_extract_headers_llm_failure_emits_message(monkeypatch, tmp_path) -> Non
         )
     )
 
-    assert result["mode"] == "native"
+    assert result["mode"] == "llm_full_error"
     assert result["messages"]
     assert "HTTP 403" in result["messages"][0]
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -74,14 +74,22 @@ function updateHeaderModeTag(mode) {
   }
 
   const normalised = String(mode).toLowerCase();
-  let label = 'Heur';
-  let variant = 'heuristic';
-  let description = 'Headers derived via heuristic extraction.';
+  let label = 'LLM';
+  let variant = 'openrouter';
+  let description = 'Headers derived from the OpenRouter LLM.';
 
   if (normalised === 'llm_full') {
     label = 'LLM';
     variant = 'llm';
     description = 'Headers derived via LLM extraction.';
+  } else if (normalised === 'llm_full_error') {
+    label = 'LLM';
+    variant = 'llm';
+    description = 'LLM header extraction failed; see logs for details.';
+  } else if (normalised === 'llm_disabled') {
+    label = 'Off';
+    variant = 'openrouter';
+    description = 'LLM header extraction is disabled.';
   }
 
   tag.textContent = label;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -350,7 +350,7 @@ body {
   color: var(--accent-strong);
 }
 
-.panel-tag[data-variant='heuristic'] {
+.panel-tag[data-variant='openrouter'] {
   background: color-mix(in srgb, var(--success) 22%, transparent);
   border-color: color-mix(in srgb, var(--success) 45%, transparent);
   color: var(--success);

--- a/tests/test_headers_golden.py
+++ b/tests/test_headers_golden.py
@@ -1,4 +1,4 @@
-"""Golden tests validating header extraction heuristics and endpoint."""
+"""Golden tests validating LLM-driven header extraction and endpoint."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from sqlmodel import Session
 from backend.config import Settings, reset_settings_cache
 from backend.database import get_engine, init_db, reset_database_state
 from backend.models import Document
-from backend.services.headers import extract_headers
+from backend.services.headers import HeaderExtractionResult, HeaderNode, extract_headers
 from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
 
 
@@ -127,8 +127,30 @@ def client() -> Generator[TestClient, None, None]:
 
 def test_extract_headers_generates_expected_outline(tmp_path: Path) -> None:
     parse_result = _sample_parse_result()
+    class StubLLM:
+        is_enabled = True
+
+        def refine_outline(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            root1 = HeaderNode(title="General Requirements", numbering="1", page=0)
+            root1.children.extend(
+                [
+                    HeaderNode(title="Scope", numbering="1.1", page=0),
+                    HeaderNode(title="References", numbering="1.2", page=0),
+                ]
+            )
+            root2 = HeaderNode(title="Materials", numbering="2", page=1)
+            root2.children.extend(
+                [
+                    HeaderNode(title="Steel Alloys", numbering="2.1", page=1),
+                    HeaderNode(title="Aluminum", numbering="2.2", page=1),
+                ]
+            )
+            outline = [root1, root2]
+            fenced = "#headers#\n{\"headers\": []}\n#/headers#"
+            return HeaderExtractionResult(outline=outline, fenced_text=fenced, source="openrouter")
+
     settings = Settings(upload_dir=tmp_path)
-    result = extract_headers(parse_result, settings=settings, llm_client=None)
+    result = extract_headers(parse_result, settings=settings, llm_client=StubLLM())
 
     expected_outline = [
         {
@@ -166,6 +188,7 @@ def test_toc_pages_are_ignored(tmp_path: Path) -> None:
     settings = Settings(upload_dir=tmp_path)
     result = extract_headers(parse_result, settings=settings, llm_client=None)
     assert result.outline == []
+    assert "disabled" in result.messages[0].lower()
 
 
 def test_headers_endpoint_returns_outline(
@@ -264,16 +287,33 @@ def test_headers_endpoint_returns_outline(
             "excluded_pages": [],
         }
 
+    class StubHeadersClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.is_enabled = True
+
+        def refine_outline(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            root = HeaderNode(title="General Requirements", numbering="1", page=0)
+            root.children.append(
+                HeaderNode(title="Scope", numbering="1.1", page=0)
+            )
+            fenced = "#headers#\n{\"headers\": []}\n#/headers#"
+            return HeaderExtractionResult(
+                outline=[root], fenced_text=fenced, source="openrouter"
+            )
+
     monkeypatch.setattr("backend.routers.headers.parse_pdf", _mock_parse)
     monkeypatch.setattr(
         "backend.routers.headers.extract_headers_and_chunks",
         _mock_extract_headers_and_chunks,
     )
+    monkeypatch.setattr(
+        "backend.routers.headers.HeadersLLMClient", lambda settings: StubHeadersClient()
+    )
 
     response = client.post(f"/api/headers/{document.id}")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["source"] == "heuristic"
+    assert payload["source"] == "openrouter"
     assert payload["document_id"] == document.id
     assert payload["outline"][0]["title"] == "General Requirements"
     assert payload["outline"][0]["children"][0]["title"] == "Scope"


### PR DESCRIPTION
## Summary
- remove the native heuristic header extractor and require OpenRouter output throughout the backend
- adjust the orchestrator, UI indicators, and documentation to reflect the LLM-only workflow
- update unit tests to mock the LLM client and cover the new control flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690019b6e10483248a7a2b414c37d93f