### PR TITLE
Add sequential header alignment strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ SimpleSpecs sends the full document text to OpenRouter for a high-fidelity outli
 
 The pipeline requires `OPENROUTER_API_KEY`. Cached responses avoid repeated model invocations for unchanged documents.
 
+#### Sequential alignment strategy
+
+The default header locator uses a forward-only, parent-bounded sequential search that resists table-of-contents anchors and running headers. Tune behaviour via these environment variables:
+
+```
+HEADERS_ALIGN_STRATEGY=sequential  # use `legacy` to revert to the prior locator
+HEADERS_SUPPRESS_TOC=1            # ignore pages that look like TOCs
+HEADERS_SUPPRESS_RUNNING=1        # filter repeated running headers/footers
+HEADERS_NORMALIZE_CONFUSABLES=1   # normalise numeric lookalikes (I/l → 1)
+HEADERS_FUZZY_THRESHOLD=80        # token-set similarity for title matching
+HEADERS_WINDOW_PAD_LINES=40       # expand parent search windows by ±N lines
+```
+
+Clients can override the active strategy per request with `POST /api/headers/{document_id}?align=sequential` (or `align=legacy`). When tracing is enabled the sequential locator emits events such as `anchor_candidate_top`, `window_top`, and `anchor_resolved_child` to aid debugging.
+
 
 ### Header trace debugging
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,6 +39,27 @@ HEADERS_TRACE_EMBED_RESPONSE: bool = (
 HEADERS_TRACE_DIR: str = os.getenv("HEADERS_TRACE_DIR", "backend/logs/headers")
 HEADERS_LOG_LEVEL: str = os.getenv("HEADERS_LOG_LEVEL", "DEBUG")
 
+HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
+HEADERS_SUPPRESS_TOC: bool = os.getenv("HEADERS_SUPPRESS_TOC", "1") in (
+    "1",
+    "true",
+    "True",
+    "YES",
+    "yes",
+)
+HEADERS_SUPPRESS_RUNNING: bool = os.getenv("HEADERS_SUPPRESS_RUNNING", "1") in (
+    "1",
+    "true",
+    "True",
+    "YES",
+    "yes",
+)
+HEADERS_NORMALIZE_CONFUSABLES: bool = os.getenv(
+    "HEADERS_NORMALIZE_CONFUSABLES", "1"
+) in ("1", "true", "True", "YES", "yes")
+HEADERS_FUZZY_THRESHOLD: int = int(os.getenv("HEADERS_FUZZY_THRESHOLD", "80"))
+HEADERS_WINDOW_PAD_LINES: int = int(os.getenv("HEADERS_WINDOW_PAD_LINES", "40"))
+
 
 def _load_environment() -> None:
     """Load environment variables from a ``.env`` file if present."""
@@ -116,6 +137,18 @@ class Settings(BaseModel):
     )
     headers_suppress_running: bool = Field(
         default_factory=lambda: _env_flag("HEADERS_SUPPRESS_RUNNING", True)
+    )
+    headers_align_strategy: str = Field(
+        default_factory=lambda: os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
+    )
+    headers_normalize_confusables: bool = Field(
+        default_factory=lambda: _env_flag("HEADERS_NORMALIZE_CONFUSABLES", True)
+    )
+    headers_fuzzy_threshold: int = Field(
+        default_factory=lambda: int(os.getenv("HEADERS_FUZZY_THRESHOLD", "80"))
+    )
+    headers_window_pad_lines: int = Field(
+        default_factory=lambda: int(os.getenv("HEADERS_WINDOW_PAD_LINES", "40"))
     )
     headers_llm_strict: bool = Field(
         default_factory=lambda: os.getenv("HEADERS_LLM_STRICT", "false").lower()

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import time
 
 from typing import Any
@@ -121,6 +122,7 @@ async def generate_headers(
     session: Session = Depends(get_session),
     settings: Settings = Depends(get_settings),
     trace: bool = Query(False),
+    align: str | None = Query(None),
 ) -> HeadersResponse:
     """Return the hierarchical headers for a stored document."""
 
@@ -146,6 +148,10 @@ async def generate_headers(
     document_bytes = document_path.read_bytes()
 
     trace_requested = trace or app_config.HEADERS_TRACE_EMBED_RESPONSE
+
+    align_strategy = (align or "").strip().lower()
+    if align_strategy in {"sequential", "legacy"}:
+        os.environ["HEADERS_ALIGN_STRATEGY"] = align_strategy
 
     if settings.headers_llm_strict:
         llm_service = LLMService(settings)

--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
+import os
 import re
 from difflib import SequenceMatcher
 from typing import Dict, Iterable, List, Sequence
 
+from backend.config import (
+    HEADERS_ALIGN_STRATEGY,
+    HEADERS_FUZZY_THRESHOLD,
+    HEADERS_NORMALIZE_CONFUSABLES,
+    HEADERS_SUPPRESS_RUNNING,
+    HEADERS_SUPPRESS_TOC,
+    HEADERS_WINDOW_PAD_LINES,
+)
+
 from ..utils.trace import HeaderTracer
+from .headers_sequential import align_headers_sequential
 
 
 def _normalise(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip()).lower()
 
 
-def locate_headers_in_lines(
+def _locate_headers_legacy(
     headers: Sequence[Dict],
     lines: Sequence[Dict],
     *,
@@ -21,8 +32,6 @@ def locate_headers_in_lines(
     similarity_threshold: float = 0.88,
     tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
-    """Return located headers with page and line metadata."""
-
     excluded = set(excluded_pages)
     usable: list[dict] = []
     for line in lines:
@@ -145,6 +154,77 @@ def locate_headers_in_lines(
 
     located.sort(key=lambda item: item.get("global_idx", 0))
     return located
+
+
+def locate_headers_in_lines(
+    headers: Sequence[Dict],
+    lines: Sequence[Dict],
+    *,
+    excluded_pages: Iterable[int] = (),
+    similarity_threshold: float = 0.88,
+    tracer: HeaderTracer | None = None,
+) -> List[Dict]:
+    strategy = os.getenv("HEADERS_ALIGN_STRATEGY", HEADERS_ALIGN_STRATEGY).strip().lower()
+
+    if strategy == "sequential":
+        sequential_headers = align_headers_sequential(
+            headers,
+            lines,
+            confusables=HEADERS_NORMALIZE_CONFUSABLES,
+            threshold=HEADERS_FUZZY_THRESHOLD,
+            window_pad=HEADERS_WINDOW_PAD_LINES,
+            suppress_toc=HEADERS_SUPPRESS_TOC,
+            suppress_running=HEADERS_SUPPRESS_RUNNING,
+            tracer=tracer,
+        )
+
+        located: List[Dict] = [
+            {
+                "text": entry.get("title", ""),
+                "number": entry.get("number"),
+                "level": int(entry.get("level", 1)),
+                "page": int(entry.get("page", 0) or 0),
+                "line_idx": int(entry.get("line_idx", 0) or 0),
+                "global_idx": int(entry.get("global_idx", 0) or 0),
+            }
+            for entry in sequential_headers
+        ]
+
+        matched_numbers = {str(entry.get("number")) for entry in sequential_headers if entry.get("number")}
+        used_indices = {int(entry.get("global_idx", 0) or 0) for entry in sequential_headers}
+
+        remaining_headers: list[Dict] = []
+        for header in headers:
+            number = (header.get("number") or "").strip()
+            if number and number in matched_numbers:
+                continue
+            remaining_headers.append(header)
+
+        if remaining_headers:
+            filtered_lines = [
+                line
+                for line in lines
+                if int(line.get("global_idx", 0) or 0) not in used_indices
+            ]
+            legacy = _locate_headers_legacy(
+                remaining_headers,
+                filtered_lines,
+                excluded_pages=excluded_pages,
+                similarity_threshold=similarity_threshold,
+                tracer=tracer,
+            )
+            located.extend(legacy)
+
+        located.sort(key=lambda item: item.get("global_idx", 0))
+        return located
+
+    return _locate_headers_legacy(
+        headers,
+        lines,
+        excluded_pages=excluded_pages,
+        similarity_threshold=similarity_threshold,
+        tracer=tracer,
+    )
 
 
 __all__ = ["locate_headers_in_lines"]

--- a/backend/services/headers_sequential.py
+++ b/backend/services/headers_sequential.py
@@ -1,0 +1,374 @@
+"""Sequential alignment strategy for mapping LLM headers to PDF lines."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from rapidfuzz.fuzz import token_set_ratio
+
+try:  # pragma: no cover - optional dependency for tracing
+    from backend.utils.trace import HeaderTracer
+except Exception:  # pragma: no cover - tracing is optional in tests
+    HeaderTracer = None  # type: ignore
+
+NUM_RE = re.compile(r"^\s*(?P<num>(\d+(?:\.\d+)*))\b", re.I)
+DOT_SPACE_RE = re.compile(r"(\d)\s*\.\s*(\d)")
+MULTISPACE_RE = re.compile(r"\s+")
+TOC_LEADER_RE = re.compile(r"\.{3,}\s*\d+\s*$")
+CONFUSABLE_NUM_RE = re.compile(r"(?<=\d)\s*[Il]\s*(?=[\.\s])")
+
+
+@dataclass(slots=True)
+class Line:
+    """Lightweight container for parsed PDF line metrics."""
+
+    text: str
+    page: int
+    global_idx: int
+    line_idx: int
+    is_running: bool = False
+
+
+@dataclass(slots=True)
+class HeaderItem:
+    """LLM provided outline entry used for sequential anchoring."""
+
+    num: str
+    title: str
+    level: int
+
+
+def normalize(value: str, confusables: bool = True) -> str:
+    """Return a normalised representation for fuzzy comparisons."""
+
+    cleaned = value.replace("\u00ad", "")
+    cleaned = DOT_SPACE_RE.sub(r"\1.\2", cleaned)
+    cleaned = MULTISPACE_RE.sub(" ", cleaned)
+    if confusables:
+        cleaned = CONFUSABLE_NUM_RE.sub("1", cleaned)
+    return cleaned.strip().casefold()
+
+
+def extract_number(text: str) -> Optional[str]:
+    """Extract a dotted numbering prefix from ``text`` if present."""
+
+    match = NUM_RE.search(text)
+    return match.group("num") if match else None
+
+
+def compile_number_regex(num: str) -> re.Pattern[str]:
+    escaped = re.escape(num)
+    return re.compile(rf"^\s*{escaped}\b(?!\.)", re.I)
+
+
+def is_probable_toc_line(text: str) -> bool:
+    return bool(TOC_LEADER_RE.search(text))
+
+
+def detect_toc_pages(lines: List[Line]) -> set[int]:
+    page_hits: Dict[int, int] = {}
+    for entry in lines:
+        if entry.is_running:
+            continue
+        if is_probable_toc_line(entry.text):
+            page_hits[entry.page] = page_hits.get(entry.page, 0) + 1
+    return {page for page, count in page_hits.items() if count >= 6}
+
+
+def detect_running_header_footer(lines: List[Line], band: int = 2) -> set[str]:
+    from collections import Counter, defaultdict
+
+    per_page: Dict[int, List[Line]] = defaultdict(list)
+    for entry in lines:
+        per_page[entry.page].append(entry)
+
+    occurrences = Counter()
+    total_pages = len(per_page)
+    for page_lines in per_page.values():
+        ordered = sorted(page_lines, key=lambda line: line.global_idx)
+        tops = ordered[:band]
+        bots = ordered[-band:] if len(ordered) >= band else []
+        page_candidates = {
+            normalize(candidate.text, confusables=False)
+            for candidate in tops + bots
+            if not candidate.is_running
+        }
+        for token in page_candidates:
+            occurrences[token] += 1
+
+    threshold = max(2, int(0.6 * total_pages)) if total_pages else 0
+    return {text for text, count in occurrences.items() if count >= threshold}
+
+
+def make_header_items(llm_headers: Iterable[Dict]) -> List[HeaderItem]:
+    items: List[HeaderItem] = []
+    for header in llm_headers:
+        number = header.get("number") or extract_number(str(header.get("text", "")))
+        title = str(header.get("title") or header.get("text") or "").strip()
+        if not number:
+            continue
+        level = number.count(".") + 1
+        items.append(HeaderItem(num=number, title=title, level=level))
+    return items
+
+
+def build_top_level_windows(
+    lines: List[Line],
+    tops: List[HeaderItem],
+    *,
+    confusables: bool,
+    runners: set[str],
+    toc_pages: set[int],
+    tracer: HeaderTracer | None = None,
+) -> Dict[str, Tuple[int, int, int]]:
+    anchors: Dict[str, int] = {}
+    cursor = -1
+    line_count = len(lines)
+
+    for item in tops:
+        matcher = compile_number_regex(item.num)
+        best_idx: Optional[int] = None
+        for pos in range(cursor + 1, line_count):
+            line = lines[pos]
+            if line.page in toc_pages or line.is_running:
+                continue
+            norm = normalize(line.text, confusables=confusables)
+            if norm in runners:
+                continue
+            if matcher.search(norm):
+                score = token_set_ratio(
+                    norm, normalize(f"{item.num} {item.title}", confusables=confusables)
+                )
+                best_idx = pos
+                if tracer:
+                    tracer.ev(
+                        "anchor_candidate_top",
+                        num=item.num,
+                        page=line.page,
+                        idx=line.global_idx,
+                        score=score,
+                        text=line.text[:200],
+                    )
+                break
+        if best_idx is not None:
+            anchors[item.num] = best_idx
+            cursor = best_idx
+            if tracer:
+                tracer.ev(
+                    "anchor_resolved_top",
+                    num=item.num,
+                    idx=lines[best_idx].global_idx,
+                )
+        elif tracer:
+            tracer.ev("anchor_unresolved_top", num=item.num)
+
+    ordered = sorted(anchors.items(), key=lambda entry: [int(part) for part in entry[0].split(".")])
+    windows: Dict[str, Tuple[int, int, int]] = {}
+    for position, (number, list_idx) in enumerate(ordered):
+        start = list_idx
+        end = line_count
+        if position + 1 < len(ordered):
+            end = ordered[position + 1][1]
+        windows[number] = (list_idx, start, end)
+        if tracer:
+            tracer.ev(
+                "window_top",
+                num=number,
+                start=lines[start].global_idx if start < line_count else None,
+                end=lines[end - 1].global_idx if end <= line_count and end > 0 else None,
+            )
+    return windows
+
+
+def find_in_window(
+    lines: List[Line],
+    start_pos: int,
+    end_pos: int,
+    target: HeaderItem,
+    *,
+    confusables: bool,
+    runners: set[str],
+    toc_pages: set[int],
+    threshold: int,
+    tracer: HeaderTracer | None = None,
+) -> Optional[int]:
+    matcher = compile_number_regex(target.num)
+    expected = normalize(f"{target.num} {target.title}", confusables=confusables)
+    best: Tuple[int, int] | None = None
+
+    for pos in range(start_pos + 1, min(end_pos, len(lines))):
+        line = lines[pos]
+        if line.page in toc_pages or line.is_running:
+            continue
+        norm = normalize(line.text, confusables=confusables)
+        if norm in runners:
+            continue
+        if not matcher.search(norm):
+            continue
+        score = token_set_ratio(norm, expected)
+        if tracer:
+            tracer.ev(
+                "candidate_found",
+                num=target.num,
+                idx=line.global_idx,
+                page=line.page,
+                score=score,
+                text=line.text[:200],
+            )
+        if score >= threshold:
+            candidate = (score, pos)
+            if best is None or candidate > best:
+                best = candidate
+
+    if best is not None:
+        _, pos = best
+        anchor = lines[pos]
+        if tracer:
+            tracer.ev(
+                "anchor_resolved_child",
+                num=target.num,
+                idx=anchor.global_idx,
+                page=anchor.page,
+                score=best[0],
+            )
+        return pos
+
+    for pos in range(start_pos + 1, min(end_pos, len(lines))):
+        line = lines[pos]
+        if line.page in toc_pages or line.is_running:
+            continue
+        norm = normalize(line.text, confusables=confusables)
+        if norm in runners:
+            continue
+        if matcher.search(norm):
+            if tracer:
+                tracer.ev(
+                    "fallback_number_only",
+                    num=target.num,
+                    idx=line.global_idx,
+                    page=line.page,
+                    text=line.text[:200],
+                )
+            return pos
+
+    if tracer:
+        tracer.ev("anchor_unresolved_child", num=target.num)
+    return None
+
+
+def align_headers_sequential(
+    llm_headers: Iterable[Dict],
+    lines_input: Iterable[Dict],
+    *,
+    confusables: bool = True,
+    threshold: int = 80,
+    window_pad: int = 40,
+    suppress_toc: bool = True,
+    suppress_running: bool = True,
+    tracer: HeaderTracer | None = None,
+) -> List[Dict]:
+    """Return aligned headers with positional metadata using sequential search."""
+
+    lines: List[Line] = []
+    for raw in lines_input:
+        try:
+            line = Line(
+                text=str(raw.get("text", "")),
+                page=int(raw.get("page", 0)),
+                global_idx=int(raw.get("global_idx", 0)),
+                line_idx=int(raw.get("line_idx") or raw.get("line_index") or 0),
+                is_running=bool(raw.get("is_running")),
+            )
+        except Exception:
+            continue
+        lines.append(line)
+
+    lines.sort(key=lambda entry: entry.global_idx)
+
+    items = make_header_items(llm_headers)
+    if tracer:
+        tracer.ev("sequential_start", items=len(items), lines=len(lines))
+
+    toc_pages = detect_toc_pages(lines) if suppress_toc else set()
+    runners = detect_running_header_footer(lines) if suppress_running else set()
+    if tracer:
+        tracer.ev("toc_pages", pages=sorted(toc_pages))
+        tracer.ev("running_headers_detected", count=len(runners))
+
+    item_lookup = {item.num: item for item in items}
+
+    tops = [item for item in items if item.level == 1]
+    windows = build_top_level_windows(
+        lines,
+        tops,
+        confusables=confusables,
+        runners=runners,
+        toc_pages=toc_pages,
+        tracer=tracer,
+    )
+
+    children = [item for item in items if item.level >= 2]
+    children.sort(key=lambda item: [int(part) for part in item.num.split(".")])
+
+    results: Dict[str, Dict] = {}
+
+    for number, (pos, _, _) in windows.items():
+        line = lines[pos]
+        level = number.count(".") + 1
+        results[number] = {
+            "number": number,
+            "title": item_lookup[number].title if number in item_lookup else "",
+            "level": level,
+            "global_idx": line.global_idx,
+            "page": line.page,
+            "line_idx": line.line_idx,
+        }
+
+    for child in children:
+        parent_num = ".".join(child.num.split(".")[:-1])
+        if parent_num not in windows:
+            if tracer:
+                tracer.ev("missing_parent", child=child.num, parent=parent_num)
+            continue
+        anchor_pos, parent_start, parent_end = windows[parent_num]
+        start = max(0, parent_start - window_pad)
+        end = min(len(lines), parent_end + window_pad)
+        found_pos = find_in_window(
+            lines,
+            start,
+            end,
+            child,
+            confusables=confusables,
+            runners=runners,
+            toc_pages=toc_pages,
+            threshold=threshold,
+            tracer=tracer,
+        )
+        if found_pos is None:
+            if tracer:
+                tracer.ev("unresolved", num=child.num, reason="no_match_in_window")
+            continue
+
+        line = lines[found_pos]
+        windows[child.num] = (found_pos, found_pos, min(len(lines), parent_end))
+        results[child.num] = {
+            "number": child.num,
+            "title": child.title,
+            "level": child.level,
+            "global_idx": line.global_idx,
+            "page": line.page,
+            "line_idx": line.line_idx,
+        }
+
+    ordered = sorted(results.values(), key=lambda item: item["global_idx"])
+    if tracer:
+        tracer.ev("sequential_end", resolved=len(ordered))
+    return ordered
+
+
+__all__ = [
+    "align_headers_sequential",
+    "normalize",
+]

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -60,14 +60,23 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
     types = {event["type"] for event in events}
     assert "start_run" in types
     assert "end_run" in types
-    assert "candidate_found" in types or "anchor_resolved" in types
+    expected_trace_markers = {
+        "candidate_found",
+        "anchor_resolved",
+        "anchor_candidate_top",
+        "anchor_resolved_top",
+        "anchor_resolved_child",
+    }
+    assert types.intersection(expected_trace_markers)
     assert any(event["type"] == "pre_normalize_sample" for event in events)
 
     trace_path = Path(tracer.path)
     assert trace_path.exists()
     content = trace_path.read_text(encoding="utf-8").strip().splitlines()
     assert content
-    assert any("candidate_found" in line for line in content)
+    assert any(
+        any(marker in line for marker in expected_trace_markers) for line in content
+    )
     assert payload["headers"]
 
     summary_path = Path(tracer.summary_path)

--- a/backend/tests/test_headers_sequential.py
+++ b/backend/tests/test_headers_sequential.py
@@ -1,0 +1,83 @@
+"""Tests for the sequential header alignment strategy."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.headers_sequential import align_headers_sequential, normalize
+
+
+@pytest.fixture
+def sample_llm_headers() -> list[dict[str, str]]:
+    return [
+        {"number": "1", "title": "Introduction"},
+        {"number": "1.1", "title": "Background"},
+        {"number": "2", "title": "Requirements"},
+        {"number": "2.1", "title": "Scope"},
+    ]
+
+
+@pytest.fixture
+def sample_lines() -> list[dict[str, object]]:
+    return [
+        {
+            "text": "Table of Contents .......... 1",
+            "page": 0,
+            "line_idx": 0,
+            "global_idx": 0,
+        },
+        {
+            "text": "1 Introduction",
+            "page": 1,
+            "line_idx": 0,
+            "global_idx": 1,
+        },
+        {
+            "text": "Some introductory text",
+            "page": 1,
+            "line_idx": 1,
+            "global_idx": 2,
+        },
+        {
+            "text": "1 . 1 Background",
+            "page": 1,
+            "line_idx": 2,
+            "global_idx": 3,
+        },
+        {
+            "text": "2 Requirements",
+            "page": 2,
+            "line_idx": 0,
+            "global_idx": 4,
+        },
+        {
+            "text": "2.1 Scope",
+            "page": 2,
+            "line_idx": 1,
+            "global_idx": 5,
+        },
+    ]
+
+
+def test_normalize_handles_confusables_and_spacing() -> None:
+    assert normalize("1 . 1 Scope") == "1.1 scope"
+    assert normalize("A I .2 Definitions").endswith("definitions")
+
+
+def test_sequential_orders_chapters_and_children(
+    sample_llm_headers: list[dict[str, str]], sample_lines: list[dict[str, object]]
+) -> None:
+    out = align_headers_sequential(
+        sample_llm_headers,
+        sample_lines,
+        confusables=True,
+        threshold=80,
+        window_pad=40,
+        suppress_toc=True,
+        suppress_running=True,
+        tracer=None,
+    )
+
+    numbers = [item["number"] for item in out]
+    assert numbers == ["1", "1.1", "2", "2.1"]
+    assert all(item["page"] != 0 for item in out)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ httpx==0.27.0
 requests==2.32.3
 pytest==8.2.2
 python-docx==1.1.0
+rapidfuzz>=3.9.6


### PR DESCRIPTION
## Summary
- add a forward-only sequential header alignment service with fuzzy matching, TOC/running-header suppression, and tracer events
- expose feature flags and API override for switching between sequential and legacy strategies, plus documentation updates
- add rapidfuzz dependency and tests covering sequential normalization and tracing expectations

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_6904d0e2e7788324b4127f7079e12f2f