### PR TITLE
Add strict header guardrails and tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ Each trace entry captures the reasoning behind the locator, including:
 Trace files are newline-delimited JSON and can be streamed into tooling such as `jq` for analysis.
 
 
+## Strict Guardrails & Trace
+
+- **Preconditions**
+  - Abort with HTTP 422 `no_lines` when extraction returns zero lines. Controlled via `HEADERS_STRICT_ABORT_ON_NO_LINES`.
+  - Size guard logs `outline_skipped: size_guard` when estimated tokens exceed `HEADERS_MAX_DOC_TOKENS`.
+- **LLM outline**
+  - Emits `outline_call_start` / `outline_call_end` events describing provider, model, bytes, and status.
+  - `_parse_outline_strict` records `outline_parse_ok` or `outline_parse_failed` (`empty_raw`, `non_list_json`, `json_items_missing_fields`, `no_json_no_bullets`, …).
+  - Empty outline parses raise HTTP 422 `empty_outline` (configurable with `HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE`).
+- **Trace events**
+  - `doc_stats`, `outline_skipped`, `abort_no_lines`, `abort_empty_outline`, `strict_align_done`, `end_run`, and more.
+  - When `?trace=1` (or `HEADERS_TRACE_EMBED_RESPONSE=1`), responses include inline trace data and the persisted trace file path.
+
+
 ## Windows single-file bundle (optional)
 A PyInstaller spec is provided for packaging the backend as a single executable on Windows.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -37,6 +37,20 @@ HEADERS_TRACE_EMBED_RESPONSE: bool = (
     in {"1", "true", "yes", "on"}
 )
 HEADERS_TRACE_DIR: str = os.getenv("HEADERS_TRACE_DIR", "backend/logs/headers")
+HEADERS_DEV_VERBOSE: bool = os.getenv("HEADERS_DEV_VERBOSE", "1") in (
+    "1",
+    "true",
+    "True",
+    "YES",
+    "yes",
+)
+HEADERS_STRICT_ABORT_ON_NO_LINES: bool = os.getenv(
+    "HEADERS_STRICT_ABORT_ON_NO_LINES", "1"
+) in ("1", "true", "True", "YES", "yes")
+HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE: bool = os.getenv(
+    "HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE", "1"
+) in ("1", "true", "True", "YES", "yes")
+HEADERS_MAX_DOC_TOKENS: int = int(os.getenv("HEADERS_MAX_DOC_TOKENS", "120000"))
 HEADERS_LOG_LEVEL: str = os.getenv("HEADERS_LOG_LEVEL", "DEBUG")
 
 HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "best")

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -29,6 +29,7 @@ from ..services.headers_orchestrator import extract_headers_and_chunks
 from ..services.llm import LLMService
 from ..services.pdf_native import collect_line_metrics, parse_pdf
 from ..services.simpleheaders_state import SimpleHeadersState
+from ..utils.errors import AlignmentPreconditionError, OutlineParseError
 from ..utils.trace import HeaderTracer
 
 router = APIRouter(prefix="/api", tags=["headers"])
@@ -115,39 +116,25 @@ class HeadersResponse(BaseModel):
         )
 
 
-@router.post("/headers/{document_id}", response_model=HeadersResponse)
-async def generate_headers(
-    document_id: int,
+async def _generate_headers_impl(
     *,
-    session: Session = Depends(get_session),
-    settings: Settings = Depends(get_settings),
-    trace: bool = Query(False),
-    align: str | None = Query(None),
+    document: Document,
+    document_bytes: bytes,
+    document_path,
+    settings: Settings,
+    trace_requested: bool,
+    align: str | None,
+    session: Session,
+    tracer_holder: dict[str, HeaderTracer | None],
 ) -> HeadersResponse:
-    """Return the hierarchical headers for a stored document."""
+    tracer_holder["tracer"] = None
 
-    document = session.get(Document, document_id)
-    if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
-        )
-
-    if document.id is None:
+    doc_id = document.id
+    if doc_id is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Document is missing a primary key",
         )
