### PR TITLE
Add trace logging to header pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ SimpleSpecs sends the full document text to OpenRouter for a high-fidelity outli
 The pipeline requires `OPENROUTER_API_KEY`. Cached responses avoid repeated model invocations for unchanged documents.
 
 
+### Header trace debugging
+
+Set the following flags to capture a detailed, end-to-end trace of header discovery:
+
+```
+HEADERS_TRACE=1
+HEADERS_TRACE_DIR=backend/logs/headers
+HEADERS_TRACE_EMBED_RESPONSE=1  # optional: echo events in API responses
+HEADERS_LOG_LEVEL=DEBUG
+```
+
+With tracing enabled, each call to `POST /api/headers/{document_id}?trace=1` writes a JSONL file under `HEADERS_TRACE_DIR` and, when `trace=1` (or `HEADERS_TRACE_EMBED_RESPONSE=1`), returns the events inline:
+
+```bash
+curl -X POST "http://localhost:8000/api/headers/42?trace=1" \
+  -H "accept: application/json"
+```
+
+Each trace entry captures the reasoning behind the locator, including:
+
+- `start_run`, `doc_stats`, and `end_run` – run metadata, document shape, timings, and unresolved headers.
+- `pre_normalize_sample` / `normalized_line` – representative text before and after cleanup.
+- `toc_detected` / `running_header_filtered` – TOC and running-header suppression decisions.
+- `llm_outline_received` – outline size sampled from the LLM.
+- `candidate_found`, `candidate_scored`, `anchor_resolved`, `monotonic_violation`, `fallback_triggered` – per-header search and alignment decisions, including gap fills.
+
+Trace files are newline-delimited JSON and can be streamed into tooling such as `jq` for analysis.
+
+
 ## Windows single-file bundle (optional)
 A PyInstaller spec is provided for packaging the backend as a single executable on Windows.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -26,6 +26,20 @@ DEFAULT_TERMS_DIR = BASE_DIR / "resources" / "terms"
 DEFAULT_BASELINES_PATH = BASE_DIR / "resources" / "baselines" / "mandatory_clauses.json"
 
 
+HEADERS_TRACE: bool = os.getenv("HEADERS_TRACE", "0").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+HEADERS_TRACE_EMBED_RESPONSE: bool = (
+    os.getenv("HEADERS_TRACE_EMBED_RESPONSE", "0").strip().lower()
+    in {"1", "true", "yes", "on"}
+)
+HEADERS_TRACE_DIR: str = os.getenv("HEADERS_TRACE_DIR", "backend/logs/headers")
+HEADERS_LOG_LEVEL: str = os.getenv("HEADERS_LOG_LEVEL", "DEBUG")
+
+
 def _load_environment() -> None:
     """Load environment variables from a ``.env`` file if present."""
 

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import inspect
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
 from sqlmodel import Session
 
+import backend.config as app_config
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
@@ -83,6 +86,8 @@ class HeadersResponse(BaseModel):
     sections: list[SectionPayload] = Field(default_factory=list)
     mode: str | None = None
     messages: list[str] = Field(default_factory=list)
