### PR TITLE
Ensure strict header extraction writes trace logs

### DIFF
--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import time
 
 from typing import Any
 
@@ -27,6 +28,7 @@ from ..services.headers_orchestrator import extract_headers_and_chunks
 from ..services.llm import LLMService
 from ..services.pdf_native import collect_line_metrics, parse_pdf
 from ..services.simpleheaders_state import SimpleHeadersState
+from ..utils.trace import HeaderTracer
 
 router = APIRouter(prefix="/api", tags=["headers"])
 
@@ -148,15 +150,33 @@ async def generate_headers(
     if settings.headers_llm_strict:
         llm_service = LLMService(settings)
         if llm_service.is_enabled:
+            tracer: HeaderTracer | None = HeaderTracer(
+                out_dir=app_config.HEADERS_TRACE_DIR
+            )
+            start_time = time.perf_counter()
+            if tracer is not None:
+                tracer.ev(
+                    "start_run",
+                    mode="llm_strict",
+                    file_id=doc_id,
+                    cfg={
+                        "suppress_toc": settings.headers_suppress_toc,
+                        "suppress_running": settings.headers_suppress_running,
+                    },
+                    metadata={"filename": document.filename},
+                )
+
             lines, _, doc_hash = collect_line_metrics(
                 document_bytes,
                 {"filename": document.filename},
                 suppress_toc=settings.headers_suppress_toc,
                 suppress_running=settings.headers_suppress_running,
+                tracer=tracer,
             )
             strict_output = extract_headers_and_sections_strict(
                 llm=llm_service,
                 lines=lines,
+                tracer=tracer,
             )
 
             SimpleHeadersState.set(doc_id, doc_hash, lines)
@@ -192,7 +212,7 @@ async def generate_headers(
                 for section in strict_output.get("sections", [])
             ]
 
-            return HeadersResponse(
+            response = HeadersResponse(
                 document_id=doc_id,
                 source="llm_strict",
                 fenced_text=strict_output.get("fenced_text", ""),
@@ -203,6 +223,31 @@ async def generate_headers(
                 trace=None,
                 trace_file=None,
             )
+
+            if tracer is not None:
+                elapsed = time.perf_counter() - start_time
+                tracer.ev(
+                    "final_outline",
+                    headers=[payload.model_dump() for payload in simpleheaders_payload],
+                    sections=[section.model_dump() for section in sections_payload],
+                    mode="llm_strict",
+                    messages=[],
+                    elapsed_s=elapsed,
+                )
+                tracer.ev(
+                    "end_run",
+                    elapsed_s=elapsed,
+                    total_headers=len(simpleheaders_payload),
+                    unresolved=[],
+                    mode="llm_strict",
+                    doc_hash=doc_hash,
+                )
+                tracer.flush_jsonl()
+                if trace_requested:
+                    response.trace = tracer.as_list()
+                    response.trace_file = tracer.path
+
+            return response
 
     parse_result = parse_pdf(document_path, settings=settings)
     llm_client = HeadersLLMClient(settings)

--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -7,6 +7,8 @@ import logging
 import re
 from typing import Any, Dict, Iterable, List, Mapping, Protocol, Sequence, Tuple
 
+from ..utils.trace import HeaderTracer
+
 log = logging.getLogger(__name__)
 
 FENCE = "#headers#"
@@ -159,6 +161,7 @@ def extract_headers_and_sections_strict(
     *,
     llm: _SupportsGenerate,
     lines: Sequence[BodyLine],
+    tracer: HeaderTracer | None = None,
 ) -> Dict[str, Any]:
     """Locate headers and construct contiguous section ranges."""
 
@@ -176,14 +179,34 @@ def extract_headers_and_sections_strict(
         log.error("Failed to decode headers JSON: %s", exc)
         payload = {}
 
+    llm_headers = list(_extract_headers(payload))
+    if tracer is not None:
+        tracer.ev(
+            "llm_outline_received",
+            count=len(llm_headers),
+            headers=[{**header} for header in llm_headers],
+        )
+
     located: List[Dict[str, Any]] = []
 
-    for header in _extract_headers(payload):
+    for header in llm_headers:
         position = _find_header_line(header["text"], lines)
         if not position:
             log.debug("Header not located in body: %s", header["text"])
+            if tracer is not None:
+                tracer.ev("candidate_missing", header={**header})
             continue
         list_index, global_idx, page = position
+        if tracer is not None:
+            tracer.ev(
+                "candidate_found",
+                header_text=header["text"],
+                header_number=header["number"],
+                level=header["level"],
+                page=page,
+                line_index=list_index,
+                global_idx=global_idx,
+            )
         located.append(
             {
                 "text": header["text"],

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import backend.config as app_config
 from backend.config import Settings
 from backend.services import headers_orchestrator
+from backend.services.headers_llm_strict import extract_headers_and_sections_strict
+from backend.utils.trace import HeaderTracer
 
 
 def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
@@ -127,3 +129,46 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
     assert summary["llm_headers"][0]["text"] == "Intro"
     assert summary["final_outline"]["headers"][0]["text"] == "Intro"
     assert payload["headers"]
+
+
+def test_header_trace_events_emitted_for_strict_mode(tmp_path) -> None:
+    tracer = HeaderTracer(out_dir=str(tmp_path))
+
+    class _FakeLLM:
+        def generate(self, *, messages, fence, params=None, metadata=None):  # noqa: ANN001, D401
+            class _Result:
+                def __init__(self) -> None:
+                    self.fenced = json.dumps(
+                        {
+                            "headers": [
+                                {"text": "1 Introduction", "number": "1", "level": 1}
+                            ]
+                        }
+                    )
+
+            return _Result()
+
+    lines = [
+        {
+            "text": "1 Introduction",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+            "is_running": False,
+            "is_toc": False,
+            "is_index": False,
+        }
+    ]
+
+    output = extract_headers_and_sections_strict(
+        llm=_FakeLLM(),
+        lines=lines,
+        tracer=tracer,
+    )
+
+    assert output["headers"]
+    tracer.flush_jsonl()
+    events = tracer.as_list()
+    event_types = {event["type"] for event in events}
+    assert "llm_outline_received" in event_types
+    assert "candidate_found" in event_types


### PR DESCRIPTION
## Summary
- create and flush a `HeaderTracer` when the headers endpoint runs in `llm_strict` mode so the search log is written and returned when requested
- emit structured tracing events from the strict header extractor for both matches and misses to populate the trace log
- cover the strict-mode tracing path with a regression test

## Testing
- pytest backend/tests/test_header_trace.py

------
https://chatgpt.com/codex/tasks/task_e_6904ca7648f88324b03c823403b7e3a1