### PR TITLE
Ensure header search traces are always logged

### DIFF
--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -61,10 +61,7 @@ async def extract_headers_and_chunks(
 ) -> tuple[dict, HeaderTracer | None]:
     """Return located headers and section ranges for the provided document."""
 
-    tracer: HeaderTracer | None = None
-    trace_requested = app_config.HEADERS_TRACE or want_trace
-    if trace_requested:
-        tracer = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
+    tracer: HeaderTracer | None = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
 
     start_time = time.perf_counter()
     if tracer:
@@ -78,6 +75,19 @@ async def extract_headers_and_chunks(
             },
             metadata=dict(metadata or {}),
         )
+        if native_headers:
+            tracer.ev(
+                "native_expectations",
+                expected=[
+                    {
+                        "text": str(entry.get("text", "")).strip(),
+                        "number": (entry.get("number") or None),
+                        "level": int(entry.get("level") or 1),
+                    }
+                    for entry in native_headers
+                ],
+                count=len(native_headers),
+            )
 
     lines, excluded_pages, doc_hash = collect_line_metrics(
         document_bytes,
@@ -111,25 +121,49 @@ async def extract_headers_and_chunks(
         )
         if cached is not None:
             payload = dict(cached.body)
+            located = list(payload.get("headers", []))
+            sections = list(payload.get("sections", []))
+            messages = list(payload.get("messages", []))
+            mode_used = payload.get("mode", "cache")
+            matched_titles = {str(item.get("text", "")).strip() for item in located}
+            expected_titles = [str(item.get("text", "")) for item in (native_headers or [])]
+            unresolved = [
+                title for title in expected_titles if title and title not in matched_titles
+            ]
+            elapsed = time.perf_counter() - start_time
             if tracer:
                 tracer.ev(
+                    "llm_outline_received",
+                    count=len(located),
+                    headers=list(payload.get("headers", [])),
+                )
+                tracer.ev(
+                    "final_outline",
+                    headers=located,
+                    sections=sections,
+                    mode=mode_used,
+                    messages=messages,
+                    elapsed_s=elapsed,
+                )
+                tracer.ev(
                     "end_run",
-                    elapsed_s=time.perf_counter() - start_time,
-                    total_headers=len(payload.get("headers", [])),
-                    unresolved=[],
+                    elapsed_s=elapsed,
+                    total_headers=len(located),
+                    unresolved=unresolved,
                     mode="cache",
                     doc_hash=doc_hash,
                 )
                 tracer.flush_jsonl()
                 LOGGER.info("[headers] Trace written: %s", tracer.path)
+                LOGGER.info("[headers] Summary written: %s", tracer.summary_path)
             return {
-                "headers": payload.get("headers", []),
-                "sections": payload.get("sections", []),
-                "mode": payload.get("mode", "cache"),
+                "headers": located,
+                "sections": sections,
+                "mode": mode_used,
                 "lines": lines,
                 "doc_hash": doc_hash,
                 "excluded_pages": sorted(excluded_pages),
-                "messages": payload.get("messages", []),
+                "messages": messages,
             }, tracer
 
     if settings.headers_mode.lower() == "llm_full":
@@ -151,7 +185,7 @@ async def extract_headers_and_chunks(
                 tracer.ev(
                     "llm_outline_received",
                     count=len(llm_headers),
-                    sample=[entry.get("text") for entry in llm_headers[:5]],
+                    headers=llm_headers,
                 )
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
@@ -159,6 +193,7 @@ async def extract_headers_and_chunks(
             messages.append(_format_llm_failure(exc))
             mode_used = "llm_full_error"
             if tracer:
+                tracer.ev("llm_outline_received", count=0, headers=[])
                 tracer.ev(
                     "fallback_triggered",
                     method="llm_full",
@@ -174,6 +209,7 @@ async def extract_headers_and_chunks(
                 method="llm_disabled",
                 reason="configuration",
             )
+            tracer.ev("llm_outline_received", count=0, headers=[])
 
     located_headers, sections = _enforce_header_sequence(
         located_headers, lines, tracer=tracer
@@ -202,6 +238,14 @@ async def extract_headers_and_chunks(
     elapsed = time.perf_counter() - start_time
     if tracer:
         tracer.ev(
+            "final_outline",
+            headers=located_headers,
+            sections=sections,
+            mode=mode_used,
+            messages=messages,
+            elapsed_s=elapsed,
+        )
+        tracer.ev(
             "end_run",
             elapsed_s=elapsed,
             total_headers=len(located_headers),
@@ -211,6 +255,7 @@ async def extract_headers_and_chunks(
         )
         trace_path = tracer.flush_jsonl()
         LOGGER.info("[headers] Trace written: %s", trace_path)
+        LOGGER.info("[headers] Summary written: %s", tracer.summary_path)
 
     return {
         "headers": located_headers,

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from pathlib import Path
 
 import backend.config as app_config
@@ -65,4 +66,64 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
     content = trace_path.read_text(encoding="utf-8").strip().splitlines()
     assert content
     assert any("candidate_found" in line for line in content)
+    assert payload["headers"]
+
+    summary_path = Path(tracer.summary_path)
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["llm_headers"]
+    assert summary["final_outline"]["headers"]
+
+
+def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(app_config, "HEADERS_TRACE", False)
+    monkeypatch.setattr(app_config, "HEADERS_TRACE_DIR", str(tmp_path))
+    monkeypatch.setattr(app_config, "HEADERS_TRACE_EMBED_RESPONSE", False)
+
+    sample_lines = [
+        {
+            "text": "1 Intro",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+        }
+    ]
+
+    def _fake_collect(document_bytes, *_args, tracer=None, **_kwargs):  # noqa: ANN001
+        if tracer is not None:
+            tracer.ev(
+                "pre_normalize_sample",
+                page=0,
+                line_idx=0,
+                text="1 Intro",
+            )
+        return sample_lines, set(), "hash-value"
+
+    async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
+        return [{"text": "Intro", "number": "1", "level": 1}]
+
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.collect_line_metrics", _fake_collect
+    )
+    monkeypatch.setattr(
+        "backend.services.headers_orchestrator.get_headers_llm_full", _fake_llm
+    )
+
+    settings = Settings(headers_mode="llm_full", upload_dir=tmp_path)
+    payload, tracer = asyncio.run(
+        headers_orchestrator.extract_headers_and_chunks(
+            b"pdf-bytes",
+            settings=settings,
+            native_headers=[{"text": "Intro", "number": "1", "level": 1}],
+            metadata={},
+        )
+    )
+
+    assert tracer is not None
+    summary_path = Path(tracer.summary_path)
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["llm_headers"][0]["text"] == "Intro"
+    assert summary["final_outline"]["headers"][0]["text"] == "Intro"
     assert payload["headers"]

--- a/backend/utils/trace.py
+++ b/backend/utils/trace.py
@@ -18,12 +18,15 @@ class TraceEvent:
 class HeaderTracer:
     """Collect structured events for header tracing."""
 
-    def __init__(self, run_id: Optional[str] = None, out_dir: str = "backend/logs/headers") -> None:
+    def __init__(
+        self, run_id: Optional[str] = None, out_dir: str = "backend/logs/headers"
+    ) -> None:
         self.run_id = run_id or str(uuid.uuid4())
         self.out_dir = out_dir
         self.events: List[TraceEvent] = []
         os.makedirs(self.out_dir, exist_ok=True)
         self._path = os.path.join(self.out_dir, f"{self.run_id}.jsonl")
+        self._summary_path = os.path.join(self.out_dir, f"{self.run_id}.summary.json")
 
     def ev(self, event_type: str, **data: Any) -> None:
         self.events.append(TraceEvent(t=time.time(), type=event_type, data=data))
@@ -33,14 +36,72 @@ class HeaderTracer:
             for event in self.events:
                 payload = {"t": event.t, "type": event.type, **event.data}
                 handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        summary_payload = self._build_summary()
+        with open(self._summary_path, "w", encoding="utf-8") as handle:
+            json.dump(summary_payload, handle, ensure_ascii=False, indent=2)
         return self._path
 
     @property
     def path(self) -> str:
         return self._path
 
+    @property
+    def summary_path(self) -> str:
+        return self._summary_path
+
     def as_list(self) -> List[Dict[str, Any]]:
         return [{"t": event.t, "type": event.type, **event.data} for event in self.events]
+
+    def _build_summary(self) -> Dict[str, Any]:
+        events = self.as_list()
+        metadata: Dict[str, Any] = {}
+        llm_headers: List[Dict[str, Any]] = []
+        final_outline: Dict[str, Any] = {}
+        decisions: List[Dict[str, Any]] = []
+        elapsed: float | None = None
+
+        decision_types = {
+            "candidate_found",
+            "anchor_resolved",
+            "fallback_triggered",
+            "monotonic_violation",
+        }
+
+        for event in events:
+            event_type = event.get("type")
+            if event_type == "start_run":
+                metadata = {
+                    key: value
+                    for key, value in event.items()
+                    if key not in {"t", "type"}
+                }
+            elif event_type == "llm_outline_received":
+                llm_headers = list(event.get("headers", []))
+            elif event_type == "final_outline":
+                final_outline = {
+                    "headers": list(event.get("headers", [])),
+                    "sections": list(event.get("sections", [])),
+                    "mode": event.get("mode"),
+                    "messages": list(event.get("messages", [])),
+                }
+                if "elapsed_s" in event:
+                    elapsed = event.get("elapsed_s")
+            elif event_type == "end_run":
+                if elapsed is None:
+                    elapsed = event.get("elapsed_s")
+                final_outline.setdefault("mode", event.get("mode"))
+
+            if event_type in decision_types:
+                decisions.append(event)
+
+        return {
+            "run_id": self.run_id,
+            "metadata": metadata,
+            "llm_headers": llm_headers,
+            "decisions": decisions,
+            "final_outline": final_outline,
+            "elapsed_s": elapsed,
+        }
 
 
 __all__ = ["HeaderTracer", "TraceEvent"]


### PR DESCRIPTION
## Summary
- always create a header tracer during header extraction so each run writes a detailed trace and summary file
- extend the tracer to emit summary JSON that captures the full LLM outline, decision events, and final output data
- expand header trace tests to validate the new summary output when tracing is explicitly requested or left at defaults

## Testing
- pytest backend/tests/test_header_trace.py backend/tests/test_headers_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_6904bca0a9648324bfbf255ca3c6b5c3