+    trace: list[dict[str, Any]] | None = None
+    trace_file: str | None = None
 
     @classmethod
     def from_result(
@@ -113,6 +118,7 @@ async def generate_headers(
     *,
     session: Session = Depends(get_session),
     settings: Settings = Depends(get_settings),
+    trace: bool = Query(False),
 ) -> HeadersResponse:
     """Return the hierarchical headers for a stored document."""
 
@@ -136,6 +142,8 @@ async def generate_headers(
         )
 
     document_bytes = document_path.read_bytes()
+
+    trace_requested = trace or app_config.HEADERS_TRACE_EMBED_RESPONSE
 
     if settings.headers_llm_strict:
         llm_service = LLMService(settings)
@@ -192,6 +200,8 @@ async def generate_headers(
                 simpleheaders=simpleheaders_payload,
                 sections=sections_payload,
                 mode="llm_strict",
+                trace=None,
+                trace_file=None,
             )
 
     parse_result = parse_pdf(document_path, settings=settings)
@@ -211,9 +221,10 @@ async def generate_headers(
     if "document" in signature.parameters:
         orchestrator_kwargs["document"] = document
 
-    orchestrated = await extract_headers_and_chunks(
+    orchestrated, tracer = await extract_headers_and_chunks(
         document_bytes,
         **orchestrator_kwargs,
+        want_trace=trace_requested,
     )
 
     SimpleHeadersState.set(doc_id, orchestrated["doc_hash"], orchestrated["lines"])
@@ -243,7 +254,7 @@ async def generate_headers(
         for section in orchestrated.get("sections", [])
     ]
 
-    return HeadersResponse.from_result(
+    response = HeadersResponse.from_result(
         doc_id,
         result,
         simpleheaders=simpleheaders_payload,
@@ -251,6 +262,12 @@ async def generate_headers(
         mode=orchestrated.get("mode"),
         messages=orchestrated.get("messages"),
     )
+
+    if trace_requested and tracer is not None:
+        response.trace = tracer.as_list()
+        response.trace_file = tracer.path
+
+    return response
 
 
 @router.get("/headers/{document_id}/section-text", response_class=PlainTextResponse)

--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -6,6 +6,8 @@ import re
 from difflib import SequenceMatcher
 from typing import Dict, Iterable, List, Sequence
 
+from ..utils.trace import HeaderTracer
+
 
 def _normalise(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip()).lower()
@@ -17,6 +19,7 @@ def locate_headers_in_lines(
     *,
     excluded_pages: Iterable[int] = (),
     similarity_threshold: float = 0.88,
+    tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
     """Return located headers with page and line metadata."""
 
@@ -32,6 +35,7 @@ def locate_headers_in_lines(
         usable.append(copy)
 
     located: list[Dict] = []
+    previous_anchor = -1
 
     for header in headers:
         target = _normalise(str(header.get("text", "")))
@@ -39,16 +43,46 @@ def locate_headers_in_lines(
             continue
         number = (header.get("number") or "").strip()
         candidates: list[dict] = []
+        if tracer:
+            pattern = rf"^\s*{re.escape(number)}" if number else None
+            tracer.ev(
+                "search_begin",
+                target=str(header.get("text", "")),
+                number=number or None,
+                pattern=pattern,
+            )
 
         for line in usable:
             text = str(line.get("text", ""))
             if number:
                 if re.match(rf"^\s*{re.escape(number)}(?:\b|[.)\-\s])", text):
                     candidates.append(line)
+                    if tracer:
+                        tracer.ev(
+                            "candidate_found",
+                            target=str(header.get("text", "")),
+                            page=int(line.get("page", 0)),
+                            line_idx=int(line.get("line_idx", 0)),
+                            snippet=text.strip(),
+                            score=1.0,
+                            before_prev_anchor=int(line.get("global_idx", -1))
+                            <= previous_anchor,
+                        )
                     continue
             norm = line.get("_norm", "")
             if norm == target or target in norm:
                 candidates.append(line)
+                if tracer:
+                    tracer.ev(
+                        "candidate_found",
+                        target=str(header.get("text", "")),
+                        page=int(line.get("page", 0)),
+                        line_idx=int(line.get("line_idx", 0)),
+                        snippet=text.strip(),
+                        score=1.0,
+                        before_prev_anchor=int(line.get("global_idx", -1))
+                        <= previous_anchor,
+                    )
 
         if not candidates:
             for line in usable:
@@ -58,11 +92,36 @@ def locate_headers_in_lines(
                 similarity = SequenceMatcher(a=target, b=norm).ratio()
                 if similarity >= similarity_threshold:
                     candidates.append(line)
+                    if tracer:
+                        tracer.ev(
+                            "candidate_scored",
+                            target=str(header.get("text", "")),
+                            page=int(line.get("page", 0)),
+                            line_idx=int(line.get("line_idx", 0)),
+                            snippet=str(line.get("text", "")).strip(),
+                            score=similarity,
+                            threshold=similarity_threshold,
+                        )
 
         if not candidates:
+            if tracer:
+                tracer.ev(
+                    "fallback_triggered",
+                    method="candidate_search",
+                    reason="no_candidates",
+                    target=str(header.get("text", "")),
+                )
             continue
 
         best = max(candidates, key=lambda item: item.get("global_idx", -1))
+        monotonic_ok = int(best.get("global_idx", -1)) >= previous_anchor
+        if tracer and not monotonic_ok:
+            tracer.ev(
+                "monotonic_violation",
+                target=str(header.get("text", "")),
+                previous_anchor=previous_anchor,
+                candidate_global=int(best.get("global_idx", -1)),
+            )
         located.append(
             {
                 "text": str(header.get("text", "")).strip(),
@@ -73,6 +132,16 @@ def locate_headers_in_lines(
                 "global_idx": int(best.get("global_idx") or 0),
             }
         )
+        previous_anchor = int(best.get("global_idx", -1))
+        if tracer:
+            tracer.ev(
+                "anchor_resolved",
+                target=str(header.get("text", "")),
+                page=int(best.get("page") or 0),
+                line_idx=int(best.get("line_idx") or 0),
+                global_idx=previous_anchor,
+                monotonic_ok=monotonic_ok,
+            )
 
     located.sort(key=lambda item: item.get("global_idx", 0))
     return located

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from typing import Iterable, Mapping, Sequence
 
 from sqlmodel import Session
 
+import backend.config as app_config
 from backend.config import Settings
 from backend.models import Document, DocumentArtifactType
 
@@ -16,8 +18,10 @@ from .header_locator import locate_headers_in_lines
 from .pdf_headers_llm_full import get_headers_llm_full
 from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
+from ..utils.logging import configure_logging
+from ..utils.trace import HeaderTracer
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = configure_logging().getChild(__name__)
 
 
 def _format_llm_failure(exc: Exception) -> str:
@@ -53,14 +57,34 @@ async def extract_headers_and_chunks(
     metadata: Mapping[str, object] | None = None,
     session: Session | None = None,
     document: Document | None = None,
-) -> dict:
+    want_trace: bool = False,
+) -> tuple[dict, HeaderTracer | None]:
     """Return located headers and section ranges for the provided document."""
+
+    tracer: HeaderTracer | None = None
+    trace_requested = app_config.HEADERS_TRACE or want_trace
+    if trace_requested:
+        tracer = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
+
+    start_time = time.perf_counter()
+    if tracer:
+        tracer.ev(
+            "start_run",
+            mode=settings.headers_mode,
+            file_id=getattr(document, "id", None),
+            cfg={
+                "suppress_toc": settings.headers_suppress_toc,
+                "suppress_running": settings.headers_suppress_running,
+            },
+            metadata=dict(metadata or {}),
+        )
 
     lines, excluded_pages, doc_hash = collect_line_metrics(
         document_bytes,
         metadata,
         suppress_toc=settings.headers_suppress_toc,
         suppress_running=settings.headers_suppress_running,
+        tracer=tracer,
     )
 
     located_headers: list[dict] = []
@@ -87,6 +111,17 @@ async def extract_headers_and_chunks(
         )
         if cached is not None:
             payload = dict(cached.body)
+            if tracer:
+                tracer.ev(
+                    "end_run",
+                    elapsed_s=time.perf_counter() - start_time,
+                    total_headers=len(payload.get("headers", [])),
+                    unresolved=[],
+                    mode="cache",
+                    doc_hash=doc_hash,
+                )
+                tracer.flush_jsonl()
+                LOGGER.info("[headers] Trace written: %s", tracer.path)
             return {
                 "headers": payload.get("headers", []),
                 "sections": payload.get("sections", []),
@@ -95,7 +130,7 @@ async def extract_headers_and_chunks(
                 "doc_hash": doc_hash,
                 "excluded_pages": sorted(excluded_pages),
                 "messages": payload.get("messages", []),
-            }
+            }, tracer
 
     if settings.headers_mode.lower() == "llm_full":
         try:
@@ -105,21 +140,44 @@ async def extract_headers_and_chunks(
                 settings=settings,
                 excluded_pages=excluded_pages,
             )
+            llm_headers = llm_headers or []
             located_headers = locate_headers_in_lines(
                 llm_headers,
                 lines,
                 excluded_pages=excluded_pages,
+                tracer=tracer,
             )
+            if tracer:
+                tracer.ev(
+                    "llm_outline_received",
+                    count=len(llm_headers),
+                    sample=[entry.get("text") for entry in llm_headers[:5]],
+                )
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []
             messages.append(_format_llm_failure(exc))
             mode_used = "llm_full_error"
+            if tracer:
+                tracer.ev(
+                    "fallback_triggered",
+                    method="llm_full",
+                    reason="exception",
+                    message=str(exc),
+                )
     else:
         mode_used = "llm_disabled"
         messages.append("LLM header extraction is disabled by configuration.")
+        if tracer:
+            tracer.ev(
+                "fallback_triggered",
+                method="llm_disabled",
+                reason="configuration",
+            )
 
-    located_headers, sections = _enforce_header_sequence(located_headers, lines)
+    located_headers, sections = _enforce_header_sequence(
+        located_headers, lines, tracer=tracer
+    )
 
     if session is not None and doc_id is not None:
         store_artifact(
@@ -137,6 +195,23 @@ async def extract_headers_and_chunks(
             },
         )
 
+    matched_titles = {str(item.get("text", "")).strip() for item in located_headers}
+    expected_titles = [str(item.get("text", "")) for item in (native_headers or [])]
+    unresolved = [title for title in expected_titles if title and title not in matched_titles]
+
+    elapsed = time.perf_counter() - start_time
+    if tracer:
+        tracer.ev(
+            "end_run",
+            elapsed_s=elapsed,
+            total_headers=len(located_headers),
+            unresolved=unresolved,
+            mode=mode_used,
+            doc_hash=doc_hash,
+        )
+        trace_path = tracer.flush_jsonl()
+        LOGGER.info("[headers] Trace written: %s", trace_path)
+
     return {
         "headers": located_headers,
         "sections": sections,
@@ -145,12 +220,14 @@ async def extract_headers_and_chunks(
         "doc_hash": doc_hash,
         "excluded_pages": sorted(excluded_pages),
         "messages": messages,
-    }
+    }, tracer
 
 
 def _enforce_header_sequence(
     headers: Sequence[Mapping[str, object]],
     lines: Sequence[Mapping[str, object]],
+    *,
+    tracer: HeaderTracer | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """Ensure located headers follow sequential numbering when possible."""
 
@@ -172,10 +249,25 @@ def _enforce_header_sequence(
 
     sections = single_chunks_from_headers(working_headers, lines)
 
+    iteration = 0
     while True:
         gaps = _identify_missing_headers(working_headers)
         if not gaps:
             break
+        iteration += 1
+        if tracer:
+            tracer.ev(
+                "monotonic_violation",
+                iteration=iteration,
+                gaps=[
+                    {
+                        "after_index": gap.get("after_index"),
+                        "components": gap.get("components"),
+                        "level": gap.get("level"),
+                    }
+                    for gap in gaps
+                ],
+            )
 
         index_by_global = {
             int(line.get("global_idx", -1)): idx for idx, line in enumerate(lines)
@@ -214,9 +306,25 @@ def _enforce_header_sequence(
             working_headers.sort(key=lambda item: item.get("global_idx", 0))
             sections = single_chunks_from_headers(working_headers, lines)
             inserted = True
+            if tracer:
+                tracer.ev(
+                    "anchor_resolved",
+                    target=candidate.get("text"),
+                    page=candidate.get("page"),
+                    line_idx=candidate.get("line_idx"),
+                    global_idx=candidate.get("global_idx"),
+                    monotonic_ok=True,
+                    method="gap_fill",
+                )
             break
 
         if not inserted:
+            if tracer:
+                tracer.ev(
+                    "fallback_triggered",
+                    method="gap_fill",
+                    reason="unresolved",
+                )
             break
 
     return working_headers, sections

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -31,6 +31,7 @@ except Exception:  # pragma: no cover - optional dependency
     Image = None  # type: ignore
 
 from ..config import Settings
+from ..utils.trace import HeaderTracer
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="pytesseract")
 
@@ -386,6 +387,7 @@ def collect_line_metrics(
     *,
     suppress_toc: bool = True,
     suppress_running: bool = True,
+    tracer: HeaderTracer | None = None,
 ) -> tuple[list[dict], set[int], str]:
     """Return flattened line metrics for the provided PDF bytes."""
 
@@ -396,6 +398,7 @@ def collect_line_metrics(
     footer_counter: Counter[str] = Counter()
 
     with fitz.open(stream=document_bytes, filetype="pdf") as pdf_document:
+        sample_budget = 10
         for page in pdf_document:
             page_number = int(page.number)
             text_dict = page.get_text("dict") or {}
@@ -435,6 +438,14 @@ def collect_line_metrics(
                         "is_index": False,
                         "is_running": False,
                     }
+                    if tracer and sample_budget > 0:
+                        tracer.ev(
+                            "pre_normalize_sample",
+                            page=page_number,
+                            line_idx=entry["line_idx"],
+                            text=text,
+                        )
+                        sample_budget -= 1
                     page_lines.append(entry)
 
             height = float(page.rect.height)
@@ -444,6 +455,14 @@ def collect_line_metrics(
                 normalised = _normalise_text(entry.get("text", ""))
                 if not normalised:
                     continue
+                if tracer and entry.get("line_idx", 0) < 5:
+                    tracer.ev(
+                        "normalized_line",
+                        page=page_number,
+                        line_idx=entry.get("line_idx", 0),
+                        raw=entry.get("text", ""),
+                        normalised=normalised,
+                    )
                 if entry["top"] <= top_threshold:
                     header_counter[normalised] += 1
                 elif entry["bottom"] >= bottom_threshold:
@@ -462,6 +481,14 @@ def collect_line_metrics(
         running_markers = {
             text for text, count in header_counter.items() if count > 1
         } | {text for text, count in footer_counter.items() if count > 1}
+        if tracer and running_markers:
+            for text in sorted(running_markers):
+                tracer.ev(
+                    "running_header_filtered",
+                    text=text,
+                    header_hits=header_counter.get(text, 0),
+                    footer_hits=footer_counter.get(text, 0),
+                )
 
     all_lines: list[dict] = []
     global_idx = 0
@@ -474,6 +501,13 @@ def collect_line_metrics(
         is_index_page = _is_index_like(texts)
         if suppress_toc and (is_toc_page or is_index_page):
             excluded_pages.add(page_number)
+            if tracer:
+                tracer.ev(
+                    "toc_detected",
+                    page=page_number,
+                    reason="index" if is_index_page else "toc",
+                    sample=texts[:6],
+                )
 
         for entry in page_lines:
             normalised = _normalise_text(entry.get("text", ""))
@@ -484,6 +518,15 @@ def collect_line_metrics(
             entry["global_idx"] = global_idx
             all_lines.append(entry)
             global_idx += 1
+
+    if tracer:
+        tracer.ev(
+            "doc_stats",
+            pages=len(pages),
+            lines=len(all_lines),
+            bytes=len(document_bytes),
+            excluded_pages=sorted(excluded_pages),
+        )
 
     return all_lines, excluded_pages, doc_hash
 

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -1,0 +1,67 @@
+import asyncio
+from pathlib import Path
+
+import backend.config as app_config
+from backend.config import Settings
+from backend.services import headers_orchestrator
+
+
+def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(app_config, "HEADERS_TRACE", True)
+    monkeypatch.setattr(app_config, "HEADERS_TRACE_DIR", str(tmp_path))
+    monkeypatch.setattr(app_config, "HEADERS_TRACE_EMBED_RESPONSE", False)
+
+    sample_lines = [
+        {
+            "text": "1 Introduction",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+        }
+    ]
+
+    def _fake_collect(document_bytes, *_args, tracer=None, **_kwargs):  # noqa: ANN001
+        if tracer is not None:
+            tracer.ev(
+                "pre_normalize_sample",
+                page=0,
+                line_idx=0,
+                text="1 Introduction",
+            )
+        return sample_lines, set(), "hash-value"
+
+    async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
+        return [{"text": "Introduction", "number": "1", "level": 1}]
+
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.collect_line_metrics", _fake_collect
+    )
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.get_headers_llm_full", _fake_llm
+    )
+
+    settings = Settings(headers_mode="llm_full", upload_dir=tmp_path)
+    payload, tracer = asyncio.run(
+        headers_orchestrator.extract_headers_and_chunks(
+            b"pdf-bytes",
+            settings=settings,
+            native_headers=[{"text": "Introduction", "number": "1", "level": 1}],
+            metadata={},
+            want_trace=True,
+        )
+    )
+
+    assert tracer is not None
+    events = tracer.as_list()
+    types = {event["type"] for event in events}
+    assert "start_run" in types
+    assert "end_run" in types
+    assert "candidate_found" in types or "anchor_resolved" in types
+
+    trace_path = Path(tracer.path)
+    assert trace_path.exists()
+    content = trace_path.read_text(encoding="utf-8").strip().splitlines()
+    assert content
+    assert any("candidate_found" in line for line in content)
+    assert payload["headers"]

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -15,7 +15,15 @@ async def _run_extract(monkeypatch, tmp_path, *, llm_exception: Exception | None
         }
     ]
 
-    def _fake_collect(*args, **kwargs):  # noqa: ANN001 - test stub
+    def _fake_collect(*args, tracer=None, **kwargs):  # noqa: ANN001 - test stub
+        if tracer is not None:
+            tracer.ev(
+                "doc_stats",
+                pages=1,
+                lines=len(lines),
+                bytes=len(args[0]) if args else 0,
+                excluded_pages=[],
+            )
         return lines, set(), "hash-value"
 
     async def _fake_llm(*args, **kwargs):  # noqa: ANN001 - test stub
@@ -25,7 +33,17 @@ async def _run_extract(monkeypatch, tmp_path, *, llm_exception: Exception | None
             {"text": "Intro", "number": "1", "level": 1},
         ]
 
-    def _fake_locate(headers, *_args, **_kwargs):  # noqa: ANN001 - test stub
+    def _fake_locate(headers, *_args, tracer=None, **_kwargs):  # noqa: ANN001 - test stub
+        if tracer is not None:
+            tracer.ev(
+                "candidate_found",
+                target=headers[0]["text"] if headers else "",
+                page=0,
+                line_idx=0,
+                snippet=headers[0]["text"] if headers else "",
+                score=1.0,
+                before_prev_anchor=False,
+            )
         return [
             {
                 "text": headers[0]["text"],
@@ -67,12 +85,13 @@ async def _run_extract(monkeypatch, tmp_path, *, llm_exception: Exception | None
 
     settings = Settings(upload_dir=tmp_path, headers_mode="llm_full")
 
-    return await headers_orchestrator.extract_headers_and_chunks(
+    result, _ = await headers_orchestrator.extract_headers_and_chunks(
         b"pdf-bytes",
         settings=settings,
         native_headers=[{"text": "Intro", "number": "1", "level": 1}],
         metadata={"filename": "doc.pdf"},
     )
+    return result
 
 
 def test_extract_headers_llm_failure_emits_message(monkeypatch, tmp_path) -> None:

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for the SimpleSpecs backend."""
+
+__all__: list[str] = []

--- a/backend/utils/logging.py
+++ b/backend/utils/logging.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+TRACE_LEVEL = 5
+logging.addLevelName(TRACE_LEVEL, "TRACE")
+
+
+def trace(self: logging.Logger, msg: str, *args, **kwargs) -> None:  # type: ignore[override]
+    if self.isEnabledFor(TRACE_LEVEL):
+        self._log(TRACE_LEVEL, msg, args, **kwargs)
+
+
+logging.Logger.trace = trace  # type: ignore[attr-defined]
+
+
+def configure_logging(default_level: str = "DEBUG") -> logging.Logger:
+    level_name = os.getenv("HEADERS_LOG_LEVEL", default_level).upper()
+    level = getattr(logging, level_name, logging.DEBUG)
+    logging.basicConfig(
+        level=level,
+        stream=sys.stdout,
+        format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+    )
+    return logging.getLogger("simplespecs")
+
+
+__all__ = ["TRACE_LEVEL", "configure_logging"]

--- a/backend/utils/trace.py
+++ b/backend/utils/trace.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(slots=True)
+class TraceEvent:
+    t: float
+    type: str
+    data: Dict[str, Any]
+
+
+class HeaderTracer:
+    """Collect structured events for header tracing."""
+
+    def __init__(self, run_id: Optional[str] = None, out_dir: str = "backend/logs/headers") -> None:
+        self.run_id = run_id or str(uuid.uuid4())
+        self.out_dir = out_dir
+        self.events: List[TraceEvent] = []
+        os.makedirs(self.out_dir, exist_ok=True)
+        self._path = os.path.join(self.out_dir, f"{self.run_id}.jsonl")
+
+    def ev(self, event_type: str, **data: Any) -> None:
+        self.events.append(TraceEvent(t=time.time(), type=event_type, data=data))
+
+    def flush_jsonl(self) -> str:
+        with open(self._path, "w", encoding="utf-8") as handle:
+            for event in self.events:
+                payload = {"t": event.t, "type": event.type, **event.data}
+                handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        return self._path
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def as_list(self) -> List[Dict[str, Any]]:
+        return [{"t": event.t, "type": event.type, **event.data} for event in self.events]
+
+
+__all__ = ["HeaderTracer", "TraceEvent"]

--- a/tests/test_headers_golden.py
+++ b/tests/test_headers_golden.py
@@ -221,7 +221,8 @@ def test_headers_endpoint_returns_outline(
         settings,
         native_headers,
         metadata,
-    ) -> dict:
+        want_trace=False,
+    ) -> tuple[dict, None]:
         lines = [
             {
                 "text": "General Requirements",
@@ -242,7 +243,7 @@ def test_headers_endpoint_returns_outline(
                 "is_index": False,
             },
         ]
-        return {
+        payload = {
             "headers": [
                 {
                     "text": "General Requirements",
@@ -286,6 +287,7 @@ def test_headers_endpoint_returns_outline(
             "doc_hash": "abc123",
             "excluded_pages": [],
         }
+        return payload, None
 
     class StubHeadersClient:
         def __init__(self, *_args, **_kwargs) -> None:


### PR DESCRIPTION
## Summary
- add configurable TRACE-level logging helpers for the header pipeline
- instrument header parsing, locator, and orchestrator codepaths to emit structured trace events and expose them via the API
- document the new trace workflow and cover it with focused tests

## Testing
- pytest backend/tests/test_header_trace.py backend/tests/test_headers_orchestrator.py tests/test_headers_golden.py

------
https://chatgpt.com/codex/tasks/task_e_6904a462ffe083248ee020dac5a4b20e