### PR TITLE
Fix section chunk boundaries

### DIFF
--- a/backend/services/section_chunking.py
+++ b/backend/services/section_chunking.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from typing import Dict, List, Sequence
 
 
+def _safe_int(value: object) -> int | None:
+    """Return ``value`` coerced to ``int`` when possible."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
 def single_chunks_from_headers(
     headers: Sequence[Dict], lines: Sequence[Dict]
 ) -> List[Dict]:
@@ -13,16 +22,29 @@ def single_chunks_from_headers(
     if not headers:
         return []
 
-    index_by_global = {int(line.get("global_idx", -1)): idx for idx, line in enumerate(lines)}
+    index_by_global: Dict[int, int] = {}
+    for idx, line in enumerate(lines):
+        global_idx = _safe_int(line.get("global_idx"))
+        if global_idx is None:
+            continue
+        index_by_global.setdefault(global_idx, idx)
     chunks: list[Dict] = []
 
     for position, header in enumerate(headers):
-        current_idx = index_by_global.get(int(header.get("global_idx", -1)))
+        current_global = _safe_int(header.get("global_idx"))
+        if current_global is None:
+            continue
+
+        current_idx = index_by_global.get(current_global)
         if current_idx is None:
             continue
         if position < len(headers) - 1:
             next_header = headers[position + 1]
-            next_idx = index_by_global.get(int(next_header.get("global_idx", -1)), len(lines))
+            next_global = _safe_int(next_header.get("global_idx"))
+            if next_global is None:
+                next_idx = len(lines)
+            else:
+                next_idx = index_by_global.get(next_global, len(lines))
             end_index = max(current_idx, next_idx - 1)
         else:
             end_index = len(lines) - 1

--- a/backend/tests/test_llm_full_headers.py
+++ b/backend/tests/test_llm_full_headers.py
@@ -64,6 +64,27 @@ def test_single_chunks_from_headers_produces_ranges() -> None:
     assert chunks[1]["end_global_idx"] == 3
 
 
+def test_single_chunks_from_headers_avoids_overlap() -> None:
+    headers = [
+        {"text": "Overview", "number": "1", "level": 1, "global_idx": 10},
+        {"text": "Scope", "number": "1.1", "level": 2, "global_idx": 20},
+    ]
+    lines = [
+        {"global_idx": 10, "page": 0, "text": "Overview"},
+        {"global_idx": 11, "page": 0, "text": "Intro text"},
+        {"global_idx": 20, "page": 1, "text": "Scope heading"},
+        {"global_idx": 21, "page": 1, "text": "Scope body"},
+        {"global_idx": 20, "page": 1, "text": "Scope heading duplicate"},
+        {"global_idx": 22, "page": 1, "text": "More scope"},
+    ]
+
+    chunks = single_chunks_from_headers(headers, lines)
+
+    assert len(chunks) == 2
+    assert chunks[0]["end_global_idx"] == 11
+    assert chunks[1]["start_global_idx"] == 20
+
+
 def test_get_headers_llm_full_uses_cache(monkeypatch, tmp_path) -> None:
     calls = 0
 


### PR DESCRIPTION
## Summary
- ensure section chunking uses the first occurrence of header lines when calculating section ranges to eliminate overlap
- add a regression test covering duplicate global index lines to guard the new behaviour

## Testing
- pytest backend/tests/test_llm_full_headers.py

------
https://chatgpt.com/codex/tasks/task_e_69055e91215c832489c261b58b081eb0