### PR TITLE
Improve strict header alignment normalization

### DIFF
--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -5,7 +5,19 @@ from __future__ import annotations
 import json
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Mapping, Protocol, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency in some environments
+    from rapidfuzz.fuzz import token_set_ratio as _rf_token_set_ratio
+except Exception:  # pragma: no cover - fallback for minimal installs
+    from difflib import SequenceMatcher
+
+    def token_set_ratio(a: str, b: str) -> int:
+        return int(SequenceMatcher(None, a, b).ratio() * 100)
+
+else:  # pragma: no cover - passthrough when rapidfuzz is available
+    token_set_ratio = _rf_token_set_ratio
 
 from ..utils.trace import HeaderTracer
 
@@ -53,8 +65,31 @@ def _is_toc_or_index_line(text: str) -> bool:
     return False
 
 
+DOT_VARIANTS = ".\u2024\u2027"
+DOT_CASCADE_RE = re.compile(rf"(\d)\s*[{DOT_VARIANTS}]\s*(\d)")
+IL_MIDDLE_RE = re.compile(r"(?<=\d)\s*[Il]\s*(?=(?:\d|\b))")
+IL_AFTER_DOT_RE = re.compile(rf"(?<=[{DOT_VARIANTS}])\s*[Il]\b")
+WHITESPACE_RE = re.compile(r"\s+")
+APPENDIX_LINE_RE = re.compile(r"^APPENDIX\s+[A-Z0-9]+$", re.IGNORECASE)
+NBSP_TRANSLATION = str.maketrans({"\u00A0": " ", "\u2007": " ", "\u2009": " "})
+BAND_LIMIT = 3
+NUMERIC_THRESHOLD = 74
+TITLE_THRESHOLD = 80
+
+
+def _pre_normalise(value: str) -> str:
+    cleaned = value.translate(NBSP_TRANSLATION)
+    cleaned = DOT_CASCADE_RE.sub(r"\1.\2", cleaned)
+    cleaned = cleaned.replace("\u2024", ".").replace("\u2027", ".")
+    cleaned = IL_MIDDLE_RE.sub("1", cleaned)
+    cleaned = IL_AFTER_DOT_RE.sub("1", cleaned)
+    return cleaned
+
+
 def _normalise(text: str) -> str:
-    return re.sub(r"\s+", " ", text.strip().lower())
+    cleaned = _pre_normalise(text)
+    cleaned = WHITESPACE_RE.sub(" ", cleaned)
+    return cleaned.strip().casefold()
 
 
 def _is_body_candidate(line: BodyLine) -> bool:
@@ -70,47 +105,158 @@ def _is_body_candidate(line: BodyLine) -> bool:
     return True
 
 
-def _find_header_line(
-    header_text: str,
-    lines: Sequence[BodyLine],
-) -> Tuple[int, int, int] | None:
-    """Return (list_index, global_idx, page) for the header text."""
+def _compile_number_regex(number: str) -> re.Pattern[str]:
+    cleaned = WHITESPACE_RE.sub(" ", _pre_normalise(number)).strip()
+    if not cleaned:
+        raise ValueError("empty number pattern")
+    escaped = re.escape(cleaned)
+    escaped = escaped.replace(r"\ ", r"\s+")
+    escaped = escaped.replace(r"\.", rf"\s*[{DOT_VARIANTS}]\s*")
+    return re.compile(rf"^\s*{escaped}\b(?![{DOT_VARIANTS}])", re.IGNORECASE)
 
-    target = _normalise(header_text)
-    candidates: List[Tuple[int, int, int]] = []
 
+def _is_all_caps(value: str) -> bool:
+    letters = re.sub(r"[^A-Za-z0-9]", "", value)
+    return bool(letters) and letters.upper() == letters
+
+
+def _appendix_merge_text(index: int, lines: Sequence[BodyLine]) -> str:
+    current = str(lines[index].get("text", ""))
+    stripped = current.strip()
+    if not APPENDIX_LINE_RE.match(stripped):
+        return current
+    if index + 1 >= len(lines):
+        return current
+    next_text = str(lines[index + 1].get("text", "")).strip()
+    if not next_text:
+        return current
+    if _is_all_caps(next_text):
+        return f"{current} {next_text}"
+    return current
+
+
+def _band_indices(lines: Sequence[BodyLine]) -> set[int]:
+    per_page: Dict[int, List[Tuple[int, int]]] = {}
     for idx, line in enumerate(lines):
         if not _is_body_candidate(line):
             continue