-
-    doc_id = document.id
-    document_path = settings.upload_dir / str(doc_id) / document.filename
-    if not document_path.exists():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
-        )
-
-    document_bytes = document_path.read_bytes()
-
-    trace_requested = trace or app_config.HEADERS_TRACE_EMBED_RESPONSE
 
     align_strategy = (align or "").strip().lower()
     if align_strategy in {"best", "sequential", "legacy", "strict"}:
@@ -156,21 +143,19 @@ async def generate_headers(
     if settings.headers_llm_strict:
         llm_service = LLMService(settings)
         if llm_service.is_enabled:
-            tracer: HeaderTracer | None = HeaderTracer(
-                out_dir=app_config.HEADERS_TRACE_DIR
-            )
+            tracer = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
+            tracer_holder["tracer"] = tracer
             start_time = time.perf_counter()
-            if tracer is not None:
-                tracer.ev(
-                    "start_run",
-                    mode="llm_strict",
-                    file_id=doc_id,
-                    cfg={
-                        "suppress_toc": settings.headers_suppress_toc,
-                        "suppress_running": settings.headers_suppress_running,
-                    },
-                    metadata={"filename": document.filename},
-                )
+            tracer.ev(
+                "start_run",
+                mode="llm_strict",
+                file_id=doc_id,
+                cfg={
+                    "suppress_toc": settings.headers_suppress_toc,
+                    "suppress_running": settings.headers_suppress_running,
+                },
+                metadata={"filename": document.filename},
+            )
 
             lines, _, doc_hash = collect_line_metrics(
                 document_bytes,
@@ -211,9 +196,7 @@ async def generate_headers(
                         )
                     ),
                     start_page=int(section.get("start_page", 0)),
-                    end_page=int(
-                        section.get("end_page", section.get("start_page", 0))
-                    ),
+                    end_page=int(section.get("end_page", section.get("start_page", 0))),
                 )
                 for section in strict_output.get("sections", [])
             ]
@@ -230,28 +213,24 @@ async def generate_headers(
                 trace_file=None,
             )
 
-            if tracer is not None:
-                elapsed = time.perf_counter() - start_time
-                tracer.ev(
-                    "final_outline",
-                    headers=[payload.model_dump() for payload in simpleheaders_payload],
-                    sections=[section.model_dump() for section in sections_payload],
-                    mode="llm_strict",
-                    messages=[],
-                    elapsed_s=elapsed,
-                )
-                tracer.ev(
-                    "end_run",
-                    elapsed_s=elapsed,
-                    total_headers=len(simpleheaders_payload),
-                    unresolved=[],
-                    mode="llm_strict",
-                    doc_hash=doc_hash,
-                )
-                tracer.flush_jsonl()
-                if trace_requested:
-                    response.trace = tracer.as_list()
-                    response.trace_file = tracer.path
+            elapsed = time.perf_counter() - start_time
+            tracer.ev(
+                "final_outline",
+                headers=[payload.model_dump() for payload in simpleheaders_payload],
+                sections=[section.model_dump() for section in sections_payload],
+                mode="llm_strict",
+                messages=[],
+                elapsed_s=elapsed,
+            )
+            tracer.ev(
+                "end_run",
+                elapsed_s=elapsed,
+                total_headers=len(simpleheaders_payload),
+                unresolved=[],
+                mode="llm_strict",
+                doc_hash=doc_hash,
+            )
+            tracer.flush_jsonl()
 
             return response
 
@@ -277,6 +256,7 @@ async def generate_headers(
         **orchestrator_kwargs,
         want_trace=trace_requested,
     )
+    tracer_holder["tracer"] = tracer
 
     SimpleHeadersState.set(doc_id, orchestrated["doc_hash"], orchestrated["lines"])
 
@@ -314,6 +294,79 @@ async def generate_headers(
         messages=orchestrated.get("messages"),
     )
 
