### PR TITLE
Fix refresh button label initialization and embed favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,11 @@
     <meta name="api-base" content="/api" />
     <title>SimpleSpecs</title>
     <link rel="stylesheet" href="/static/styles.css" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231d4ed8'/%3E%3Ctext x='32' y='42' font-size='36' text-anchor='middle' font-family='Arial,Helvetica,sans-serif' fill='white'%3ESS%3C/text%3E%3C/svg%3E"
+    />
   </head>
   <body>
     <div class="app-shell" data-theme="light">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -302,7 +302,9 @@ function setHeaderRefreshBusy(busy) {
     return;
   }
 
-  const defaultLabel = button.dataset.defaultLabel ?? button.textContent.trim() || 'Refresh';
+  const labelFromText = (button.textContent || '').trim();
+  const defaultLabel =
+    button.dataset.defaultLabel ?? (labelFromText || 'Refresh');
   button.dataset.defaultLabel = defaultLabel;
 
   if (busy) {


### PR DESCRIPTION
## Summary
- ensure the refresh button label fallback avoids mixing nullish coalescing with logical operators
- embed an inline SVG favicon so browsers stop requesting a missing /favicon.ico

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69016910813483248090cec1d0520db7