### PR TITLE
Fix header alignment ordering for MFC appendix outline

### DIFF
--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -15,11 +15,15 @@ from backend.config import (
 )
 
 from ..utils.trace import HeaderTracer
-from .headers_sequential import align_headers_sequential
+from .headers_sequential import (
+    align_headers_sequential,
+    compile_number_regex,
+    normalize,
+)
 
 
 def _normalise(text: str) -> str:
-    return re.sub(r"\s+", " ", text.strip()).lower()
+    return normalize(text, confusables=True)
 
 
 def _locate_headers_legacy(
@@ -50,6 +54,7 @@ def _locate_headers_legacy(
             continue
         number = (header.get("number") or "").strip()
         candidates: list[dict] = []
+        number_pattern = compile_number_regex(number) if number else None
         if tracer:
             pattern = rf"^\s*{re.escape(number)}" if number else None
             tracer.ev(
@@ -59,25 +64,44 @@ def _locate_headers_legacy(
                 pattern=pattern,
             )
 
+        target_tokens = [token for token in target.split() if token]
+
         for line in usable:
             text = str(line.get("text", ""))
-            if number:
-                if re.match(rf"^\s*{re.escape(number)}(?:\b|[.)\-\s])", text):
-                    candidates.append(line)
-                    if tracer:
-                        tracer.ev(
-                            "candidate_found",
-                            target=str(header.get("text", "")),
-                            page=int(line.get("page", 0)),
-                            line_idx=int(line.get("line_idx", 0)),
-                            snippet=text.strip(),
-                            score=1.0,
-                            before_prev_anchor=int(line.get("global_idx", -1))
-                            <= previous_anchor,
-                        )
-                    continue
+            norm_text = line.get("_norm", "")
+            if number_pattern and (
+                number_pattern.search(text) or number_pattern.search(norm_text)
+            ):
+                candidates.append(line)
+                if tracer:
+                    tracer.ev(
+                        "candidate_found",
+                        target=str(header.get("text", "")),
+                        page=int(line.get("page", 0)),
+                        line_idx=int(line.get("line_idx", 0)),
+                        snippet=text.strip(),
+                        score=1.0,
+                        before_prev_anchor=int(line.get("global_idx", -1))
+                        <= previous_anchor,
+                    )
+                continue
             norm = line.get("_norm", "")
             if norm == target or target in norm:
+                candidates.append(line)
+                if tracer:
+                    tracer.ev(
+                        "candidate_found",
+                        target=str(header.get("text", "")),
+                        page=int(line.get("page", 0)),
+                        line_idx=int(line.get("line_idx", 0)),
+                        snippet=text.strip(),
+                        score=1.0,
+                        before_prev_anchor=int(line.get("global_idx", -1))
+                        <= previous_anchor,
+                    )
+                continue
+
+            if target_tokens and all(token in norm for token in target_tokens):
                 candidates.append(line)
                 if tracer:
                     tracer.ev(
@@ -120,7 +144,15 @@ def _locate_headers_legacy(
                 )
             continue
 
-        best = max(candidates, key=lambda item: item.get("global_idx", -1))
+        candidates.sort(key=lambda item: item.get("global_idx", -1))
+        best = None
+        for candidate in candidates:
+            gid = int(candidate.get("global_idx", -1))
+            if gid >= previous_anchor:
+                best = candidate
+                break
+        if best is None:
+            best = candidates[-1]
         monotonic_ok = int(best.get("global_idx", -1)) >= previous_anchor
         if tracer and not monotonic_ok:
             tracer.ev(
@@ -164,15 +196,56 @@ def locate_headers_in_lines(
 ) -> List[Dict]:
     strategy = os.getenv("HEADERS_ALIGN_STRATEGY", HEADERS_ALIGN_STRATEGY).strip().lower()
 
+    index_buckets: dict[tuple[str, str], list[int]] = {}
+    for idx, header in enumerate(headers):
+        number_key = (header.get("number") or "").strip()
+        text_key = _normalise(str(header.get("text", "")))
+        index_buckets.setdefault((number_key, text_key), []).append(idx)
+
+    def _take_index(number: str | None, text: str) -> int:
+        key = ((number or "").strip(), _normalise(text))
+        bucket = index_buckets.get(key)
+        if bucket:
+            return bucket.pop(0)
+        return len(headers) + 1000
+
     if strategy == "sequential":
+        excluded = {int(page) for page in excluded_pages}
+
+        def _eligible(line: Dict) -> bool:
+            page = int(line.get("page", 0) or 0)
+            if page in excluded:
+                return False
+            if line.get("is_toc") or line.get("is_index"):
+                return False
+            return True
+
+        sequential_lines = [line for line in lines if _eligible(line)]
+
         sequential_headers = align_headers_sequential(
             headers,
-            lines,
+            sequential_lines,
             confusables=HEADERS_NORMALIZE_CONFUSABLES,
             threshold=HEADERS_FUZZY_THRESHOLD,
             window_pad=HEADERS_WINDOW_PAD_LINES,
             tracer=tracer,
         )
+
+        total_numbered = sum(1 for header in headers if (header.get("number") or "").strip())
+        coverage = (
+            len(sequential_headers) / total_numbered
+            if total_numbered
+            else 1.0
+        )
+        if coverage < 0.6:
+            if tracer:
+                tracer.ev(
+                    "fallback_triggered",
+                    method="sequential",
+                    reason="low_coverage",
+                    coverage=coverage,
+                )
+            sequential_headers = []
 
         located: List[Dict] = [
             {
@@ -185,6 +258,9 @@ def locate_headers_in_lines(
             }
             for entry in sequential_headers
         ]
+
+        for entry in located:
+            entry["source_idx"] = _take_index(entry.get("number"), entry.get("text", ""))
 
         matched_numbers = {str(entry.get("number")) for entry in sequential_headers if entry.get("number")}
         used_indices = {int(entry.get("global_idx", 0) or 0) for entry in sequential_headers}
@@ -199,7 +275,7 @@ def locate_headers_in_lines(
         if remaining_headers:
             filtered_lines = [
                 line
-                for line in lines
+                for line in sequential_lines
                 if int(line.get("global_idx", 0) or 0) not in used_indices
             ]
             legacy = _locate_headers_legacy(
@@ -209,18 +285,32 @@ def locate_headers_in_lines(
                 similarity_threshold=similarity_threshold,
                 tracer=tracer,
             )
+            for entry in legacy:
+                entry["source_idx"] = _take_index(
+                    entry.get("number"), entry.get("text", "")
+                )
             located.extend(legacy)
 
-        located.sort(key=lambda item: item.get("global_idx", 0))
+        located.sort(
+            key=lambda item: (int(item.get("source_idx", len(headers) + 1000)), item.get("global_idx", 0))
+        )
         return located
 
-    return _locate_headers_legacy(
+    legacy_only = _locate_headers_legacy(
         headers,
         lines,
         excluded_pages=excluded_pages,
         similarity_threshold=similarity_threshold,
         tracer=tracer,
     )
+
+    for entry in legacy_only:
+        entry["source_idx"] = _take_index(entry.get("number"), entry.get("text", ""))
+
+    legacy_only.sort(
+        key=lambda item: (int(item.get("source_idx", len(headers) + 1000)), item.get("global_idx", 0))
+    )
+    return legacy_only
 
 
 __all__ = ["locate_headers_in_lines"]

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -15,6 +15,7 @@ from backend.models import Document, DocumentArtifactType
 
 from .artifact_store import PARSER_VERSION, get_cached_artifact, store_artifact
 from .header_locator import locate_headers_in_lines
+from .headers_sequential import number_key
 from .pdf_headers_llm_full import get_headers_llm_full
 from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
@@ -109,6 +110,7 @@ async def extract_headers_and_chunks(
         "suppress_toc": settings.headers_suppress_toc,
         "suppress_running": settings.headers_suppress_running,
         "metadata": dict(metadata or {}),
+        "header_locator_rev": "2025-10-31-seq-source-order",
     }
 
     if session is not None and doc_id is not None:
@@ -279,6 +281,19 @@ def _enforce_header_sequence(
     if not headers:
         return [], []
 
+    def _order_key(header: Mapping[str, object]) -> tuple:
+        number = header.get("number")
+        order = number_key(str(number)) if number else [-1]
+        source_idx = int(header.get("source_idx", -1))
+        if source_idx >= 0:
+            return (
+                source_idx,
+                *order,
+                int(header.get("level", 0)),
+                int(header.get("global_idx", 0)),
+            )
+        return (*order, int(header.get("level", 0)), int(header.get("global_idx", 0)))
+
     working_headers = [
         {
             "text": str(header.get("text", "")).strip(),
@@ -287,10 +302,12 @@ def _enforce_header_sequence(
             "page": int(header.get("page") or 0),
             "line_idx": int(header.get("line_idx") or 0),
             "global_idx": int(header.get("global_idx") or 0),
+            "source_idx": int(header.get("source_idx", -1)),
         }
         for header in headers
     ]
     working_headers.sort(key=lambda item: item.get("global_idx", 0))
+    working_headers.sort(key=_order_key)
 
     sections = single_chunks_from_headers(working_headers, lines)
 
@@ -371,6 +388,12 @@ def _enforce_header_sequence(
                     reason="unresolved",
                 )
             break
+
+    working_headers.sort(key=lambda item: item.get("global_idx", 0))
+    working_headers.sort(key=_order_key)
+
+    for entry in working_headers:
+        entry.pop("source_idx", None)
 
     return working_headers, sections
 

--- a/backend/services/headers_sequential.py
+++ b/backend/services/headers_sequential.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from rapidfuzz.fuzz import token_set_ratio
@@ -36,6 +36,8 @@ DOT_SPACE_RE = re.compile(r"(\d)\s*\.\s*(\d)")
 MULTISPACE_RE = re.compile(r"\s+")
 TOC_LEADER_RE = re.compile(r"\.{3,}\s*\d+\s*$")
 CONFUSABLE_NUM_RE = re.compile(r"(?<=\d)\s*[Il]\s*(?=[\.\s])")
+ALPHA_ONE_RE = re.compile(r"(?<=\b[A-Za-z])\s*[Il](?=\b)")
+NUMBER_COMPONENT_RE = re.compile(r"[A-Za-z]+|\d+")
 
 
 @dataclass(slots=True)
@@ -56,6 +58,7 @@ class HeaderItem:
     num: str
     title: str
     level: int
+    tokens: tuple[str, ...] = field(default_factory=tuple)
 
 
 def normalize(value: str, confusables: bool = True) -> str:
@@ -66,7 +69,76 @@ def normalize(value: str, confusables: bool = True) -> str:
     cleaned = MULTISPACE_RE.sub(" ", cleaned)
     if confusables:
         cleaned = CONFUSABLE_NUM_RE.sub("1", cleaned)
+        cleaned = ALPHA_ONE_RE.sub("1", cleaned)
     return cleaned.strip().casefold()
+
+
+def number_tokens(num: str | None) -> tuple[str, ...]:
+    """Return alphanumeric components that form *num* in document order."""
+
+    if not num:
+        return tuple()
+    return tuple(NUMBER_COMPONENT_RE.findall(str(num)))
+
+
+def _alpha_component_value(token: str) -> int:
+    total = 0
+    for char in token.upper():
+        if "A" <= char <= "Z":
+            total = total * 26 + (ord(char) - ord("A") + 1)
+    return total
+
+
+def _component_value(token: str) -> int:
+    if token.isdigit():
+        return int(token)
+    if token.isalpha():
+        return _alpha_component_value(token)
+    digits = re.findall(r"\d+", token)
+    if digits:
+        return int(digits[0])
+    return 0
+
+
+def number_key(num: str | Sequence[str]) -> List[int]:
+    """Return sortable key for a numbering token or sequence of tokens."""
+
+    if isinstance(num, str):
+        tokens = number_tokens(num)
+    else:
+        tokens = tuple(num)
+    return [_component_value(token) for token in tokens]
+
+
+def number_parent(num: str | None) -> str | None:
+    """Return the immediate parent numbering token for *num* if available."""
+
+    if not num:
+        return None
+    if "." in num:
+        return num.rsplit(".", 1)[0]
+    stripped = num.strip()
+    if not stripped:
+        return None
+    idx = len(stripped)
+    while idx > 0 and stripped[idx - 1].isdigit():
+        idx -= 1
+    if idx <= 0 or idx >= len(stripped):
+        return None
+    return stripped[:idx]
+
+
+def is_number_descendant(candidate: str, parent: str | None) -> bool:
+    """Return True when *candidate* is a descendant of *parent*."""
+
+    if not parent or not candidate or candidate == parent:
+        return False
+    current = number_parent(candidate)
+    while current:
+        if current == parent:
+            return True
+        current = number_parent(current)
+    return False
 
 
 def extract_number(text: str) -> Optional[str]:
@@ -77,8 +149,26 @@ def extract_number(text: str) -> Optional[str]:
 
 
 def compile_number_regex(num: str) -> re.Pattern[str]:
-    escaped = re.escape(num)
-    return re.compile(rf"^\s*{escaped}\b(?!\.)", re.I)
+    tokens = number_tokens(num)
+    if not tokens:
+        escaped = re.escape(num)
+        return re.compile(rf"(?<!\S){escaped}(?=$|\s|[).:-])", re.I)
+
+    parts: List[str] = []
+    for idx, token in enumerate(tokens):
+        escaped = re.escape(token)
+        if idx == 0:
+            parts.append(escaped)
+            continue
+        prev = tokens[idx - 1]
+        if prev.isdigit() and token.isdigit():
+            parts.append(rf"\s*\.\s*{escaped}")
+        else:
+            parts.append(rf"[.\s]*{escaped}")
+
+    core = "".join(parts)
+    pattern = rf"(?<!\S){core}(?=$|\s|[).:-])"
+    return re.compile(pattern, re.I)
 
 
 def is_probable_toc_line(text: str) -> bool:
@@ -133,12 +223,6 @@ def cand_score(norm_line: str, want_norm: str, has_number: bool, in_band: bool) 
     if in_band:
         score -= 15
     return score
-
-
-def number_key(num: str) -> List[int]:
-    return [int(x) for x in num.split(".")]
-
-
 def is_ineligible_runner_or_toc(
     ln: Line, norm_text: str, toc_pages: Set[int], runners: Set[str]
 ) -> bool:
@@ -156,9 +240,19 @@ def make_header_items(llm_headers: Iterable[Dict]) -> List[HeaderItem]:
         title = str(header.get("title") or header.get("text") or "").strip()
         if not number:
             continue
-        level = number.count(".") + 1
-        items.append(HeaderItem(num=number, title=title, level=level))
-    items.sort(key=lambda item: ([int(part) for part in item.num.split(".")], item.level))
+        tokens = number_tokens(str(number))
+        if not tokens:
+            continue
+        level = int(header.get("level") or len(tokens) or 1)
+        items.append(
+            HeaderItem(
+                num=str(number),
+                title=title,
+                level=level,
+                tokens=tokens,
+            )
+        )
+    items.sort(key=lambda item: (number_key(item.tokens), item.level))
     return items
 
 
@@ -203,7 +297,22 @@ def has_child_hint(
 ) -> bool:
     if lookahead <= 0:
         return False
-    hint_pattern = re.compile(rf"^\s*{re.escape(parent_num)}\.\d+", re.I)
+    tokens = number_tokens(parent_num)
+    if not tokens:
+        return False
+    pattern_parts: List[str] = []
+    for idx, token in enumerate(tokens):
+        escaped = re.escape(token)
+        if idx == 0:
+            pattern_parts.append(escaped)
+            continue
+        prev = tokens[idx - 1]
+        if prev.isdigit() and token.isdigit():
+            pattern_parts.append(rf"\.{escaped}")
+        else:
+            pattern_parts.append(rf"[.\s]*{escaped}")
+    pattern = r"^\s*" + "".join(pattern_parts) + r"[.\s]*\d+"
+    hint_pattern = re.compile(pattern, re.I)
     end = min(len(lines), idx + 1 + lookahead)
     for offset in range(idx + 1, end):
         candidate = lines[offset]
@@ -368,7 +477,7 @@ def build_top_level_windows(
             if tracer:
                 tracer.ev("anchor_unresolved_top", num=item.num)
 
-    ordered = sorted(anchors.items(), key=lambda kv: [int(part) for part in kv[0].split(".")])
+    ordered = sorted(anchors.items(), key=lambda kv: number_key(kv[0]))
     windows: Dict[str, Tuple[int, int, int]] = {}
     for pos, (num, idx) in enumerate(ordered):
         start = idx
@@ -523,11 +632,13 @@ def compute_windows_from_anchors_and_children(
     if not lines or not anchors:
         return {}
 
-    l1s = sorted([h for h in llm_items if h.level == 1], key=lambda h: number_key(h.num))
+    l1s = sorted([h for h in llm_items if h.level == 1], key=lambda h: number_key(h.tokens))
     children_by_parent: Dict[str, List[int]] = {}
     for h in llm_items:
         if h.level >= 2 and h.num in anchors:
-            parent = ".".join(h.num.split(".")[:-1])
+            parent = number_parent(h.num)
+            if not parent:
+                continue
             children_by_parent.setdefault(parent, []).append(anchors[h.num])
 
     ordered: List[Tuple[str, int]] = []
@@ -631,7 +742,9 @@ def enforce_invariants_and_autofix(
         mapping: Dict[str, List[str]] = {}
         for item in llm_items:
             if item.level >= 2:
-                parent = ".".join(item.num.split(".")[:-1])
+                parent = number_parent(item.num)
+                if not parent:
+                    continue
                 mapping.setdefault(parent, []).append(item.num)
         return mapping
 
@@ -641,7 +754,7 @@ def enforce_invariants_and_autofix(
             for num, idx in pos.items():
                 if not within(idx, window_start, window_end):
                     continue
-                if num == parent_num or num.startswith(parent_num + "."):
+                if num == parent_num or is_number_descendant(num, parent_num):
                     bucket.setdefault(num, []).append(idx)
             for num, indices in bucket.items():
                 if len(indices) <= 1:
@@ -706,7 +819,7 @@ def enforce_invariants_and_autofix(
 
         for parent_num, (_, window_start, window_end) in windows.items():
             for num, idx in list(pos.items()):
-                if num == parent_num or not num.startswith(parent_num + "."):
+                if num == parent_num or not is_number_descendant(num, parent_num):
                     continue
                 if within(idx, window_start, window_end):
                     continue
@@ -837,12 +950,14 @@ def align_headers_sequential(
         windows[num] = (anchor_idx, anchor_idx, end_idx)
 
     children = [item for item in items if item.level >= 2]
-    children.sort(key=lambda h: ([int(part) for part in h.num.split(".")], h.level))
+    children.sort(key=lambda h: (number_key(h.tokens), h.level))
 
     chain_cursor: Dict[str, int] = {num: idx for num, (idx, _, _) in windows.items()}
 
     for header in children:
-        parent_num = ".".join(header.num.split(".")[:-1])
+        parent_num = number_parent(header.num)
+        if not parent_num:
+            continue
         if parent_num not in windows:
             if tracer:
                 tracer.ev("missing_parent", child=header.num, parent=parent_num)
@@ -894,9 +1009,10 @@ def align_headers_sequential(
 
         children_by_parent: Dict[str, List[int]] = defaultdict(list)
         for num, gidx in anchors.items():
-            if "." in num:
-                parent = ".".join(num.split(".")[:-1])
-                children_by_parent[parent].append(gidx)
+            parent = number_parent(num)
+            if not parent:
+                continue
+            children_by_parent[parent].append(gidx)
         for parent, child_positions in children_by_parent.items():
             if parent not in anchors or not child_positions:
                 continue

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -369,13 +369,34 @@ _INDEX_ENTRY_RE = re.compile(
 
 
 def _is_toc_like(lines: list[str], page_number: int) -> bool:
-    if page_number > 4 or not lines:
+    if not lines:
         return False
-    blob = " ".join(line.lower() for line in lines)
-    if "table of contents" in blob or blob.strip().startswith("contents"):
+
+    cleaned = [line.strip() for line in lines if line.strip()]
+    if not cleaned:
+        return False
+
+    lowered = [line.lower() for line in cleaned]
+    if any(
+        entry.startswith("table of contents") or entry == "contents"
+        for entry in lowered
+    ):
         return True
-    dotted_entries = sum(1 for line in lines if re.search(r"\.{2,}\s*\d+$", line))
-    return dotted_entries >= max(4, len(lines) // 2)
+
+    dotted_entries = sum(
+        1 for line in cleaned if re.search(r"\.{2,}\s*\d+$", line)
+    )
+    dot_only = sum(1 for line in cleaned if re.fullmatch(r"\.{3,}", line))
+    threshold = max(4, len(cleaned) // 2)
+
+    if dotted_entries >= threshold:
+        return True
+    if dot_only >= 12:
+        return True
+    if dot_only >= 6 and dotted_entries >= 1:
+        return True
+
+    return False
 
 
 def _is_index_like(lines: list[str]) -> bool:


### PR DESCRIPTION
## Summary
- reuse the sequential normalisation helpers in `header_locator` so legacy matching respects numbering, filters TOC/index pages, and tags each located header with its outline index
- propagate the outline index through `_enforce_header_sequence`, prefer the original LLM order when sorting, and bump the cache revision to invalidate older artefacts
- extend the TOC detector so any “CONTENTS” page (or heavy dot leaders) is excluded during native parsing

## Testing
- HEADERS_LOG_LEVEL=WARNING python scripts/process_pdf.py uploads/1/MFC-9M_R2001_E1988.pdf --skip-risk

------
https://chatgpt.com/codex/tasks/task_e_69051c64c15c8324b54abb2b42c757bc