### PR TITLE
Add panel for header LLM raw response

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -58,6 +58,13 @@
           <div class="panel-body" id="parse-content" aria-live="polite"></div>
         </section>
 
+        <section class="panel" id="panel-header-raw" aria-labelledby="panel-header-raw-title">
+          <div class="panel-header">
+            <h3 id="panel-header-raw-title">LLM raw response</h3>
+          </div>
+          <div class="panel-body" id="headers-raw-content" aria-live="polite"></div>
+        </section>
+
         <section class="panel" id="panel-headers" aria-labelledby="panel-headers-title">
           <div class="panel-header">
             <div class="panel-header__title">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -19,6 +19,7 @@ import {
   setPanelLoading,
   setPanelError,
   renderParseSummary,
+  renderHeaderRawResponse,
   renderHeaderOutline,
   renderSpecsBuckets,
   renderRiskPanel,
@@ -50,6 +51,7 @@ const elements = {
   workspaceSubtitle: document.querySelector('#workspace-subtitle'),
   parseContent: document.querySelector('#parse-content'),
   headersContent: document.querySelector('#headers-content'),
+  headersRawContent: document.querySelector('#headers-raw-content'),
   specsContent: document.querySelector('#specs-content'),
   riskContent: document.querySelector('#risk-content'),
   approveSpecs: document.querySelector('#approve-specs'),
@@ -197,6 +199,7 @@ async function selectDocument(documentId) {
 
   setPanelLoading(elements.parseContent, 'Parsing document…');
   setPanelLoading(elements.headersContent, 'Generating outline…');
+  setPanelLoading(elements.headersRawContent, 'Fetching raw LLM response…');
   setPanelLoading(elements.specsContent, 'Classifying specification lines…');
   setPanelLoading(elements.riskContent, 'Computing risk score…');
   updateHeaderModeTag(null);
@@ -228,6 +231,7 @@ async function selectDocument(documentId) {
 
     if (headersResult.status === 'fulfilled') {
       state.headers = headersResult.value;
+      renderHeaderRawResponse(elements.headersRawContent, state.headers?.fenced_text ?? '');
       renderHeaderOutline(elements.headersContent, state.headers, {
         documentId,
         fetchSection: fetchSectionText,
@@ -243,6 +247,10 @@ async function selectDocument(documentId) {
       }
     } else {
       state.headers = null;
+      setPanelError(
+        elements.headersRawContent,
+        headersResult.reason?.message ?? 'Unable to load raw response.',
+      );
       setPanelError(elements.headersContent, headersResult.reason?.message ?? 'Unable to load headers.');
       updateHeaderModeTag(null);
     }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -195,6 +195,21 @@ export function renderParseSummary(container, payload) {
   container.append(grid);
 }
 
+export function renderHeaderRawResponse(container, text) {
+  if (!container) return;
+  if (!text || !String(text).trim()) {
+    container.innerHTML = '<p class="panel-status">Raw response unavailable.</p>';
+    return;
+  }
+
+  const pre = document.createElement('pre');
+  pre.className = 'raw-response';
+  pre.textContent = String(text);
+
+  container.innerHTML = '';
+  container.append(pre);
+}
+
 export function renderHeaderOutline(container, payload, options = {}) {
   if (!container) return;
   if (Array.isArray(payload?.simpleheaders) && payload.simpleheaders.length && Array.isArray(payload.sections) && payload.sections.length) {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -369,6 +369,21 @@ body {
   min-height: 120px;
 }
 
+.raw-response {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  background: color-mix(in srgb, var(--bg-panel) 98%, CanvasText 2%);
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
 .simpleheaders {
   display: grid;
   gap: 1.25rem;


### PR DESCRIPTION
## Summary
- add a dedicated panel above the header outline to display the raw LLM response
- render the raw response with a new UI helper and styling that preserves formatting
- hook the panel into the existing header loading and error states

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69015b04fab48324ae8a51b7c7180979