### PR TITLE
Add best-practice header alignment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,23 @@ SimpleSpecs sends the full document text to OpenRouter for a high-fidelity outli
 
 The pipeline requires `OPENROUTER_API_KEY`. Cached responses avoid repeated model invocations for unchanged documents.
 
-#### Sequential alignment strategy
+#### Best-practice alignment strategy (`align=best`)
 
-The default header locator uses a forward-only, parent-bounded sequential search that resists table-of-contents anchors and running headers. Tune behaviour via these environment variables:
+The production-grade "best" strategy is now the default. It layers multiple signals to reliably anchor LLM-provided outlines:
+
+- Normalises numbering and OCR artefacts (e.g. `1 .I` → `1.1`) before scoring.
+- Suppresses TOC/running headers by detecting dotted leaders and repeated band lines.
+- Factors in typography (larger fonts, bold weight) when ranking candidates.
+- Anchors sequentially, with a last-occurrence fallback that still respects TOC bans.
+- Constrains children to hierarchical windows derived from their parents.
+- Applies a final monotonic guard so parents always precede descendants.
+- Emits rich trace events such as `candidate_found`, `anchor_resolved_best`, and `final_monotonic_pass_best` when tracing.
+
+Toggle via `HEADERS_ALIGN_STRATEGY=best` or per-request with `?align=best`. Combine with `HEADERS_TRACE=1` to inspect the new trace events.
+
+#### Sequential alignment strategy (legacy)
+
+The legacy forward-only sequential locator remains available for comparison and regression checks. Tune behaviour via these environment variables:
 
 ```
 HEADERS_ALIGN_STRATEGY=sequential  # use `legacy` to revert to the prior locator
@@ -55,7 +69,7 @@ HEADERS_SUPPRESS_RUNNING=1        # filter repeated running headers/footers
 HEADERS_NORMALIZE_CONFUSABLES=1   # normalise numeric lookalikes (I/l → 1)
 HEADERS_FUZZY_THRESHOLD=80        # token-set similarity for title matching
 HEADERS_WINDOW_PAD_LINES=40       # expand parent search windows by ±N lines
-HEADERS_BAND_LINES=5              # top/bottom lines per page considered a running band
+HEADERS_BAND_LINES=3              # top/bottom lines per page considered a running band
 HEADERS_L1_REQUIRE_NUMERIC=1      # insist on numeric prefixes for L1 anchors before fallback
 HEADERS_L1_LOOKAHEAD_CHILD_HINT=30  # scan ahead for 1.1-style hints when ranking anchors
 HEADERS_MONOTONIC_STRICT=1        # enforce forward-only anchoring with duplicate retries

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,7 +39,7 @@ HEADERS_TRACE_EMBED_RESPONSE: bool = (
 HEADERS_TRACE_DIR: str = os.getenv("HEADERS_TRACE_DIR", "backend/logs/headers")
 HEADERS_LOG_LEVEL: str = os.getenv("HEADERS_LOG_LEVEL", "DEBUG")
 
-HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
+HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "best")
 HEADERS_SUPPRESS_TOC: bool = os.getenv("HEADERS_SUPPRESS_TOC", "1") in (
     "1",
     "true",
@@ -59,7 +59,7 @@ HEADERS_NORMALIZE_CONFUSABLES: bool = os.getenv(
 ) in ("1", "true", "True", "YES", "yes")
 HEADERS_FUZZY_THRESHOLD: int = int(os.getenv("HEADERS_FUZZY_THRESHOLD", "80"))
 HEADERS_WINDOW_PAD_LINES: int = int(os.getenv("HEADERS_WINDOW_PAD_LINES", "40"))
-HEADERS_BAND_LINES: int = int(os.getenv("HEADERS_BAND_LINES", "5"))
+HEADERS_BAND_LINES: int = int(os.getenv("HEADERS_BAND_LINES", "3"))
 HEADERS_L1_REQUIRE_NUMERIC: bool = os.getenv("HEADERS_L1_REQUIRE_NUMERIC", "1") in (
     "1",
     "true",
@@ -100,6 +100,37 @@ HEADERS_TITLE_ONLY_REANCHOR: bool = os.getenv("HEADERS_TITLE_ONLY_REANCHOR", "1"
 )
 HEADERS_RESCAN_PASSES: int = int(os.getenv("HEADERS_RESCAN_PASSES", "2"))
 HEADERS_DEDUPE_POLICY: str = os.getenv("HEADERS_DEDUPE_POLICY", "best")
+
+# Strategy-specific tunables for the "best" aligner
+HEADERS_FUZZY_TITLE: int = int(os.getenv("HEADERS_FUZZY_TITLE", "78"))
+HEADERS_FUZZY_NUMTITLE: int = int(os.getenv("HEADERS_FUZZY_NUMTITLE", "75"))
+HEADERS_FUZZY_TITLE_ONLY: int = int(os.getenv("HEADERS_FUZZY_TITLE_ONLY", "72"))
+
+HEADERS_TOC_MIN_DOT_LEADERS: int = int(
+    os.getenv("HEADERS_TOC_MIN_DOT_LEADERS", "4")
+)
+HEADERS_TOC_MIN_SECTION_TOKENS: int = int(
+    os.getenv("HEADERS_TOC_MIN_SECTION_TOKENS", "6")
+)
+HEADERS_RUNNER_MIN_PAGES: int = int(os.getenv("HEADERS_RUNNER_MIN_PAGES", "6"))
+
+HEADERS_W_FUZZY: float = float(os.getenv("HEADERS_W_FUZZY", "0.62"))
+HEADERS_W_TYPO: float = float(os.getenv("HEADERS_W_TYPO", "0.28"))
+HEADERS_W_POS: float = float(os.getenv("HEADERS_W_POS", "0.10"))
+
+HEADERS_PENALTY_BAND: int = int(os.getenv("HEADERS_PENALTY_BAND", "10"))
+HEADERS_PENALTY_TOC: int = int(os.getenv("HEADERS_PENALTY_TOC", "999"))
+
+HEADERS_AFTER_ANCHOR_ONLY: bool = os.getenv("HEADERS_AFTER_ANCHOR_ONLY", "1") in (
+    "1",
+    "true",
+    "True",
+    "YES",
+    "yes",
+)
+HEADERS_LAST_OCCURRENCE_FALLBACK: bool = os.getenv(
+    "HEADERS_LAST_OCCURRENCE_FALLBACK", "1"
+) in ("1", "true", "True", "YES", "yes")
 
 # Strict/LLM matcher hardening
 HEADERS_STRICT_FUZZY_THRESH: int = int(
@@ -231,7 +262,7 @@ class Settings(BaseModel):
         default_factory=lambda: _env_flag("HEADERS_SUPPRESS_RUNNING", True)
     )
     headers_align_strategy: str = Field(
-        default_factory=lambda: os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
+        default_factory=lambda: os.getenv("HEADERS_ALIGN_STRATEGY", "best")
     )
     headers_normalize_confusables: bool = Field(
         default_factory=lambda: _env_flag("HEADERS_NORMALIZE_CONFUSABLES", True)

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -150,7 +150,7 @@ async def generate_headers(
     trace_requested = trace or app_config.HEADERS_TRACE_EMBED_RESPONSE
 
     align_strategy = (align or "").strip().lower()
-    if align_strategy in {"sequential", "legacy"}:
+    if align_strategy in {"best", "sequential", "legacy", "strict"}:
         os.environ["HEADERS_ALIGN_STRATEGY"] = align_strategy
 
     if settings.headers_llm_strict:

--- a/backend/services/extractors/fitz_extractor.py
+++ b/backend/services/extractors/fitz_extractor.py
@@ -4,48 +4,37 @@ from typing import Dict, List
 
 import fitz
 
-from backend.config import PARSER_KEEP_BBOX, PARSER_LINE_Y_TOLERANCE
-
+from backend.config import PARSER_KEEP_BBOX
 from ._normalize import normalize_numeric_artifacts
 
 
-def _group_words_into_lines(words: list) -> List[Dict[str, object]]:
+def _lines_from_rawdict(raw: dict) -> List[Dict[str, object]]:
     lines: List[Dict[str, object]] = []
-    if not words:
-        return lines
-
-    words.sort(key=lambda w: (w[1], w[0]))
-    current_y = None
-    buffer: list = []
-
-    def flush() -> None:
-        nonlocal buffer
-        if not buffer:
-            return
-        text = " ".join(entry[4] for entry in buffer)
-        if not text.strip():
-            buffer = []
-            return
-        x0 = min(entry[0] for entry in buffer)
-        y0 = min(entry[1] for entry in buffer)
-        x1 = max(entry[2] for entry in buffer)
-        y1 = max(entry[3] for entry in buffer)
-        lines.append({"_text": text, "_bbox": (x0, y0, x1, y1)})
-        buffer = []
-
-    for word in words:
-        x0, y0, x1, y1 = word[0], word[1], word[2], word[3]
-        if current_y is None:
-            current_y = y0
-            buffer = [word]
+    for block in raw.get("blocks", []):
+        if block.get("type") != 0:
             continue
-        if abs(y0 - current_y) <= PARSER_LINE_Y_TOLERANCE:
-            buffer.append(word)
-        else:
-            flush()
-            current_y = y0
-            buffer = [word]
-    flush()
+        for line in block.get("lines", []):
+            spans = line.get("spans", [])
+            if not spans:
+                continue
+            text = "".join(span.get("text", "") for span in spans).strip()
+            if not text:
+                continue
+            size_max = max(float(span.get("size", 0.0)) for span in spans)
+            bold = any((int(span.get("flags", 0)) & 2) != 0 for span in spans)
+            x0 = min(span.get("bbox", [0.0, 0.0, 0.0, 0.0])[0] for span in spans)
+            y0 = min(span.get("bbox", [0.0, 0.0, 0.0, 0.0])[1] for span in spans)
+            x1 = max(span.get("bbox", [0.0, 0.0, 0.0, 0.0])[2] for span in spans)
+            y1 = max(span.get("bbox", [0.0, 0.0, 0.0, 0.0])[3] for span in spans)
+            lines.append(
+                {
+                    "_text": text,
+                    "_bbox": (x0, y0, x1, y1),
+                    "_size": size_max,
+                    "_bold": bold,
+                }
+            )
+    lines.sort(key=lambda entry: (entry["_bbox"][1], entry["_bbox"][0]))
     return lines
 
 
@@ -54,18 +43,20 @@ def extract_lines_fitz(pdf_path: str) -> List[Dict[str, object]]:
     global_idx = 0
     with fitz.open(pdf_path) as document:
         for page_number, page in enumerate(document, start=1):
-            words = page.get_text("words")
-            grouped = _group_words_into_lines(words)
-            for record in grouped:
-                raw_text = record["_text"]
+            raw = page.get_text("rawdict")
+            lines = _lines_from_rawdict(raw)
+            for entry in lines:
+                raw_text = entry["_text"]
                 text = normalize_numeric_artifacts(raw_text)
-                bbox = record["_bbox"] if PARSER_KEEP_BBOX else None
+                bbox = entry["_bbox"] if PARSER_KEEP_BBOX else None
                 output.append(
                     {
                         "text": text,
                         "page": page_number,
                         "global_idx": global_idx,
                         "bbox": bbox,
+                        "font_size": entry.get("_size"),
+                        "bold": bool(entry.get("_bold")),
                     }
                 )
                 global_idx += 1

--- a/backend/services/header_align_bp.py
+++ b/backend/services/header_align_bp.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+import re
+
+from rapidfuzz.fuzz import token_set_ratio
+
+from backend.config import (
+    HEADERS_AFTER_ANCHOR_ONLY,
+    HEADERS_BAND_LINES,
+    HEADERS_FUZZY_NUMTITLE,
+    HEADERS_FUZZY_TITLE,
+    HEADERS_FUZZY_TITLE_ONLY,
+    HEADERS_LAST_OCCURRENCE_FALLBACK,
+    HEADERS_PENALTY_BAND,
+    HEADERS_PENALTY_TOC,
+    HEADERS_RUNNER_MIN_PAGES,
+    HEADERS_TOC_MIN_DOT_LEADERS,
+    HEADERS_TOC_MIN_SECTION_TOKENS,
+    HEADERS_W_FUZZY,
+    HEADERS_W_POS,
+    HEADERS_W_TYPO,
+    HEADERS_FINAL_MONOTONIC_GUARD,
+)
+
+try:
+    from backend.utils.trace import HeaderTracer
+except Exception:  # pragma: no cover - trace optional in tests
+    HeaderTracer = None  # type: ignore[assignment]
+
+DOTS = r"[.\u2024\u2027·]"
+DOTTED_LEADER_RE = re.compile(r"\.{3,}\s*\d+\s*$")
+SECTION_LIKE_RE = re.compile(r"^\s*\d+(?:\s*" + DOTS + r"\s*\d+)*\b")
+APPENDIX_LINE_RE = re.compile(r"^\s*APPENDIX\s+[A-Z]\b", re.IGNORECASE)
+
+
+Line = Dict[str, object]
+Header = Dict[str, object]
+
+
+def _norm(value: str | None) -> str:
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", value).strip().casefold()
+
+
+def _compile_num_regex(number: str) -> re.Pattern[str]:
+    number_pattern = re.escape(number).replace(r"\.", r"\s*" + DOTS + r"\s*")
+    return re.compile(r"^\s*" + number_pattern + r"\b(?!\.)", re.IGNORECASE)
+
+
+def _two_line_appendix_fuse(lines: Sequence[Line]) -> List[Line]:
+    fused: List[Line] = []
+    index = 0
+    while index < len(lines):
+        current = lines[index]
+        text = str(current.get("text", ""))
+        if APPENDIX_LINE_RE.match(text):
+            if index + 1 < len(lines):
+                nxt = lines[index + 1]
+                nxt_text = str(nxt.get("text", ""))
+                if nxt_text.strip():
+                    combined = f"{text} {nxt_text}".strip()
+                    updated = dict(current)
+                    updated["_synthetic_text"] = combined
+                    fused.append(updated)
+                    index += 2
+                    continue
+        fused.append(current)
+        index += 1
+    return fused
+
+
+def detect_toc_pages(lines: Sequence[Line]) -> Set[int]:
+    by_page: Dict[int, List[str]] = defaultdict(list)
+    for line in lines:
+        by_page[int(line.get("page", 0) or 0)].append(str(line.get("text", "")))
+    toc: Set[int] = set()
+    for page, texts in by_page.items():
+        dots = sum(1 for text in texts if DOTTED_LEADER_RE.search(text))
+        sections = sum(1 for text in texts if SECTION_LIKE_RE.search(_norm(text)))
+        if dots >= HEADERS_TOC_MIN_DOT_LEADERS or sections >= HEADERS_TOC_MIN_SECTION_TOKENS:
+            toc.add(page)
+    return toc
+
+
+def detect_running_headers(lines: Sequence[Line]) -> Set[str]:
+    per_page: Dict[int, List[Line]] = defaultdict(list)
+    for line in lines:
+        per_page[int(line.get("page", 0) or 0)].append(line)
+    signatures: Dict[str, int] = defaultdict(int)
+    for entries in per_page.values():
+        sorted_entries = sorted(entries, key=lambda item: int(item.get("global_idx", 0) or 0))
+        top_band = sorted_entries[: HEADERS_BAND_LINES]
+        bottom_band = sorted_entries[-HEADERS_BAND_LINES :]
+        for candidate in top_band + bottom_band:
+            signatures[_norm(str(candidate.get("text", "")))] += 1
+    return {text for text, count in signatures.items() if count >= HEADERS_RUNNER_MIN_PAGES and len(text) >= 6}
+
+
+def _typography_score(line: Line, median_size: float) -> float:
+    font_size = float(line.get("font_size") or 0.0)
+    bold = 1.0 if line.get("bold") else 0.0
+    bonus = 1.0 if font_size >= max(12.0, median_size * 1.1) else 0.0
+    return bold + bonus
+
+
+def _page_positions(lines: Sequence[Line]) -> Dict[int, Dict[int, int]]:
+    per_page: Dict[int, List[Line]] = defaultdict(list)
+    for line in lines:
+        per_page[int(line.get("page", 0) or 0)].append(line)
+    lookup: Dict[int, Dict[int, int]] = {}
+    for page, entries in per_page.items():
+        sorted_entries = sorted(entries, key=lambda item: int(item.get("global_idx", 0) or 0))
+        lookup[page] = {
+            int(entry.get("global_idx", 0) or 0): position for position, entry in enumerate(sorted_entries)
+        }
+    return lookup
+
+
+def _in_band(line: Line, positions: Dict[int, Dict[int, int]]) -> bool:
+    page = int(line.get("page", 0) or 0)
+    idx = int(line.get("global_idx", 0) or 0)
+    page_map = positions.get(page, {})
+    if idx not in page_map:
+        return False
+    position = page_map[idx]
+    total = len(page_map)
+    return position < HEADERS_BAND_LINES or position >= max(0, total - HEADERS_BAND_LINES)
+
+
+def align_headers_best(llm_headers: Sequence[Header], lines_input: Sequence[Line], tracer: HeaderTracer | None = None) -> List[Dict[str, object]]:
+    lines = _two_line_appendix_fuse(list(lines_input))
+    sizes = [float(line.get("font_size") or 0.0) for line in lines if line.get("font_size") is not None]
+    median_size = sorted(sizes)[len(sizes) // 2] if sizes else 0.0
+
+    positions = _page_positions(lines)
+    toc_pages = detect_toc_pages(lines)
+    running_headers = detect_running_headers(lines)
+    if tracer:
+        tracer.ev("toc_pages", pages=sorted(toc_pages))
+        tracer.ev("running_headers", n=len(running_headers))
+
+    anchors: Dict[str, int] = {}
+    prev_idx = -1
+
+    def level_of(number: str) -> int:
+        return number.count(".") + 1
+
+    def parent_of(number: str) -> Optional[str]:
+        if "." in number:
+            return number.rsplit(".", 1)[0]
+        return None
+
+    windows: Dict[str, Tuple[int, int]] = {}
+
+    for header in llm_headers:
+        number = (header.get("number") or "").strip()
+        if not number:
+            continue
+        title = str(header.get("title") or header.get("text") or "")
+        want_full = _norm(f"{number} {title}")
+        want_title = _norm(title)
+        number_regex = _compile_num_regex(number)
+
+        parent = parent_of(number)
+        window_start = prev_idx + 1
+        window_end = int(lines[-1].get("global_idx", 0) or 0) + 1 if lines else 0
+        if parent and parent in anchors:
+            window_start = max(window_start, anchors[parent] + 1)
+        if parent and parent in windows:
+            window_start, window_end = windows[parent]
+
+        candidates: List[Tuple[float, Line, str]] = []
+        for line in lines:
+            global_idx = int(line.get("global_idx", 0) or 0)
+            if HEADERS_AFTER_ANCHOR_ONLY and global_idx <= prev_idx:
+                continue
+            text = str(line.get("_synthetic_text") or line.get("text") or "")
+            norm_text = _norm(text)
+            in_toc = int(line.get("page", 0) or 0) in toc_pages
+            has_number = bool(number_regex.search(norm_text))
+            fuzzy = token_set_ratio(norm_text, want_full if has_number else want_title)
+            typo_score = _typography_score(line, median_size)
+            band = _in_band(line, positions)
+
+            score = HEADERS_W_FUZZY * fuzzy + HEADERS_W_TYPO * (50 * typo_score) + HEADERS_W_POS * (0 if band else 50)
+            if band:
+                score -= HEADERS_PENALTY_BAND
+            if in_toc:
+                score -= HEADERS_PENALTY_TOC
+            if _norm(str(line.get("text", ""))) in running_headers:
+                score -= 500
+
+            strategy = "num+title" if has_number else "title_only"
+            in_window = window_start <= global_idx < window_end
+            if in_window:
+                score += 5
+
+            threshold = HEADERS_FUZZY_NUMTITLE if has_number else HEADERS_FUZZY_TITLE_ONLY
+            if fuzzy >= threshold:
+                candidates.append((score, line, strategy))
+                if tracer:
+                    tracer.ev(
+                        "candidate_found",
+                        number=number,
+                        idx=global_idx,
+                        page=int(line.get("page", 0) or 0),
+                        fuzzy=fuzzy,
+                        score=score,
+                        strategy=strategy,
+                        band=band,
+                        toc=in_toc,
+                        in_window=in_window,
+                    )
+
+        chosen: Optional[Tuple[float, Line, str]] = None
+        if candidates:
+            in_window_candidates = [candidate for candidate in candidates if window_start <= int(candidate[1].get("global_idx", 0) or 0) < window_end]
+            pool = in_window_candidates or candidates
+            chosen = max(pool, key=lambda item: (item[0], int(item[1].get("global_idx", 0) or 0)))
+
+        if not chosen and HEADERS_LAST_OCCURRENCE_FALLBACK:
+            outside_toc = [candidate for candidate in candidates if int(candidate[1].get("page", 0) or 0) not in toc_pages]
+            if outside_toc:
+                chosen = max(outside_toc, key=lambda item: int(item[1].get("global_idx", 0) or 0))
+                chosen = (chosen[0], chosen[1], "last_occurrence")
+
+        if chosen:
+            score, line, strategy = chosen
+            global_idx = int(line.get("global_idx", 0) or 0)
+            anchors[number] = global_idx
+            prev_idx = global_idx
+            if tracer:
+                tracer.ev(
+                    "anchor_resolved_best",
+                    number=number,
+                    idx=global_idx,
+                    page=int(line.get("page", 0) or 0),
+                    score=score,
+                    strategy=strategy,
+                    text=str(line.get("text", ""))[:200],
+                )
+        else:
+            if tracer:
+                tracer.ev("anchor_unresolved_best", number=number, reason="no_candidate")
+
+        if level_of(number) == 1 and number in anchors:
+            window_end = int(lines[-1].get("global_idx", 0) or 0) + 1 if lines else anchors[number] + 1
+            windows[number] = (anchors[number], window_end)
+
+    top_level = sorted(
+        [number for number in anchors if number.count(".") == 0],
+        key=lambda value: [int(part) for part in value.split(".") if part.isdigit()],
+    )
+    if lines:
+        final_idx = int(lines[-1].get("global_idx", 0) or 0) + 1
+    else:
+        final_idx = 0
+    for index, number in enumerate(top_level):
+        start = anchors[number]
+        end = final_idx
+        if index + 1 < len(top_level):
+            end = anchors[top_level[index + 1]]
+        windows[number] = (start, end)
+
+    def parent(number: str) -> Optional[str]:
+        if "." in number:
+            return number.rsplit(".", 1)[0]
+        return None
+
+    changed = True
+    while changed:
+        changed = False
+        by_parent: Dict[str, List[str]] = defaultdict(list)
+        for number in anchors:
+            p = parent(number)
+            if p:
+                by_parent[p].append(number)
+        for p, children in by_parent.items():
+            if p not in anchors:
+                continue
+            child_positions = [anchors[child] for child in children if child in anchors]
+            if not child_positions:
+                continue
+            earliest_child = min(child_positions)
+            if anchors[p] > earliest_child:
+                regex = _compile_num_regex(p)
+                candidates = [
+                    line
+                    for line in lines
+                    if int(line.get("global_idx", 0) or 0) < earliest_child
+                    and regex.search(
+                        _norm(
+                            str(line.get("_synthetic_text") or line.get("text") or "")
+                        )
+                    )
+                    and int(line.get("page", 0) or 0) not in toc_pages
+                ]
+                if candidates:
+                    best_parent = max(
+                        candidates, key=lambda line: int(line.get("global_idx", 0) or 0)
+                    )
+                    anchors[p] = int(best_parent.get("global_idx", 0) or 0)
+                    changed = True
+                    if tracer:
+                        tracer.ev(
+                            "reanchor_parent_best",
+                            parent=p,
+                            to_idx=anchors[p],
+                            page=int(best_parent.get("page", 0) or 0),
+                        )
+        for number, global_idx in list(anchors.items()):
+            p = parent(number)
+            if not p or p not in windows:
+                continue
+            window_start, window_end = windows[p]
+            if global_idx < window_start or global_idx >= window_end:
+                regex = _compile_num_regex(number)
+                best_line: Optional[Line] = None
+                for line in lines:
+                    candidate_idx = int(line.get("global_idx", 0) or 0)
+                    if not (window_start <= candidate_idx < window_end):
+                        continue
+                    text = str(line.get("_synthetic_text") or line.get("text") or "")
+                    if regex.search(_norm(text)):
+                        best_line = line
+                        break
+                if best_line:
+                    anchors[number] = int(best_line.get("global_idx", 0) or 0)
+                    changed = True
+                    if tracer:
+                        tracer.ev(
+                            "child_relocate_best",
+                            number=number,
+                            parent=p,
+                            to_idx=anchors[number],
+                        )
+        deduped: Dict[str, int] = {}
+        for number in sorted(anchors, key=lambda key: (key, anchors[key])):
+            if number not in deduped:
+                deduped[number] = anchors[number]
+            else:
+                changed = True
+                if tracer:
+                    tracer.ev(
+                        "dedupe_drop_best",
+                        number=number,
+                        drop_idx=anchors[number],
+                        keep_idx=deduped[number],
+                    )
+        anchors = deduped
+
+    results: List[Dict[str, object]] = []
+    for number, idx in anchors.items():
+        line = next((entry for entry in lines if int(entry.get("global_idx", 0) or 0) == idx), None)
+        header_meta = next(
+            (
+                header
+                for header in llm_headers
+                if (header.get("number") or "").strip() == number
+            ),
+            {},
+        )
+        results.append(
+            {
+                "number": number,
+                "title": str(header_meta.get("title") or header_meta.get("text") or ""),
+                "level": int(header_meta.get("level") or 1),
+                "global_idx": idx,
+                "page": int(line.get("page", 0) or 0) if line else None,
+                "line_idx": int(line.get("line_idx", 0) or 0) if line else 0,
+            }
+        )
+
+    if HEADERS_FINAL_MONOTONIC_GUARD:
+        results.sort(key=lambda item: item["global_idx"])
+        positions = {entry["number"]: entry["global_idx"] for entry in results}
+        fixes = 0
+        for entry in results:
+            number = entry["number"]
+            p = parent(number)
+            if not p or p not in positions:
+                continue
+            if entry["global_idx"] > positions[number]:
+                positions[number] = entry["global_idx"]
+            if positions[p] <= entry["global_idx"]:
+                continue
+            regex = _compile_num_regex(number)
+            candidates = [
+                line
+                for line in lines
+                if int(line.get("global_idx", 0) or 0) > positions[p]
+                and regex.search(_norm(str(line.get("_synthetic_text") or line.get("text") or "")))
+                and int(line.get("page", 0) or 0) not in toc_pages
+            ]
+            if candidates:
+                replacement = min(candidates, key=lambda line: int(line.get("global_idx", 0) or 0))
+                entry["global_idx"] = int(replacement.get("global_idx", 0) or 0)
+                entry["page"] = int(replacement.get("page", 0) or 0)
+                entry["line_idx"] = int(replacement.get("line_idx", 0) or 0)
+                positions[number] = entry["global_idx"]
+                fixes += 1
+                if tracer:
+                    tracer.ev(
+                        "final_monotonic_fix_best",
+                        number=number,
+                        new_idx=entry["global_idx"],
+                        parent=p,
+                    )
+        if tracer:
+            tracer.ev("final_monotonic_pass_best", fixed=fixes)
+
+    results.sort(key=lambda item: item["global_idx"])
+    return results
+
+
+__all__ = ["align_headers_best", "detect_toc_pages", "detect_running_headers"]

--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -15,6 +15,8 @@ from backend.config import (
 )
 
 from ..utils.trace import HeaderTracer
+from .header_align_bp import align_headers_best
+from .headers_llm_strict import align_headers_llm_strict
 from .headers_sequential import align_headers_sequential
 
 
@@ -163,6 +165,75 @@ def locate_headers_in_lines(
     tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
     strategy = os.getenv("HEADERS_ALIGN_STRATEGY", HEADERS_ALIGN_STRATEGY).strip().lower()
+
+    if strategy == "best":
+        best_headers = align_headers_best(headers, lines, tracer=tracer)
+
+        located: List[Dict] = [
+            {
+                "text": str(entry.get("title", "")),
+                "number": entry.get("number"),
+                "level": int(entry.get("level", 1)),
+                "page": int(entry.get("page", 0) or 0),
+                "line_idx": int(entry.get("line_idx", 0) or 0),
+                "global_idx": int(entry.get("global_idx", 0) or 0),
+            }
+            for entry in best_headers
+        ]
+
+        matched_numbers = {
+            str(entry.get("number"))
+            for entry in best_headers
+            if entry.get("number")
+        }
+        used_indices = {
+            int(entry.get("global_idx", 0) or 0)
+            for entry in best_headers
+        }
+
+        remaining_headers: list[Dict] = []
+        for header in headers:
+            number = (header.get("number") or "").strip()
+            if number and number in matched_numbers:
+                continue
+            remaining_headers.append(header)
+
+        if remaining_headers:
+            filtered_lines = [
+                line
+                for line in lines
+                if int(line.get("global_idx", 0) or 0) not in used_indices
+            ]
+            legacy = _locate_headers_legacy(
+                remaining_headers,
+                filtered_lines,
+                excluded_pages=excluded_pages,
+                similarity_threshold=similarity_threshold,
+                tracer=tracer,
+            )
+            located.extend(legacy)
+
+        located.sort(key=lambda item: item.get("global_idx", 0))
+        return located
+
+    if strategy == "strict":
+        resolved = align_headers_llm_strict(list(headers), list(lines), tracer=tracer)
+        located: List[Dict] = []
+        for item in resolved:
+            header = item.get("header", {})
+            line = item.get("line", {})
+            located.append(
+                {
+                    "text": str(header.get("title") or header.get("text") or ""),
+                    "number": header.get("number"),
+                    "level": int(header.get("level", 1)),
+                    "page": int(line.get("page", 0) or 0),
+                    "line_idx": int(line.get("line_index", 0) or 0),
+                    "global_idx": int(line.get("global_idx", 0) or 0),
+                }
+            )
+        located.sort(key=lambda item: item.get("global_idx", 0))
+        return located
 
     if strategy == "sequential":
         sequential_headers = align_headers_sequential(

--- a/backend/tests/test_header_align_bp.py
+++ b/backend/tests/test_header_align_bp.py
@@ -1,0 +1,53 @@
+import pytest
+
+pytest.importorskip("rapidfuzz")
+
+from backend.services.header_align_bp import align_headers_best
+
+
+def _mk_line(text: str, page: int, global_idx: int, *, size: float = 12.0, bold: bool = False):
+    return {
+        "text": text,
+        "page": page,
+        "global_idx": global_idx,
+        "font_size": size,
+        "bold": bold,
+    }
+
+
+def test_toc_suppression_and_after_anchor():
+    llm_headers = [
+        {"number": "1", "title": "GENERAL", "level": 1},
+        {"number": "1.1", "title": "Scope and Field of Application", "level": 2},
+        {"number": "2", "title": "METHODS", "level": 1},
+    ]
+    lines = [
+        _mk_line("1 GENERAL .... 3", 1, 0, size=10),
+        _mk_line("1.1 Scope and Field of Application .... 4", 1, 1, size=10),
+        _mk_line("Preface text", 2, 2, size=10),
+        _mk_line("1 GENERAL", 3, 3, size=14, bold=True),
+        _mk_line("1 .I Scope and Field of Application", 4, 4, size=13, bold=True),
+        _mk_line("2 METHODS", 10, 5, size=14, bold=True),
+    ]
+
+    resolved = align_headers_best(llm_headers, lines, tracer=None)
+    numbers = [entry["number"] for entry in resolved]
+    assert numbers == ["1", "1.1", "2"]
+
+    lookup = {entry["number"]: entry["global_idx"] for entry in resolved}
+    assert lookup["1.1"] == 4
+
+
+def test_monotonic_parent_before_child():
+    llm_headers = [
+        {"number": "1", "title": "A", "level": 1},
+        {"number": "1.1", "title": "B", "level": 2},
+    ]
+    lines = [
+        _mk_line("1 A", 3, 3, size=14, bold=True),
+        _mk_line("1.1 B", 4, 4, size=13, bold=True),
+    ]
+
+    resolved = align_headers_best(llm_headers, lines, tracer=None)
+    assert [entry["number"] for entry in resolved] == ["1", "1.1"]
+    assert resolved[0]["global_idx"] < resolved[1]["global_idx"]


### PR DESCRIPTION
## Summary
- add a layout-aware "best" header aligner with hierarchical windows, TOC/running suppression, and trace events
- capture font weight/size from the PyMuPDF extractor to support typography scoring and wire the strategy selector to the API
- document the new default strategy and provide unit coverage for key heuristics

## Testing
- pytest backend/tests/test_header_align_bp.py

------
https://chatgpt.com/codex/tasks/task_e_6905061666d083249f756d919bdd5254