+    return response
+
+
+@router.post("/headers/{document_id}", response_model=HeadersResponse)
+async def generate_headers(
+    document_id: int,
+    *,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+    trace: bool = Query(False),
+    align: str | None = Query(None),
+) -> HeadersResponse:
+    """Return the hierarchical headers for a stored document."""
+
+    document = session.get(Document, document_id)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    if document.id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Document is missing a primary key",
+        )
+
+    doc_id = document.id
+    document_path = settings.upload_dir / str(doc_id) / document.filename
+    if not document_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
+        )
+
+    document_bytes = document_path.read_bytes()
+
+    trace_requested = trace or app_config.HEADERS_TRACE_EMBED_RESPONSE
+
+    tracer_holder: dict[str, HeaderTracer | None] = {}
+    try:
+        response = await _generate_headers_impl(
+            document=document,
+            document_bytes=document_bytes,
+            document_path=document_path,
+            settings=settings,
+            trace_requested=trace_requested,
+            align=align,
+            session=session,
+            tracer_holder=tracer_holder,
+        )
+    except AlignmentPreconditionError as exc:
+        tracer = tracer_holder.get("tracer")
+        detail = {"error": exc.code, "message": str(exc), **(exc.extra or {})}
+        if trace_requested and tracer is not None:
+            try:
+                detail["trace_file"] = tracer.path
+            except Exception:
+                pass
+        raise HTTPException(status_code=422, detail=detail) from exc
+    except OutlineParseError as exc:
+        tracer = tracer_holder.get("tracer")
+        detail = {"error": exc.code, "message": str(exc)}
+        if exc.raw:
+            detail["raw_head"] = exc.raw[:500]
+        if exc.extra:
+            detail.update(exc.extra)
+        if trace_requested and tracer is not None:
+            try:
+                detail["trace_file"] = tracer.path
+            except Exception:
+                pass
+        raise HTTPException(status_code=422, detail=detail) from exc
+
+    tracer = tracer_holder.get("tracer")
     if trace_requested and tracer is not None:
         response.trace = tracer.as_list()
         response.trace_file = tracer.path

--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import time
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 try:  # pragma: no cover - optional dependency in some environments
@@ -19,22 +21,30 @@ else:  # pragma: no cover - passthrough when rapidfuzz is available
     token_set_ratio = _rf_token_set_ratio
 
 from ..config import (
+    HEADERS_DEV_VERBOSE,
     HEADERS_FINAL_MONOTONIC_GUARD,
+    HEADERS_MAX_DOC_TOKENS,
+    HEADERS_STRICT_ABORT_ON_NO_LINES,
     HEADERS_STRICT_AFTER_ANCHOR_ONLY,
     HEADERS_STRICT_BAND_LINES,
+    HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE,
     HEADERS_STRICT_FUZZY_THRESH,
     HEADERS_STRICT_LAST_OCCURRENCE_FALLBACK,
     HEADERS_STRICT_TITLE_ONLY_THRESH,
     HEADERS_STRICT_TOC_MIN_DOT_LEADERS,
     HEADERS_STRICT_TOC_MIN_SECTION_TOKENS,
+    HEADERS_TRACE,
+    HEADERS_TRACE_DIR,
+    HEADERS_TRACE_EMBED_RESPONSE,
 )
+from ..utils.errors import AlignmentPreconditionError, OutlineParseError
 
 try:  # pragma: no cover - tracing is optional in some deployments
     from ..utils.trace import HeaderTracer
 except Exception:  # pragma: no cover - tracing disabled
     HeaderTracer = None  # type: ignore[assignment]
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("simplespecs.headers.strict")
 
 FENCE = "#headers#"
 
@@ -542,4 +552,236 @@ def extract_headers_and_sections_strict(
     }
 
 