+        page = int(line.get("page", 0) or 0)
+        global_idx = int(line.get("global_idx", idx) or idx)
+        per_page.setdefault(page, []).append((global_idx, idx))
+
+    banded: set[int] = set()
+    for entries in per_page.values():
+        entries.sort(key=lambda item: item[0])
+        if not entries:
+            continue
+        tops = entries[:BAND_LIMIT]
+        bots = entries[-BAND_LIMIT:] if len(entries) > BAND_LIMIT else entries
+        for _, idx in tops + bots:
+            banded.add(idx)
+    return banded
+
+
+@dataclass(slots=True)
+class PreparedLine:
+    index: int
+    text: str
+    page: int
+    global_idx: int
+    line_idx: int
+    combined_normalised: str
+    prenormalised: str
+    is_candidate: bool
+    in_band: bool
+
+
+def _prepare_lines(lines: Sequence[BodyLine]) -> List[PreparedLine]:
+    banded = _band_indices(lines)
+    prepared: List[PreparedLine] = []
+    for idx, line in enumerate(lines):
         text = str(line.get("text", ""))
-        if _normalise(text) == target:
-            candidates.append(
-                (
-                    idx,
-                    int(line.get("global_idx", idx)),
-                    int(line.get("page", 0)),
-                )
+        merged = _appendix_merge_text(idx, lines)
+        prepared.append(
+            PreparedLine(
+                index=idx,
+                text=text,
+                page=int(line.get("page", 0) or 0),
+                global_idx=int(line.get("global_idx", idx) or idx),
+                line_idx=int(line.get("line_idx", idx) or idx),
+                combined_normalised=_normalise(merged),
+                prenormalised=WHITESPACE_RE.sub(" ", _pre_normalise(text)).casefold(),
+                is_candidate=_is_body_candidate(line),
+                in_band=idx in banded,
             )
+        )
+    return prepared
 
-    if not candidates:
-        for idx, line in enumerate(lines):
-            if not _is_body_candidate(line):
-                continue
-            text = str(line.get("text", ""))
-            if _normalise(text).startswith(target):
-                candidates.append(
-                    (
-                        idx,
-                        int(line.get("global_idx", idx)),
-                        int(line.get("page", 0)),
-                    )
-                )
 
-    if not candidates:
+def _select_best(current: Tuple[int, int, PreparedLine] | None, score: int, line: PreparedLine) -> Tuple[int, int, PreparedLine]:
+    if current is None:
+        return (score, line.global_idx, line)
+    best_score, best_idx, _ = current
+    if score > best_score:
+        return (score, line.global_idx, line)
+    if score == best_score and line.global_idx < best_idx:
+        return (score, line.global_idx, line)
+    return current
+
+
+def _find_header_line(
+    header: Mapping[str, Any],
+    prepared_lines: Sequence[PreparedLine],
+) -> PreparedLine | None:
+    title = str(header.get("text", ""))
+    title_norm = _normalise(title)
+    if not title_norm:
         return None
 
-    candidates.sort(key=lambda item: item[1])
-    return candidates[-1]
+    number_value = header.get("number")
+    number_regex: re.Pattern[str] | None = None
+    combined_target = title_norm
+    if isinstance(number_value, str) and number_value.strip():
+        try:
+            number_regex = _compile_number_regex(number_value)
+            combined_target = _normalise(f"{number_value} {title}")
+        except ValueError:
+            number_regex = None
+
+    best_numeric: Tuple[int, int, PreparedLine] | None = None
+    best_title: Tuple[int, int, PreparedLine] | None = None
+
+    for prepared in prepared_lines:
+        if not prepared.is_candidate:
+            continue
+
+        has_number = False
+        numeric_score = -1
+        if number_regex is not None:
+            if number_regex.search(prepared.prenormalised):
+                has_number = True
+                numeric_score = token_set_ratio(
+                    prepared.combined_normalised, combined_target
+                )
+
+        if prepared.in_band and not has_number:
+            continue
+
+        if has_number and numeric_score >= NUMERIC_THRESHOLD:
+            best_numeric = _select_best(best_numeric, numeric_score, prepared)
+            continue
+
+        title_score = token_set_ratio(prepared.combined_normalised, title_norm)
+        if number_regex is not None and has_number and numeric_score >= 0:
+            # numeric evidence but below threshold – allow fallback with slight boost
+            title_score += 2
+
+        if title_score >= TITLE_THRESHOLD:
+            best_title = _select_best(best_title, title_score, prepared)
+
+    if best_numeric is not None:
+        return best_numeric[2]
+    if best_title is not None:
+        return best_title[2]
+    return None
 
 
 def _coerce_level(value: Any) -> int:
@@ -180,6 +326,7 @@ def extract_headers_and_sections_strict(
         payload = {}
 
     llm_headers = list(_extract_headers(payload))
+    prepared_lines = _prepare_lines(lines)
     if tracer is not None:
         tracer.ev(
             "llm_outline_received",
@@ -190,13 +337,15 @@ def extract_headers_and_sections_strict(
     located: List[Dict[str, Any]] = []
 
     for header in llm_headers:
-        position = _find_header_line(header["text"], lines)
-        if not position:
+        prepared = _find_header_line(header, prepared_lines)
+        if not prepared:
             log.debug("Header not located in body: %s", header["text"])
             if tracer is not None:
                 tracer.ev("candidate_missing", header={**header})
             continue
-        list_index, global_idx, page = position
+        list_index = prepared.index
+        global_idx = prepared.global_idx
+        page = prepared.page
         if tracer is not None:
             tracer.ev(
                 "candidate_found",

--- a/backend/tests/test_headers_llm_strict.py
+++ b/backend/tests/test_headers_llm_strict.py
@@ -86,3 +86,112 @@ def test_strict_headers_skip_toc_lines() -> None:
     assert result["sections"][0]["end_global_index"] == 3
     assert result["sections"][1]["start_global_index"] == 4
     assert result["sections"][1]["end_global_index"] == 5
+
+
+def test_strict_handles_confusable_numbers_and_spacing() -> None:
+    lines = [
+        {
+            "text": "Intro text",
+            "global_idx": 0,
+            "page": 0,
+            "line_idx": 0,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "1 \u2024 I\u00A0Purpose",
+            "global_idx": 10,
+            "page": 0,
+            "line_idx": 1,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+    ]
+
+    payload = {
+        "headers": [
+            {"text": "1.1 Purpose", "number": "1.1", "level": 2},
+        ]
+    }
+
+    llm = DummyLLM(payload)
+    result = extract_headers_and_sections_strict(llm=llm, lines=lines)
+
+    assert [header["start_global_index"] for header in result["headers"]] == [10]
+
+
+def test_strict_matches_appendix_split_across_two_lines() -> None:
+    lines = [
+        {
+            "text": "APPENDIX A",
+            "global_idx": 20,
+            "page": 3,
+            "line_idx": 0,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+        {
+            "text": "SUBMITTALS AND FORMS",
+            "global_idx": 21,
+            "page": 3,
+            "line_idx": 1,
+            "is_toc": False,
+            "is_index": False,
+            "is_running": False,
+        },
+    ]
+
+    payload = {
+        "headers": [
+            {
+                "text": "Appendix A Submittals and Forms",
+                "number": "APPENDIX A",
+                "level": 1,
+            }
+        ]
+    }
+
+    llm = DummyLLM(payload)
+    result = extract_headers_and_sections_strict(llm=llm, lines=lines)
+
+    assert [header["start_global_index"] for header in result["headers"]] == [20]
+
+
+def test_strict_title_only_fallback_when_number_missing() -> None:
+    lines = []
+    for idx, text in enumerate(
+        [
+            "Preface",
+            "General",
+            "Summary",
+            "FOREWORD",
+            "Details",
+            "More details",
+            "Closing",
+        ]
+    ):
+        lines.append(
+            {
+                "text": text,
+                "global_idx": idx + 100,
+                "page": 0,
+                "line_idx": idx,
+                "is_toc": False,
+                "is_index": False,
+                "is_running": False,
+            }
+        )
+
+    payload = {
+        "headers": [
+            {"text": "FOREWORD", "number": "1", "level": 1},
+        ]
+    }
+
+    llm = DummyLLM(payload)
+    result = extract_headers_and_sections_strict(llm=llm, lines=lines)
+
+    assert [header["start_global_index"] for header in result["headers"]] == [103]


### PR DESCRIPTION
## Summary
- enhance the strict LLM alignment pipeline with number pre-normalisation, dot/nbsp cleanup, appendix two-line handling, and revised scoring thresholds
- add a rapidfuzz fallback so the strict path works in minimal environments
- exercise the new behaviour with tests covering spaced dots, appendix splits, and title-only fallback

## Testing
- pytest backend/tests/test_headers_llm_strict.py

------
https://chatgpt.com/codex/tasks/task_e_6904eb0e76e483249e950ce4bbd81539