### PR TITLE
Add automatic migration for document mime_type column

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import make_url
 from sqlmodel import Session, SQLModel, create_engine
 
 from .config import PROJECT_ROOT, get_settings
+from .migrations import run_migrations
 
 _engine = None
 
@@ -56,6 +57,7 @@ def init_db() -> None:
 
     engine = get_engine()
     SQLModel.metadata.create_all(engine)
+    run_migrations(engine)
 
 
 def reset_database_state() -> None:

--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -1,0 +1,40 @@
+"""Lightweight schema migration helpers for the SimpleSpecs backend."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import NoSuchTableError
+
+
+MigrationFunc = Callable[[Engine], None]
+
+
+def _ensure_document_mime_type(engine: Engine) -> None:
+    """Add the ``mime_type`` column to ``document`` if it is missing."""
+
+    with engine.begin() as connection:
+        inspector = inspect(connection)
+        try:
+            columns = inspector.get_columns("document")
+        except NoSuchTableError:
+            return
+
+        if any(column["name"] == "mime_type" for column in columns):
+            return
+
+        connection.execute(text("ALTER TABLE document ADD COLUMN mime_type VARCHAR"))
+
+
+_MIGRATIONS: tuple[MigrationFunc, ...] = (
+    _ensure_document_mime_type,
+)
+
+
+def run_migrations(engine: Engine, migrations: Iterable[MigrationFunc] | None = None) -> None:
+    """Execute idempotent schema migrations for the provided engine."""
+
+    for migration in migrations or _MIGRATIONS:
+        migration(engine)

--- a/backend/tests/test_database_migrations.py
+++ b/backend/tests/test_database_migrations.py
@@ -1,0 +1,48 @@
+"""Tests covering automatic database migrations."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from backend import database
+from backend.config import reset_settings_cache
+
+
+def _create_legacy_document_table(path: Path) -> None:
+    """Create a ``document`` table missing the ``mime_type`` column."""
+
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE document (
+                id INTEGER PRIMARY KEY,
+                filename VARCHAR NOT NULL,
+                checksum VARCHAR NOT NULL,
+                uploaded_at DATETIME NOT NULL,
+                status VARCHAR NOT NULL
+            )
+            """
+        )
+
+
+def test_init_db_backfills_mime_type_column(tmp_path, monkeypatch):
+    """``init_db`` should add the ``mime_type`` column when it is missing."""
+
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_document_table(db_path)
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    database.reset_database_state()
+    reset_settings_cache()
+
+    database.init_db()
+
+    with sqlite3.connect(db_path) as connection:
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info(document)")
+        }
+
+    assert "mime_type" in columns


### PR DESCRIPTION
## Summary
- add a lightweight migration runner that backfills the document.mime_type column when missing
- invoke the migration runner during database initialisation so legacy SQLite databases are upgraded
- add a regression test covering the mime_type backfill behaviour

## Testing
- pytest backend/tests/test_database_migrations.py

------
https://chatgpt.com/codex/tasks/task_e_69016a19ecdc8324a9d06f3c1c9739d4