-__all__ = ["extract_headers_and_sections_strict", "align_headers_llm_strict", "FENCE"]
+def _estimate_doc_tokens(lines: Sequence[BodyLine]) -> int:
+    """Return a coarse token estimate for the extracted body lines."""
+
+    chars = 0
+    for entry in lines:
+        text = entry.get("text", "")
+        if not isinstance(text, str):
+            text = str(text)
+        chars += len(text)
+    return max(1, chars // 4)
+
+
+def _parse_outline_strict(raw: str, tracer: HeaderTracer | None) -> List[Dict[str, Any]]:
+    """Parse an outline payload into a canonical list of header dicts."""
+
+    if not raw or not raw.strip():
+        if tracer is not None:
+            tracer.ev("outline_parse_failed", reason="empty_raw")
+        return []
+
+    import json as _json
+    import re as _re
+
+    fence_match = _re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw, flags=_re.IGNORECASE)
+    payload = fence_match.group(1) if fence_match else raw
+
+    try:
+        data = _json.loads(payload)
+    except Exception:
+        items: List[Dict[str, Any]] = []
+        lines = [line.strip("-*• \t") for line in payload.splitlines()]
+        for line in lines:
+            match = _re.match(r"^([A-Za-z0-9.\-]+)\s+(.+)$", line)
+            if not match:
+                continue
+            number = match.group(1).strip()
+            title = match.group(2).strip()
+            if not title:
+                continue
+            items.append({"number": number, "title": title, "text": title})
+        if items and tracer is not None:
+            tracer.ev(
+                "outline_parse_ok",
+                count=len(items),
+                sample=items[:3],
+                mode="bullets",
+            )
+        elif not items and tracer is not None:
+            tracer.ev("outline_parse_failed", reason="no_json_no_bullets")
+        return items
+
+    if not isinstance(data, list):
+        if tracer is not None:
+            tracer.ev("outline_parse_failed", reason="non_list_json")
+        return []
+
+    parsed: List[Dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        number = item.get("number") or item.get("num") or item.get("id")
+        if number is not None:
+            number = str(number).strip()
+        title = (
+            item.get("title")
+            or item.get("text")
+            or item.get("heading")
+            or ""
+        )
+        title = str(title).strip()
+        if not title:
+            continue
+        parsed.append({"number": number, "title": title, "text": title})
+
+    if parsed:
+        if tracer is not None:
+            tracer.ev("outline_parse_ok", count=len(parsed), sample=parsed[:3])
+    elif tracer is not None:
+        tracer.ev("outline_parse_failed", reason="json_items_missing_fields")
+
+    return parsed
+
+
+def run_strict_headers_pipeline(
+    file_id: int,
+    file_path: str,
+    *,
+    provider: str,
+    model: str,
+    trace: bool = False,
+) -> Tuple[List[Dict[str, Any]], HeaderTracer | None]:
+    """Execute the strict alignment pipeline with guardrails and tracing."""
+
+    tracer: HeaderTracer | None = None
+    if trace or HEADERS_TRACE or HEADERS_TRACE_EMBED_RESPONSE:
+        tracer = HeaderTracer(out_dir=HEADERS_TRACE_DIR)
+
+    start_time = time.perf_counter()
+
+    from .text_extraction import extract_lines
+
+    lines = extract_lines(file_path)
+
+    pages = 0
+    if lines:
+        try:
+            pages = max(
+                int(entry.get("page", 0) or 0)
+                for entry in lines
+            )
+        except Exception:
+            pages = 0
+
+    try:
+        file_bytes = os.path.getsize(file_path)
+    except Exception:
+        file_bytes = 0
+
+    if tracer is not None:
+        tracer.ev(
+            "doc_stats",
+            file_id=file_id,
+            pages=pages,
+            lines=len(lines),
+            bytes=file_bytes,
+        )
+
+    log.debug(
+        "Strict pipeline stats file_id=%s pages=%s lines=%s bytes=%s",
+        file_id,
+        pages,
+        len(lines),
+        file_bytes,
+    )
+
+    if len(lines) == 0 and HEADERS_STRICT_ABORT_ON_NO_LINES:
+        if tracer is not None:
+            tracer.ev("abort_no_lines", reason="extractor_returned_empty")
+            tracer.flush_jsonl()
+        raise AlignmentPreconditionError(
+            "no_lines",
+            "PDF contained no extractable lines",
+            {"file_id": file_id},
+        )
+
+    token_estimate = _estimate_doc_tokens(lines)
+    skip_reason: str | None = None
+
+    if token_estimate > HEADERS_MAX_DOC_TOKENS:
+        skip_reason = "size_guard"
+        if tracer is not None:
+            tracer.ev(
+                "outline_skipped",
+                reason=skip_reason,
+                est_tokens=token_estimate,
+                max=HEADERS_MAX_DOC_TOKENS,
+            )
+        llm_raw = ""
+    else:
+        if tracer is not None:
+            tracer.ev(
+                "outline_call_start",
+                provider=provider,
+                model=model,
+                est_tokens=token_estimate,
+            )
+        llm_raw = ""
+        from . import llm as llm_service
+
+        try:
+            llm_raw = llm_service.get_outline_for_headers(
+                file_id=file_id,
+                lines=lines,
+                provider=provider,
+                model=model,
+            )
+            if tracer is not None:
+                tracer.ev(
+                    "outline_call_end", status="ok", bytes=len(llm_raw)
+                )
+        except Exception as exc:
+            if tracer is not None:
+                tracer.ev(
+                    "outline_call_end",
+                    status="error",
+                    error=exc.__class__.__name__,
+                    message=str(exc),
+                )
+            log.error("Strict outline call failed for file_id=%s: %s", file_id, exc)
+            if HEADERS_DEV_VERBOSE:
+                raise
+
+    headers = _parse_outline_strict(llm_raw, tracer)
+
+    if (
+        not headers
+        and skip_reason is None
+        and HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE
+    ):
+        trace_path = None
+        if tracer is not None:
+            tracer.ev("abort_empty_outline", reason="empty_after_parse")
+            trace_path = tracer.flush_jsonl()
+        log.error(
+            "Strict outline empty after parse file_id=%s trace=%s",
+            file_id,
+            trace_path,
+        )
+        raise OutlineParseError(
+            "empty_outline",
+            "LLM outline is empty after parse",
+            raw=(llm_raw[:1000] if llm_raw else ""),
+            extra={"file_id": file_id},
+        )
+
+    resolved = align_headers_llm_strict(headers, lines, tracer=tracer)
+
+    if tracer is not None:
+        tracer.ev("strict_align_done", resolved=len(resolved))
+        tracer.ev(
+            "end_run",
+            elapsed_s=round(time.perf_counter() - start_time, 3),
+        )
+
+    return resolved, tracer
+
+
+__all__ = [
+    "extract_headers_and_sections_strict",
+    "align_headers_llm_strict",
+    "FENCE",
+    "run_strict_headers_pipeline",
+]

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -19,6 +19,31 @@ from .openrouter_client import OpenRouterError, chat as openrouter_chat
 
 LOGGER = logging.getLogger(__name__)
 
+_HEADERS_OUTLINE_FENCE = "#headers#"
+_HEADERS_OUTLINE_PROMPT = """Return ONLY the fenced JSON below.
+
+{fence}
+{{
+  "headers": [
+    {{"text":"<exact printed heading text>","number": "<printed number like 1, 1.2.3, A, A.1 or null>", "level": <positive integer>}}
+  ]
+}}
+{fence}
+
+Rules (non-negotiable):
+- Include ONLY headings/subheadings that appear in the MAIN BODY.
+- EXCLUDE anything from a Contents/Table of Contents, any Index, any Glossary, and any running headers/footers.
+- Copy numbering EXACTLY as printed when present; if none, set "number": null. Do not infer or normalize.
+- Preserve the original document order.
+- No prose outside the fenced JSON.
+- If unsure, omit the item.
+
+Document:
+<BEGIN>
+{doc_text}
+<END>
+"""
+
 
 class LLMProviderError(RuntimeError):
     """Raised when the LLM provider returns an unrecoverable error."""
@@ -389,6 +414,40 @@ class LLMService:
         )
 
 
