### PR TITLE
Handle reversed section bounds gracefully

### DIFF
--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -331,11 +331,14 @@ async def section_text(
 ) -> PlainTextResponse:
     """Return the plain text for a section bounded by global indices."""
 
-    if start < 0 or end < 0 or end < start:
+    if start < 0 or end < 0:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid section bounds",
         )
+
+    if end < start:
+        start, end = end, start
 
     document = session.get(Document, document_id)
     if document is None:

--- a/backend/tests/test_headers_section_text.py
+++ b/backend/tests/test_headers_section_text.py
@@ -1,0 +1,46 @@
+"""Tests for the section text retrieval endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+pytest.importorskip("rapidfuzz")
+
+from backend.database import get_engine
+from backend.models.document import Document
+from backend.services.simpleheaders_state import SimpleHeadersState
+from backend.main import app
+
+
+def test_section_text_accepts_reversed_bounds() -> None:
+    """The endpoint should gracefully handle ranges where start > end."""
+
+    engine = get_engine()
+
+    with Session(engine) as session:
+        document = Document(filename="example.pdf", checksum="checksum")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+    lines = [
+        {"global_idx": 36, "text": "First"},
+        {"global_idx": 664, "text": "Second"},
+    ]
+    SimpleHeadersState.set(document.id, "hash", lines)
+
+    try:
+        from fastapi.testclient import TestClient
+
+        with TestClient(app) as client:
+            response = client.get(
+                f"/api/headers/{document.id}/section-text",
+                params={"start": 664, "end": 36},
+            )
+    finally:
+        SimpleHeadersState._store.pop(document.id, None)  # type: ignore[attr-defined]
+
+    assert response.status_code == 200
+    assert response.text == "First\nSecond"
+


### PR DESCRIPTION
## Summary
- allow the section-text endpoint to normalise reversed index ranges instead of returning a 400
- add a regression test that exercises the endpoint with swapped start/end values

## Testing
- pytest backend/tests/test_headers_section_text.py

------
https://chatgpt.com/codex/tasks/task_e_6904f177df448324a33e1295733506e4