### PR TITLE
Fix strict header line mapping and add regression test

### DIFF
--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -471,38 +471,38 @@ def extract_headers_and_sections_strict(
 
     resolved = align_headers_llm_strict(llm_headers, lines_list, tracer=tracer)
 
+    index_by_global: Dict[int, int] = {
+        int(entry.get("global_idx", idx) or idx): idx
+        for idx, entry in enumerate(lines_list)
+    }
+
     located: List[Dict[str, Any]] = []
     for item in resolved:
         header = item["header"]
         line = item["line"]
         if not lines_list:
             continue
-        line_index = line.get("line_index", 0)
-        try:
-            line_index = int(line_index)
-        except Exception:
-            line_index = 0
-        if not (0 <= line_index < len(lines_list)):
-            fallback_index = next(
-                (
-                    idx
-                    for idx, original in enumerate(lines_list)
-                    if int(original.get("global_idx", idx) or idx) == line["global_idx"]
-                ),
-                None,
-            )
-            if fallback_index is not None:
-                line_index = fallback_index
+        global_idx = int(line.get("global_idx", 0))
+        line_index = index_by_global.get(global_idx)
+        if line_index is None:
+            raw_line_index = line.get("line_index", 0)
+            try:
+                raw_line_index = int(raw_line_index)
+            except Exception:
+                raw_line_index = 0
+            if 0 <= raw_line_index < len(lines_list):
+                line_index = raw_line_index
             else:
-                line_index = max(0, min(len(lines_list) - 1, line_index))
+                line_index = max(0, min(len(lines_list) - 1, raw_line_index))
+        line_entry = lines_list[line_index]
         located.append(
             {
                 "text": header.get("text", ""),
                 "number": header.get("number"),
                 "level": header.get("level"),
                 "line_index": line_index,
-                "start_global_index": line["global_idx"],
-                "start_page": line["page"],
+                "start_global_index": global_idx,
+                "start_page": int(line_entry.get("page", line.get("page", 0))),
             }
         )
 

--- a/backend/tests/test_headers_llm_strict.py
+++ b/backend/tests/test_headers_llm_strict.py
@@ -88,6 +88,40 @@ def test_strict_headers_skip_toc_lines() -> None:
     assert result["sections"][1]["end_global_index"] == 5
 
 
+def test_strict_global_index_alignment() -> None:
+    lines = []
+    global_idx = 0
+    for page in range(1, 4):
+        for local_idx in range(3):
+            text = f"Header {page}-{local_idx}" if local_idx == 1 else f"Body {page}-{local_idx}"
+            lines.append(
+                {
+                    "text": text,
+                    "global_idx": global_idx,
+                    "page": page,
+                    "line_idx": local_idx,
+                    "is_toc": False,
+                    "is_index": False,
+                    "is_running": False,
+                }
+            )
+            global_idx += 1
+
+    payload = {
+        "headers": [
+            {"text": "Header 1-1", "number": "1", "level": 1},
+            {"text": "Header 2-1", "number": "2", "level": 1},
+            {"text": "Header 3-1", "number": "3", "level": 1},
+        ]
+    }
+
+    llm = DummyLLM(payload)
+    result = extract_headers_and_sections_strict(llm=llm, lines=lines)
+
+    assert [header["line_index"] for header in result["headers"]] == [1, 4, 7]
+    assert [section["end_global_index"] for section in result["sections"]] == [3, 6, 8]
+
+
 def test_strict_handles_confusable_numbers_and_spacing() -> None:
     lines = [
         {


### PR DESCRIPTION
## Summary
- ensure strict header alignment resolves line indices using document global indices
- derive section ranges from the corrected indices so strict mode returns non-empty sections
- add regression coverage that exercises cross-page global index mapping

## Testing
- pytest backend/tests/test_headers_llm_strict.py

------
https://chatgpt.com/codex/tasks/task_e_69050b2a6ee48324bc5fb02b2262c27b