### PR TITLE
Persist document artifacts and expose retrieval endpoints

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -49,6 +49,7 @@ def init_db() -> None:
     """Initialise database tables."""
 
     from .models import (  # noqa: F401  Ensures models are registered with SQLModel metadata.
+        artifacts,
         document,
         spec_record,
     )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,6 +1,28 @@
 """Database models for the SimpleSpecs backend."""
 
+from .artifacts import (
+    DocumentArtifact,
+    DocumentArtifactType,
+    DocumentEmbedding,
+    DocumentEntity,
+    DocumentFigure,
+    DocumentPage,
+    DocumentTable,
+    PromptResponse,
+)
 from .document import Document
 from .spec_record import SpecAuditEntry, SpecRecord
 
-__all__ = ["Document", "SpecRecord", "SpecAuditEntry"]
+__all__ = [
+    "Document",
+    "DocumentArtifact",
+    "DocumentArtifactType",
+    "DocumentEmbedding",
+    "DocumentEntity",
+    "DocumentFigure",
+    "DocumentPage",
+    "DocumentTable",
+    "PromptResponse",
+    "SpecRecord",
+    "SpecAuditEntry",
+]

--- a/backend/models/artifacts.py
+++ b/backend/models/artifacts.py
@@ -1,0 +1,213 @@
+"""Database models for persisted document artifacts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Optional
+
+from sqlalchemy import JSON, Column, Enum as SAEnum, Float, LargeBinary, Text, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+
+    return datetime.now(UTC)
+
+
+class DocumentArtifactType(str, Enum):
+    """Enumerated artifact families persisted for a document."""
+
+    HEADER_TREE = "header_tree"
+    SECTION = "section"
+    TABLE_CSV = "table_csv"
+    TABLE_JSON = "table_json"
+    FIGURE_THUMB = "figure_thumb"
+    FIGURE_OCR = "figure_ocr"
+    SUMMARY_DOC = "summary_doc"
+    SUMMARY_SECTION = "summary_section"
+    ENTITIES = "entities"
+    EMBEDDINGS_INDEX = "embeddings_index"
+    PROMPT_RESPONSE = "prompt_response"
+    PAGE_LAYOUT = "page_layout"
+
+
+class DocumentPage(SQLModel, table=True):
+    """Flattened representation of a parsed document page."""
+
+    __tablename__ = "document_pages"
+    __table_args__ = (
+        UniqueConstraint("document_id", "page_index", name="uq_document_page_index"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    page_index: int = Field(nullable=False)
+    width: float = Field(nullable=False)
+    height: float = Field(nullable=False)
+    text_raw: str = Field(
+        default="",
+        sa_column=Column(Text, nullable=False),
+        description="Concatenated text extracted from the page.",
+    )
+    layout: list[dict[str, Any]] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+        description="Structured block layout for the page.",
+    )
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class DocumentTable(SQLModel, table=True):
+    """Structured metadata for detected tables within a document."""
+
+    __tablename__ = "document_tables"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    page_index: int = Field(nullable=False)
+    bbox: list[float] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+        description="Bounding box describing the table location.",
+    )
+    flavor: str | None = Field(default=None, nullable=True)
+    accuracy: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class DocumentFigure(SQLModel, table=True):
+    """Detected figures, thumbnails, and optional OCR content."""
+
+    __tablename__ = "document_figures"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    page_index: int = Field(nullable=False)
+    bbox: list[float] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+    )
+    thumb_path: str | None = Field(default=None, nullable=True)
+    ocr_text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class DocumentArtifact(SQLModel, table=True):
+    """Generic persisted artifact keyed by document and input hash."""
+
+    __tablename__ = "document_artifacts"
+    __table_args__ = (
+        UniqueConstraint(
+            "document_id",
+            "artifact_type",
+            "artifact_key",
+            "sha_inputs",
+            name="uq_document_artifact_cache",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    artifact_type: DocumentArtifactType = Field(
+        sa_column=Column(SAEnum(DocumentArtifactType), nullable=False)
+    )
+    artifact_key: str = Field(nullable=False)
+    sha_inputs: str = Field(nullable=False, index=True)
+    body: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+        description="Structured payload for the artifact.",
+    )
+    text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    blob_path: str | None = Field(default=None, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class DocumentEntity(SQLModel, table=True):
+    """Named entities identified within a document."""
+
+    __tablename__ = "document_entities"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    entity_type: str = Field(nullable=False, description="Entity category label.")
+    value: str = Field(nullable=False)
+    span_start: int | None = Field(default=None, nullable=True)
+    span_end: int | None = Field(default=None, nullable=True)
+    page_index: int | None = Field(default=None, nullable=True)
+    section_path: str | None = Field(default=None, nullable=True)
+    source: str | None = Field(default=None, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class DocumentEmbedding(SQLModel, table=True):
+    """Vector representations associated with document chunks."""
+
+    __tablename__ = "document_embeddings"
+    __table_args__ = (
+        UniqueConstraint(
+            "document_id",
+            "chunk_id",
+            "sha_model",
+            name="uq_document_embedding_chunk",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    chunk_id: str = Field(nullable=False)
+    dimension: int = Field(nullable=False)
+    vector: bytes = Field(sa_column=Column(LargeBinary, nullable=False))
+    norm: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
+    text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    header_path: str | None = Field(default=None, nullable=True)
+    page_index: int | None = Field(default=None, nullable=True)
+    sha_model: str = Field(nullable=False, index=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+class PromptResponse(SQLModel, table=True):
+    """LLM prompt / response cache scoped to documents."""
+
+    __tablename__ = "prompt_responses"
+    __table_args__ = (
+        UniqueConstraint(
+            "document_id",
+            "artifact_type",
+            "prompt_hash",
+            "model",
+            name="uq_prompt_response_cache",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    artifact_type: str = Field(nullable=False)
+    prompt_hash: str = Field(nullable=False, index=True)
+    model: str = Field(nullable=False)
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    request_text_ref: str | None = Field(default=None, nullable=True)
+    response_text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    usage: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+__all__ = [
+    "DocumentArtifact",
+    "DocumentArtifactType",
+    "DocumentEmbedding",
+    "DocumentEntity",
+    "DocumentFigure",
+    "DocumentPage",
+    "DocumentTable",
+    "PromptResponse",
+]
+

--- a/backend/models/document.py
+++ b/backend/models/document.py
@@ -25,3 +25,28 @@ class Document(SQLModel, table=True):
     status: str = Field(
         default="uploaded", description="Processing status for the document."
     )
+    mime_type: str | None = Field(
+        default=None, description="Detected MIME type for the uploaded document."
+    )
+    byte_size: int = Field(
+        default=0, description="Size of the uploaded document in bytes."
+    )
+    page_count: int | None = Field(
+        default=None, description="Number of pages detected during parsing."
+    )
+    has_ocr: bool = Field(
+        default=False,
+        description="Whether OCR was required during the last parse run.",
+    )
+    used_mineru: bool = Field(
+        default=False,
+        description="Whether the MinerU fallback parser was used during parsing.",
+    )
+    parser_version: str | None = Field(
+        default=None,
+        description="Version identifier for the parser that produced stored artifacts.",
+    )
+    last_parsed_at: datetime | None = Field(
+        default=None,
+        description="Timestamp of the most recent parsing operation.",
+    )

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from .compare import router as compare_router
+from .documents import router as documents_router
 from .files import router as files_router
 from .health import router as health_router
 from .headers import router as headers_router
@@ -12,6 +13,7 @@ from .specs import router as specs_router
 
 api_router = APIRouter()
 api_router.include_router(files_router)
+api_router.include_router(documents_router)
 api_router.include_router(headers_router)
 api_router.include_router(health_router)
 api_router.include_router(parse_router)

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,0 +1,208 @@
+"""Document retrieval endpoints backed by persisted artifacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import desc, select
+from sqlmodel import Session
+
+from ..database import get_session
+from ..models import (
+    Document,
+    DocumentArtifact,
+    DocumentArtifactType,
+    DocumentPage,
+    DocumentTable,
+)
+
+router = APIRouter(prefix="/api", tags=["documents"])
+
+
+class PageBlockPayload(BaseModel):
+    """Schema describing a stored page block."""
+
+    text: str
+    bbox: tuple[float, float, float, float]
+    font: str | None = None
+    font_size: float | None = None
+    source: str | None = None
+
+
+class DocumentPagePayload(BaseModel):
+    """Page payload containing raw text and layout information."""
+
+    page_index: int
+    width: float
+    height: float
+    text_raw: str
+    layout: list[PageBlockPayload] = Field(default_factory=list)
+
+
+class TablePayload(BaseModel):
+    """Representation of a stored table marker."""
+
+    page_index: int
+    bbox: tuple[float, float, float, float]
+    flavor: str | None = None
+    accuracy: float | None = None
+
+
+class StoredHeadersResponse(BaseModel):
+    """Cached header tree retrieved from the artifact store."""
+
+    headers: list[dict[str, Any]] = Field(default_factory=list)
+    sections: list[dict[str, Any]] = Field(default_factory=list)
+    mode: str | None = None
+    messages: list[str] = Field(default_factory=list)
+    doc_hash: str | None = None
+    created_at: str | None = None
+
+
+@router.get("/documents/{document_id}", response_model=Document)
+async def get_document(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+) -> Document:
+    """Return stored metadata for a document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+    return document
+
+
+@router.get(
+    "/documents/{document_id}/pages", response_model=list[DocumentPagePayload]
+)
+async def get_document_pages(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+) -> list[DocumentPagePayload]:
+    """Return persisted page layouts for a document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    statement = (
+        select(DocumentPage)
+        .where(DocumentPage.document_id == document_id)
+        .order_by(DocumentPage.page_index)
+    )
+    pages = session.exec(statement).all()
+
+    payload: list[DocumentPagePayload] = []
+    for page in pages:
+        layout_blocks = []
+        for block in page.layout:
+            bbox_values = tuple(float(value) for value in block.get("bbox", (0, 0, 0, 0)))
+            layout_blocks.append(
+                PageBlockPayload(
+                    text=str(block.get("text", "")),
+                    bbox=bbox_values,  # type: ignore[arg-type]
+                    font=block.get("font"),
+                    font_size=block.get("font_size"),
+                    source=block.get("source"),
+                )
+            )
+        payload.append(
+            DocumentPagePayload(
+                page_index=page.page_index,
+                width=page.width,
+                height=page.height,
+                text_raw=page.text_raw,
+                layout=layout_blocks,
+            )
+        )
+
+    return payload
+
+
+@router.get(
+    "/documents/{document_id}/tables", response_model=list[TablePayload]
+)
+async def get_document_tables(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+) -> list[TablePayload]:
+    """Return detected table markers for a document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    statement = (
+        select(DocumentTable)
+        .where(DocumentTable.document_id == document_id)
+        .order_by(DocumentTable.page_index)
+    )
+    tables = session.exec(statement).all()
+    payload: list[TablePayload] = []
+    for table in tables:
+        bbox_values = tuple(float(value) for value in table.bbox)
+        payload.append(
+            TablePayload(
+                page_index=table.page_index,
+                bbox=bbox_values,  # type: ignore[arg-type]
+                flavor=table.flavor,
+                accuracy=table.accuracy,
+            )
+        )
+    return payload
+
+
+@router.get(
+    "/documents/{document_id}/headers", response_model=StoredHeadersResponse
+)
+async def get_cached_headers(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+) -> StoredHeadersResponse:
+    """Return the most recent cached header tree for a document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    statement = (
+        select(DocumentArtifact)
+        .where(
+            DocumentArtifact.document_id == document_id,
+            DocumentArtifact.artifact_type == DocumentArtifactType.HEADER_TREE,
+        )
+        .order_by(desc(DocumentArtifact.created_at))
+    )
+    artifact = session.exec(statement).first()
+    if artifact is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No cached headers"
+        )
+
+    payload = dict(artifact.body)
+    return StoredHeadersResponse(
+        headers=list(payload.get("headers", [])),
+        sections=list(payload.get("sections", [])),
+        mode=payload.get("mode"),
+        messages=list(payload.get("messages", [])),
+        doc_hash=payload.get("doc_hash"),
+        created_at=artifact.created_at.isoformat() if artifact.created_at else None,
+    )
+
+
+__all__ = ["router"]
+

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
@@ -197,11 +199,21 @@ async def generate_headers(
     result = extract_headers(parse_result, settings=settings, llm_client=llm_client)
 
     native_flat = flatten_outline(result.outline)
+    orchestrator_kwargs = {
+        "settings": settings,
+        "native_headers": native_flat,
+        "metadata": {"filename": document.filename},
+    }
+
+    signature = inspect.signature(extract_headers_and_chunks)
+    if "session" in signature.parameters:
+        orchestrator_kwargs["session"] = session
+    if "document" in signature.parameters:
+        orchestrator_kwargs["document"] = document
+
     orchestrated = await extract_headers_and_chunks(
         document_bytes,
-        settings=settings,
-        native_headers=native_flat,
-        metadata={"filename": document.filename},
+        **orchestrator_kwargs,
     )
 
     SimpleHeadersState.set(doc_id, orchestrated["doc_hash"], orchestrated["lines"])

--- a/backend/routers/parse.py
+++ b/backend/routers/parse.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
+from ..services.artifact_store import persist_parse_result
 from ..services.pdf_native import ParseResult, parse_pdf
 
 router = APIRouter(prefix="/api", tags=["parse"])
@@ -81,6 +82,7 @@ async def parse_document(
         )
 
     result: ParseResult = parse_pdf(document_path, settings=settings)
+    persist_parse_result(session=session, document=document, parse_result=result)
     payload = result.to_dict()
     return ParseResponse(document_id=doc_id, **payload)
 

--- a/backend/services/artifact_store.py
+++ b/backend/services/artifact_store.py
@@ -1,0 +1,189 @@
+"""Helpers for persisting and retrieving document artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from sqlalchemy import delete, select
+from sqlmodel import Session
+
+from ..models import (
+    Document,
+    DocumentArtifact,
+    DocumentArtifactType,
+    DocumentPage,
+    DocumentTable,
+)
+from ..services.pdf_native import ParseResult
+
+PARSER_VERSION = "2025.01"
+
+
+def _now() -> datetime:
+    """Return the current UTC timestamp."""
+
+    return datetime.now(UTC)
+
+
+def _normalise_inputs(inputs: Mapping[str, Any]) -> str:
+    """Return a deterministic JSON serialisation for hashing purposes."""
+
+    def _default(value: Any) -> Any:  # noqa: ANN401 - json fallback hook
+        if isinstance(value, set):
+            return sorted(value)
+        if isinstance(value, (datetime,)):
+            return value.isoformat()
+        if isinstance(value, Path):
+            return str(value)
+        return value
+
+    packed = json.dumps(inputs, sort_keys=True, default=_default, separators=(",", ":"))
+    return hashlib.sha256(packed.encode("utf-8")).hexdigest()
+
+
+def persist_parse_result(
+    *, session: Session, document: Document, parse_result: ParseResult
+) -> None:
+    """Persist parsed pages and tables for a document."""
+
+    if document.id is None:
+        raise ValueError("Document must be persisted before storing artifacts")
+
+    document_id = document.id
+
+    session.exec(delete(DocumentPage).where(DocumentPage.document_id == document_id))
+    session.exec(delete(DocumentTable).where(DocumentTable.document_id == document_id))
+
+    for page in parse_result.pages:
+        layout = [
+            {
+                "text": block.text,
+                "bbox": list(block.bbox),
+                "font": block.font,
+                "font_size": block.font_size,
+                "source": block.source,
+            }
+            for block in page.blocks
+        ]
+        text_content = "\n".join(block.text for block in page.blocks if block.text)
+        session.add(
+            DocumentPage(
+                document_id=document_id,
+                page_index=page.page_number,
+                width=page.width,
+                height=page.height,
+                text_raw=text_content,
+                layout=layout,
+            )
+        )
+
+    for page in parse_result.pages:
+        for marker in page.tables:
+            session.add(
+                DocumentTable(
+                    document_id=document_id,
+                    page_index=marker.page_number,
+                    bbox=list(marker.bbox),
+                    flavor=marker.flavor,
+                    accuracy=marker.accuracy,
+                )
+            )
+
+    document.page_count = len(parse_result.pages)
+    document.has_ocr = parse_result.has_ocr
+    document.used_mineru = parse_result.used_mineru
+    document.parser_version = PARSER_VERSION
+    document.last_parsed_at = _now()
+    document.status = "parsed"
+    session.add(document)
+    session.commit()
+
+
+def get_cached_artifact(
+    *,
+    session: Session,
+    document_id: int,
+    artifact_type: DocumentArtifactType,
+    key: str,
+    inputs: Mapping[str, Any],
+) -> DocumentArtifact | None:
+    """Return a cached artifact if the hashed inputs match."""
+
+    sha_inputs = _normalise_inputs(inputs)
+    statement = select(DocumentArtifact).where(
+        DocumentArtifact.document_id == document_id,
+        DocumentArtifact.artifact_type == artifact_type,
+        DocumentArtifact.artifact_key == key,
+        DocumentArtifact.sha_inputs == sha_inputs,
+    )
+    result = session.exec(statement).first()
+    if result is None:
+        return None
+    if isinstance(result, DocumentArtifact):
+        return result
+    if hasattr(result, "__getitem__"):
+        try:
+            candidate = result[0]
+            if isinstance(candidate, DocumentArtifact):
+                return candidate
+        except (IndexError, KeyError, TypeError):
+            pass
+    return result
+
+
+def store_artifact(
+    *,
+    session: Session,
+    document_id: int,
+    artifact_type: DocumentArtifactType,
+    key: str,
+    inputs: Mapping[str, Any],
+    body: Mapping[str, Any] | Iterable[Mapping[str, Any]],
+    text: str | None = None,
+    blob_path: str | None = None,
+) -> DocumentArtifact:
+    """Persist an artifact payload keyed by the hashed inputs."""
+
+    sha_inputs = _normalise_inputs(inputs)
+    existing = get_cached_artifact(
+        session=session,
+        document_id=document_id,
+        artifact_type=artifact_type,
+        key=key,
+        inputs=inputs,
+    )
+    if existing is not None:
+        return existing
+
+    payload: dict[str, Any]
+    if isinstance(body, Mapping):
+        payload = dict(body)
+    else:
+        payload = {"items": list(body)}
+
+    artifact = DocumentArtifact(
+        document_id=document_id,
+        artifact_type=artifact_type,
+        artifact_key=key,
+        sha_inputs=sha_inputs,
+        body=payload,
+        text=text,
+        blob_path=blob_path,
+    )
+    session.add(artifact)
+    session.commit()
+    session.refresh(artifact)
+    return artifact
+
+
+__all__ = [
+    "PARSER_VERSION",
+    "get_cached_artifact",
+    "persist_parse_result",
+    "store_artifact",
+]
+

--- a/backend/services/files.py
+++ b/backend/services/files.py
@@ -15,7 +15,16 @@ from sqlalchemy import desc
 from sqlmodel import Session, delete, select
 
 from ..config import Settings
-from ..models import Document
+from ..models import (
+    Document,
+    DocumentArtifact,
+    DocumentEmbedding,
+    DocumentEntity,
+    DocumentFigure,
+    DocumentPage,
+    DocumentTable,
+    PromptResponse,
+)
 from ..models.spec_record import SpecAuditEntry, SpecRecord
 
 CHUNK_SIZE = 1024 * 1024  # 1MB
@@ -78,6 +87,16 @@ async def handle_upload(
         select(Document).where(Document.checksum == checksum)
     ).first()
     if existing_document:
+        updated = False
+        if not existing_document.mime_type and upload.content_type:
+            existing_document.mime_type = upload.content_type
+            updated = True
+        if existing_document.byte_size == 0:
+            existing_document.byte_size = total_bytes
+            updated = True
+        if updated:
+            session.add(existing_document)
+            session.commit()
         if temp_path.exists():
             temp_path.unlink()
         return existing_document, False
@@ -87,6 +106,8 @@ async def handle_upload(
         checksum=checksum,
         uploaded_at=datetime.now(UTC),
         status="uploaded",
+        mime_type=upload.content_type,
+        byte_size=total_bytes,
     )
     session.add(document)
     session.commit()
@@ -125,6 +146,17 @@ def delete_document(
         delete(SpecAuditEntry).where(SpecAuditEntry.document_id == document_id)
     )
     session.exec(delete(SpecRecord).where(SpecRecord.document_id == document_id))
+    session.exec(delete(DocumentPage).where(DocumentPage.document_id == document_id))
+    session.exec(delete(DocumentTable).where(DocumentTable.document_id == document_id))
+    session.exec(delete(DocumentFigure).where(DocumentFigure.document_id == document_id))
+    session.exec(delete(DocumentEntity).where(DocumentEntity.document_id == document_id))
+    session.exec(
+        delete(DocumentEmbedding).where(DocumentEmbedding.document_id == document_id)
+    )
+    session.exec(delete(DocumentArtifact).where(DocumentArtifact.document_id == document_id))
+    session.exec(
+        delete(PromptResponse).where(PromptResponse.document_id == document_id)
+    )
     session.delete(document)
     session.commit()
 

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -6,8 +6,12 @@ import logging
 import re
 from typing import Iterable, Mapping, Sequence
 
-from backend.config import Settings
+from sqlmodel import Session
 
+from backend.config import Settings
+from backend.models import Document, DocumentArtifactType
+
+from .artifact_store import PARSER_VERSION, get_cached_artifact, store_artifact
 from .header_locator import locate_headers_in_lines
 from .pdf_headers_llm_full import get_headers_llm_full
 from .pdf_native import collect_line_metrics
@@ -47,6 +51,8 @@ async def extract_headers_and_chunks(
     settings: Settings,
     native_headers: Sequence[Mapping[str, object]] | None = None,
     metadata: Mapping[str, object] | None = None,
+    session: Session | None = None,
+    document: Document | None = None,
 ) -> dict:
     """Return located headers and section ranges for the provided document."""
 
@@ -60,6 +66,36 @@ async def extract_headers_and_chunks(
     located_headers: list[dict] = []
     mode_used = "llm_full"
     messages: list[str] = []
+
+    doc_id = document.id if document and document.id is not None else None
+    cache_inputs = {
+        "doc_hash": doc_hash,
+        "parser_version": PARSER_VERSION,
+        "headers_mode": settings.headers_mode.lower(),
+        "suppress_toc": settings.headers_suppress_toc,
+        "suppress_running": settings.headers_suppress_running,
+        "metadata": dict(metadata or {}),
+    }
+
+    if session is not None and doc_id is not None:
+        cached = get_cached_artifact(
+            session=session,
+            document_id=doc_id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            key=settings.headers_mode.lower(),
+            inputs=cache_inputs,
+        )
+        if cached is not None:
+            payload = dict(cached.body)
+            return {
+                "headers": payload.get("headers", []),
+                "sections": payload.get("sections", []),
+                "mode": payload.get("mode", "cache"),
+                "lines": lines,
+                "doc_hash": doc_hash,
+                "excluded_pages": sorted(excluded_pages),
+                "messages": payload.get("messages", []),
+            }
 
     if settings.headers_mode.lower() == "llm_full":
         try:
@@ -84,6 +120,22 @@ async def extract_headers_and_chunks(
         messages.append("LLM header extraction is disabled by configuration.")
 
     located_headers, sections = _enforce_header_sequence(located_headers, lines)
+
+    if session is not None and doc_id is not None:
+        store_artifact(
+            session=session,
+            document_id=doc_id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            key=settings.headers_mode.lower(),
+            inputs=cache_inputs,
+            body={
+                "headers": located_headers,
+                "sections": sections,
+                "mode": mode_used,
+                "messages": messages,
+                "doc_hash": doc_hash,
+            },
+        )
 
     return {
         "headers": located_headers,

--- a/backend/tests/test_artifact_store.py
+++ b/backend/tests/test_artifact_store.py
@@ -1,0 +1,110 @@
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from backend.models import Document, DocumentArtifactType, DocumentPage, DocumentTable
+from backend.services.artifact_store import (
+    PARSER_VERSION,
+    get_cached_artifact,
+    persist_parse_result,
+    store_artifact,
+)
+from backend.services.pdf_native import ParsedBlock, ParsedPage, ParsedTable, ParseResult
+
+
+def _make_session() -> Session:
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_persist_parse_result_stores_pages_and_tables() -> None:
+    session = _make_session()
+    with session:
+        document = Document(filename="doc.pdf", checksum="abc")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+        parse_result = ParseResult(
+            pages=[
+                ParsedPage(
+                    page_number=0,
+                    width=100.0,
+                    height=200.0,
+                    blocks=[
+                        ParsedBlock(
+                            text="Heading",
+                            bbox=(0.0, 0.0, 10.0, 10.0),
+                            font="Arial",
+                            font_size=12.0,
+                        )
+                    ],
+                    tables=[
+                        ParsedTable(
+                            page_number=0,
+                            bbox=(1.0, 2.0, 3.0, 4.0),
+                            flavor="stream",
+                            accuracy=0.87,
+                        )
+                    ],
+                )
+            ],
+            has_ocr=True,
+            used_mineru=False,
+        )
+
+        persist_parse_result(session=session, document=document, parse_result=parse_result)
+
+        stored_pages = session.exec(select(DocumentPage)).all()
+        stored_tables = session.exec(select(DocumentTable)).all()
+        refreshed = session.get(Document, document.id)
+
+        assert len(stored_pages) == 1
+        assert stored_pages[0].text_raw.strip() == "Heading"
+        assert len(stored_tables) == 1
+        assert refreshed is not None
+        assert refreshed.page_count == 1
+        assert refreshed.has_ocr is True
+        assert refreshed.parser_version == PARSER_VERSION
+
+
+def test_store_artifact_reuses_existing_entry() -> None:
+    session = _make_session()
+    with session:
+        document = Document(filename="doc.pdf", checksum="def")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+        inputs = {"doc_hash": "123", "parser_version": PARSER_VERSION}
+
+        first = store_artifact(
+            session=session,
+            document_id=document.id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            key="llm_full",
+            inputs=inputs,
+            body={"headers": []},
+        )
+
+        again = store_artifact(
+            session=session,
+            document_id=document.id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            key="llm_full",
+            inputs=inputs,
+            body={"headers": [1]},
+        )
+
+        fetched = get_cached_artifact(
+            session=session,
+            document_id=document.id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            key="llm_full",
+            inputs=inputs,
+        )
+
+        assert first.id == again.id
+        assert fetched is not None
+        assert fetched.id == first.id
+        assert fetched.body.get("headers") == []
+


### PR DESCRIPTION
## Summary
- expand the document schema and add dedicated tables for persisted artifacts, pages, and caches
- save native parse results into the database and reuse stored header artifacts before hitting the LLM
- expose new retrieval APIs for stored pages, tables, and cached headers and cover the artifact store with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_69016047f31c8324a47f528d02658000