### PR TITLE
Improve frontend API base resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ SimpleSpecs parses engineering specification PDFs and structures the extracted d
 5. Visit `http://localhost:8000/api/health` to verify the service responds with `{ "ok": true }`.
 6. Open `http://localhost:8000/` in your browser to use the SimpleSpecs web app; the FastAPI server serves the static frontend from the same origin.
 
+   If you need to host the static files separately (for example during local prototyping), add a `<meta name="api-base">` tag to `frontend/index.html` or assign `window.API_BASE` at runtime with the full API origin (e.g. `http://127.0.0.1:8000`). The frontend falls back to the same origin when no override is provided.
+
 The server creates the `uploads/` and `exports/` directories on startup if they are missing. Adjust their locations via the `UPLOAD_DIR` and `EXPORT_DIR` environment variables.
 
 ### Header extraction configuration

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="api-base" content="/api" />
+    <meta name="api-base" content="same-origin" />
     <title>SimpleSpecs</title>
     <link rel="stylesheet" href="/static/styles.css" />
     <link

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,7 +1,78 @@
-const API_BASE = "";
+const SAME_ORIGIN_KEYS = new Set(["", "/", ".", "auto", "same-origin"]);
+
+function normaliseBase(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  const lower = trimmed.toLowerCase();
+  if (SAME_ORIGIN_KEYS.has(lower)) {
+    return "";
+  }
+
+  if (trimmed.startsWith("//")) {
+    return `${window.location.protocol}${trimmed}`.replace(/\/+$/, "");
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/+$/, "");
+  }
+
+  if (trimmed.startsWith("/")) {
+    return `${window.location.origin}${trimmed}`.replace(/\/+$/, "");
+  }
+
+  return trimmed.replace(/\/+$/, "");
+}
+
+function resolveApiBase() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const candidates = [
+    typeof window.API_BASE === "string" ? window.API_BASE : null,
+    document?.querySelector?.('meta[name="api-base"]')?.getAttribute("content") ?? null,
+  ];
+
+  for (const candidate of candidates) {
+    const normalised = normaliseBase(candidate);
+    if (typeof normalised === "string") {
+      return normalised;
+    }
+  }
+
+  return "";
+}
+
+export const API_BASE = resolveApiBase();
+
+function buildUrl(path) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalisedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (!API_BASE) {
+    return normalisedPath;
+  }
+
+  const base = API_BASE.replace(/\/+$/, "");
+
+  if (/^https?:\/\//i.test(base)) {
+    if (normalisedPath.startsWith("/api/") && base.endsWith("/api")) {
+      return `${base}${normalisedPath.slice(4)}`;
+    }
+    return `${base}${normalisedPath}`;
+  }
+
+  return `${base}${normalisedPath}`;
+}
 
 async function request(path, options = {}) {
-  const url = `${API_BASE}${path}`;
+  const url = buildUrl(path);
   const config = {
     headers: { Accept: "application/json", ...(options.headers ?? {}) },
     ...options,
@@ -39,7 +110,7 @@ export async function listDocuments() {
 export function uploadDocument(file, onProgress) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open("POST", `${API_BASE}/api/upload`);
+    xhr.open("POST", buildUrl("/api/upload"));
     xhr.responseType = "json";
 
     xhr.upload.onprogress = (event) => {
@@ -77,7 +148,9 @@ export async function fetchHeaders(documentId) {
 
 export async function fetchSectionText(documentId, start, end) {
   const params = new URLSearchParams({ start: String(start), end: String(end) });
-  const response = await fetch(`${API_BASE}/api/headers/${documentId}/section-text?${params}`);
+  const response = await fetch(
+    buildUrl(`/api/headers/${documentId}/section-text?${params}`)
+  );
   const text = await response.text();
 
   if (!response.ok) {
@@ -113,7 +186,7 @@ export async function approveSpecRecord(documentId, body) {
 
 export async function downloadSpecExport(documentId, format) {
   const response = await fetch(
-    `${API_BASE}/api/specs/${documentId}/export?fmt=${encodeURIComponent(format)}`
+    buildUrl(`/api/specs/${documentId}/export?fmt=${encodeURIComponent(format)}`)
   );
   const clone = response.clone();
   const text = await clone.text();


### PR DESCRIPTION
## Summary
- allow the frontend API client to resolve an override from `window.API_BASE` or the `meta[name="api-base"]` tag while still defaulting to the same origin
- update the default frontend meta tag to advertise the same-origin behaviour and document how to override it when hosting the static files separately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69049a27e44083248933384609caa854