+def get_outline_for_headers(
+    *,
+    file_id: int,
+    lines: Sequence[Mapping[str, Any]],
+    provider: str,
+    model: str,
+) -> str:
+    """Return the raw outline content for strict header alignment."""
+
+    settings = get_settings()
+    llm_service = LLMService(settings)
+
+    if provider and provider.lower() != llm_service.get_provider():
+        LOGGER.debug(
+            "Strict headers outline requested provider=%s but service configured=%s",
+            provider,
+            llm_service.get_provider(),
+        )
+
+    doc_text = "\n".join(str(entry.get("text", "")) for entry in lines)
+    prompt = _HEADERS_OUTLINE_PROMPT.format(
+        fence=_HEADERS_OUTLINE_FENCE,
+        doc_text=doc_text,
+    )
+
+    result = llm_service.generate(
+        messages=[{"role": "user", "content": prompt}],
+        model=model,
+        fence=_HEADERS_OUTLINE_FENCE,
+        metadata={"file_id": file_id, "mode": "headers_strict"},
+    )
+    return result.content
+
+
 __all__ = [
     "LLMCircuitOpenError",
     "LLMProviderError",
@@ -397,4 +456,5 @@ __all__ = [
     "LLMService",
     "LLMTransportRequest",
     "LLMTransportResponse",
+    "get_outline_for_headers",
 ]

--- a/backend/tests/test_strict_guardrails.py
+++ b/backend/tests/test_strict_guardrails.py
@@ -1,0 +1,74 @@
+import pytest
+
+from backend.utils.errors import AlignmentPreconditionError, OutlineParseError
+
+
+def test_abort_on_no_lines(monkeypatch, tmp_path):
+    monkeypatch.setenv("HEADERS_STRICT_ABORT_ON_NO_LINES", "1")
+    monkeypatch.setenv("HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE", "0")
+
+    import importlib
+
+    import backend.config as config
+    import backend.services.headers_llm_strict as strict_module
+
+    importlib.reload(config)
+    importlib.reload(strict_module)
+
+    run_strict_headers_pipeline = strict_module.run_strict_headers_pipeline
+
+    def fake_extract_lines(_):
+        return []
+
+    import backend.services.text_extraction as text_extraction
+
+    monkeypatch.setattr(text_extraction, "extract_lines", fake_extract_lines)
+
+    with pytest.raises(AlignmentPreconditionError) as exc:
+        run_strict_headers_pipeline(
+            file_id=1,
+            file_path=str(tmp_path / "file.pdf"),
+            provider="provider",
+            model="model",
+            trace=True,
+        )
+
+    assert exc.value.code == "no_lines"
+
+
+def test_abort_on_empty_outline(monkeypatch, tmp_path):
+    monkeypatch.setenv("HEADERS_STRICT_ABORT_ON_NO_LINES", "0")
+    monkeypatch.setenv("HEADERS_STRICT_FAIL_ON_EMPTY_OUTLINE", "1")
+
+    import importlib
+
+    import backend.config as config
+    import backend.services.headers_llm_strict as strict_module
+
+    importlib.reload(config)
+    importlib.reload(strict_module)
+
+    run_strict_headers_pipeline = strict_module.run_strict_headers_pipeline
+
+    def fake_extract_lines(_):
+        return [{"text": "Example", "page": 1, "global_idx": 0}]
+
+    def fake_outline(**_kwargs):
+        return ""
+
+    import backend.services.text_extraction as text_extraction
+    import backend.services.llm as llm
+
+    monkeypatch.setattr(text_extraction, "extract_lines", fake_extract_lines)
+    monkeypatch.setattr(llm, "get_outline_for_headers", fake_outline)
+
+    with pytest.raises(OutlineParseError) as exc:
+        run_strict_headers_pipeline(
+            file_id=2,
+            file_path=str(tmp_path / "file.pdf"),
+            provider="provider",
+            model="model",
+            trace=True,
+        )
+
+    assert exc.value.code == "empty_outline"

--- a/backend/utils/errors.py
+++ b/backend/utils/errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class AlignmentPreconditionError(Exception):
+    """Raised when preconditions for header alignment are not satisfied."""
+
+    def __init__(self, code: str, message: str, extra: Dict[str, Any] | None = None):
+        super().__init__(message)
+        self.code = code
+        self.extra = extra or {}
+
+
+class OutlineParseError(Exception):
+    """Raised when an outline cannot be parsed from the LLM response."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        raw: str | None = None,
+        extra: Dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.raw = raw
+        self.extra = extra or {}


### PR DESCRIPTION
## Summary
- add configuration toggles and structured error types to support strict header guardrails
- instrument the strict headers pipeline with trace events and enforce outline parsing preconditions
- capture guardrail errors in the headers route, document the behaviour, and add unit tests

## Testing
- pytest backend/tests/test_strict_guardrails.py

------
https://chatgpt.com/codex/tasks/task_e_69050fcd219c83249be62d2f14135917