### PR TITLE
Add section-aware search and persistence

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -55,6 +55,7 @@ def init_db() -> None:
     from .models import (  # noqa: F401  Ensures models are registered with SQLModel metadata.
         artifacts,
         document,
+        section,
         spec_record,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from .routers import (
     health,
     observability,
     parse,
+    search,
     specs,
 )
 
@@ -124,6 +125,7 @@ ROUTERS: Iterable = (
     headers.router,
     health.router,
     parse.router,
+    search.router,
     specs.router,
     compare.router,
     observability.router,

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -11,6 +11,7 @@ from .artifacts import (
     PromptResponse,
 )
 from .document import Document
+from .section import DocumentSection
 from .spec_record import SpecAuditEntry, SpecRecord
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "DocumentFigure",
     "DocumentPage",
     "DocumentTable",
+    "DocumentSection",
     "PromptResponse",
     "SpecRecord",
     "SpecAuditEntry",

--- a/backend/models/artifacts.py
+++ b/backend/models/artifacts.py
@@ -162,6 +162,7 @@ class DocumentEmbedding(SQLModel, table=True):
     vector: bytes = Field(sa_column=Column(LargeBinary, nullable=False))
     norm: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
     text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    section_key: str | None = Field(default=None, index=True, nullable=True)
     header_path: str | None = Field(default=None, nullable=True)
     page_index: int | None = Field(default=None, nullable=True)
     sha_model: str = Field(nullable=False, index=True)

--- a/backend/models/section.py
+++ b/backend/models/section.py
@@ -1,0 +1,40 @@
+"""SQLModel definition for document sections."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+
+    return datetime.now(UTC)
+
+
+class DocumentSection(SQLModel, table=True):
+    """Canonical section span derived from the simple headers outline."""
+
+    __tablename__ = "document_sections"
+    __table_args__ = (
+        UniqueConstraint("document_id", "section_key", name="uq_document_section"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    section_key: str = Field(index=True, nullable=False)
+    title: str = Field(nullable=False)
+    number: str | None = Field(default=None, nullable=True)
+    level: int = Field(default=1, nullable=False)
+    start_global_idx: int = Field(nullable=False)
+    end_global_idx: int = Field(nullable=False)
+    start_page: int | None = Field(default=None, nullable=True)
+    end_page: int | None = Field(default=None, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+__all__ = ["DocumentSection"]
+

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -9,6 +9,7 @@ from .health import router as health_router
 from .headers import router as headers_router
 from .observability import router as observability_router
 from .parse import router as parse_router
+from .search import router as search_router
 from .specs import router as specs_router
 
 api_router = APIRouter()
@@ -20,5 +21,6 @@ api_router.include_router(parse_router)
 api_router.include_router(specs_router)
 api_router.include_router(compare_router)
 api_router.include_router(observability_router)
+api_router.include_router(search_router)
 
 __all__ = ["api_router"]

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -11,12 +11,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 import backend.config as app_config
 from ..config import Settings, get_settings
 from ..database import get_session
-from ..models import Document
+from ..models import Document, DocumentSection
 from ..services.headers import (
     HeaderExtractionResult,
     HeaderNode,
@@ -28,10 +28,20 @@ from ..services.headers_llm_strict import extract_headers_and_sections_strict
 from ..services.headers_orchestrator import extract_headers_and_chunks
 from ..services.llm import LLMService
 from ..services.pdf_native import collect_line_metrics, parse_pdf
+from ..services.sections import build_and_store_sections
 from ..services.simpleheaders_state import SimpleHeadersState
 from ..utils.trace import HeaderTracer
 
 router = APIRouter(prefix="/api", tags=["headers"])
+
+
+def _safe_int(value: object) -> int | None:
+    """Return ``value`` coerced to ``int`` when possible."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
 
 
 class HeaderNodePayload(BaseModel):
@@ -64,11 +74,13 @@ class SimpleHeaderPayload(BaseModel):
     page: int
     line_idx: int
     global_idx: int
+    section_key: str | None = None
 
 
 class SectionPayload(BaseModel):
     """Chunk describing the line range belonging to a header."""
 
+    section_key: str
     header_text: str
     header_number: str | None = None
     level: int
@@ -187,36 +199,52 @@ async def generate_headers(
 
             SimpleHeadersState.set(doc_id, doc_hash, lines)
 
-            simpleheaders_payload = [
-                SimpleHeaderPayload(
-                    text=item.get("text", ""),
-                    number=item.get("number"),
-                    level=int(item.get("level", 1)),
-                    page=int(item.get("start_page", 0)),
-                    line_idx=int(item.get("line_index", 0)),
-                    global_idx=int(item.get("start_global_index", 0)),
-                )
-                for item in strict_output.get("headers", [])
-            ]
+            sections_models = build_and_store_sections(
+                session=session,
+                document_id=doc_id,
+                simpleheaders=strict_output.get("headers", []),
+                lines=lines,
+            )
+            key_by_anchor = {
+                section.start_global_idx: section.section_key
+                for section in sections_models
+            }
 
-            sections_payload = [
-                SectionPayload(
-                    header_text=section.get("text", ""),
-                    header_number=section.get("number"),
-                    level=int(section.get("level", 1)),
-                    start_global_idx=int(section.get("start_global_index", 0)),
-                    end_global_idx=int(
-                        section.get(
-                            "end_global_index", section.get("start_global_index", 0)
-                        )
-                    ),
-                    start_page=int(section.get("start_page", 0)),
-                    end_page=int(
-                        section.get("end_page", section.get("start_page", 0))
-                    ),
+            simpleheaders_payload: list[SimpleHeaderPayload] = []
+            for item in strict_output.get("headers", []) or []:
+                gid = _safe_int(
+                    item.get("start_global_index") or item.get("global_idx")
                 )
-                for section in strict_output.get("sections", [])
-            ]
+                resolved_gid = gid or 0
+                simpleheaders_payload.append(
+                    SimpleHeaderPayload(
+                        text=item.get("text", ""),
+                        number=item.get("number"),
+                        level=int(item.get("level", 1)),
+                        page=int(item.get("start_page", item.get("page", 0))),
+                        line_idx=int(item.get("line_index", item.get("line_idx", 0))),
+                        global_idx=int(resolved_gid),
+                        section_key=key_by_anchor.get(resolved_gid),
+                    )
+                )
+
+            sections_payload = []
+            for section in sorted(
+                sections_models, key=lambda entry: entry.start_global_idx
+            ):
+                end_bound = max(section.start_global_idx, section.end_global_idx - 1)
+                sections_payload.append(
+                    SectionPayload(
+                        section_key=section.section_key,
+                        header_text=section.title,
+                        header_number=section.number,
+                        level=section.level,
+                        start_global_idx=section.start_global_idx,
+                        end_global_idx=end_bound,
+                        start_page=section.start_page or 0,
+                        end_page=section.end_page or section.start_page or 0,
+                    )
+                )
 
             response = HeadersResponse(
                 document_id=doc_id,
@@ -280,30 +308,47 @@ async def generate_headers(
 
     SimpleHeadersState.set(doc_id, orchestrated["doc_hash"], orchestrated["lines"])
 
-    simpleheaders_payload = [
-        SimpleHeaderPayload(
-            text=item.get("text", ""),
-            number=item.get("number"),
-            level=int(item.get("level", 1)),
-            page=int(item.get("page", 0)),
-            line_idx=int(item.get("line_idx", 0)),
-            global_idx=int(item.get("global_idx", 0)),
-        )
-        for item in orchestrated.get("headers", [])
-    ]
+    sections_models = build_and_store_sections(
+        session=session,
+        document_id=doc_id,
+        simpleheaders=orchestrated.get("headers", []),
+        lines=orchestrated.get("lines", []),
+    )
+    key_by_anchor = {
+        section.start_global_idx: section.section_key for section in sections_models
+    }
 
-    sections_payload = [
-        SectionPayload(
-            header_text=section.get("header_text", ""),
-            header_number=section.get("header_number"),
-            level=int(section.get("level", 1)),
-            start_global_idx=int(section.get("start_global_idx", 0)),
-            end_global_idx=int(section.get("end_global_idx", 0)),
-            start_page=int(section.get("start_page", 0)),
-            end_page=int(section.get("end_page", 0)),
+    simpleheaders_payload = []
+    for item in orchestrated.get("headers", []) or []:
+        gid = _safe_int(item.get("global_idx"))
+        resolved_gid = gid or 0
+        simpleheaders_payload.append(
+            SimpleHeaderPayload(
+                text=item.get("text", ""),
+                number=item.get("number"),
+                level=int(item.get("level", 1)),
+                page=int(item.get("page", 0)),
+                line_idx=int(item.get("line_idx", 0)),
+                global_idx=int(resolved_gid),
+                section_key=key_by_anchor.get(resolved_gid),
+            )
         )
-        for section in orchestrated.get("sections", [])
-    ]
+
+    sections_payload = []
+    for section in sorted(sections_models, key=lambda entry: entry.start_global_idx):
+        end_bound = max(section.start_global_idx, section.end_global_idx - 1)
+        sections_payload.append(
+            SectionPayload(
+                section_key=section.section_key,
+                header_text=section.title,
+                header_number=section.number,
+                level=section.level,
+                start_global_idx=section.start_global_idx,
+                end_global_idx=end_bound,
+                start_page=section.start_page or 0,
+                end_page=section.end_page or section.start_page or 0,
+            )
+        )
 
     response = HeadersResponse.from_result(
         doc_id,
@@ -327,6 +372,7 @@ async def section_text(
     start: int,
     end: int,
     *,
+    section_key: str | None = Query(None),
     session: Session = Depends(get_session),
 ) -> PlainTextResponse:
     """Return the plain text for a section bounded by global indices."""
@@ -346,6 +392,20 @@ async def section_text(
             status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
         )
 
+    section_record = None
+    if section_key:
+        section_record = session.exec(
+            select(DocumentSection).where(
+                DocumentSection.document_id == document_id,
+                DocumentSection.section_key == section_key,
+            )
+        ).first()
+        if section_record is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Section not found for this document",
+            )
+
     cached = SimpleHeadersState.get(document_id)
     if cached is None:
         raise HTTPException(
@@ -354,6 +414,11 @@ async def section_text(
         )
 
     _, lines = cached
+    if section_record is not None:
+        start = max(start, section_record.start_global_idx)
+        end = min(end, section_record.end_global_idx - 1)
+        if end < start:
+            end = start
     text_lines = [
         str(line.get("text", ""))
         for line in lines

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -1,0 +1,118 @@
+"""Endpoints for section-gated document search."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import Document, DocumentSection
+from ..services.sections import route_query_to_sections, search_in_sections
+from ..services.simpleheaders_state import SimpleHeadersState
+
+router = APIRouter(prefix="/api", tags=["search"])
+
+
+class SectionSearchMatch(BaseModel):
+    """Line-level match within a document section."""
+
+    section_key: str
+    section_title: str
+    section_number: str | None = None
+    score: float
+    text: str
+    line_global_idx: int
+    page: int | None = None
+    start_global_idx: int
+    end_global_idx: int
+    start_page: int | None = None
+    end_page: int | None = None
+
+
+class SectionSearchResponse(BaseModel):
+    """Response payload for section-gated search queries."""
+
+    document_id: int
+    query: str
+    section_key: str | None = None
+    routed_section_keys: list[str] = Field(default_factory=list)
+    matches: list[SectionSearchMatch] = Field(default_factory=list)
+
+
+@router.get("/search", response_model=SectionSearchResponse)
+def search_document_sections(
+    *,
+    session: Session = Depends(get_session),
+    doc: int = Query(..., alias="doc", ge=1),
+    q: str = Query(..., alias="q"),
+    section_key: str | None = Query(None),
+    limit: int = Query(10, ge=1, le=50),
+) -> SectionSearchResponse:
+    """Return ranked matches for ``q`` filtered by document sections."""
+
+    query = q.strip()
+    if not query:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Query must not be empty",
+        )
+
+    document = session.get(Document, doc)
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Document not found"
+        )
+
+    cached = SimpleHeadersState.get(doc)
+    if cached is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Header data unavailable for this document",
+        )
+
+    _, lines = cached
+
+    routed_keys: list[str] = []
+    target_keys: list[str]
+
+    if section_key:
+        exists = session.exec(
+            select(DocumentSection.section_key).where(
+                DocumentSection.document_id == doc,
+                DocumentSection.section_key == section_key,
+            )
+        ).first()
+        if exists is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Section not found for this document",
+            )
+        target_keys = [section_key]
+    else:
+        routed_keys = route_query_to_sections(
+            session=session, document_id=doc, query=query
+        )
+        target_keys = routed_keys
+
+    matches_raw = search_in_sections(
+        session=session,
+        document_id=doc,
+        query=query,
+        section_keys=target_keys,
+        lines=lines,
+        limit=limit,
+    )
+    matches = [SectionSearchMatch(**match) for match in matches_raw]
+
+    return SectionSearchResponse(
+        document_id=doc,
+        query=query,
+        section_key=section_key,
+        routed_section_keys=routed_keys,
+        matches=matches,
+    )
+
+
+__all__ = ["router"]
+

--- a/backend/services/sections.py
+++ b/backend/services/sections.py
@@ -1,0 +1,428 @@
+"""Helpers for deriving and persisting canonical document sections."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Mapping, Sequence
+
+from sqlalchemy import delete
+from sqlmodel import Session, select
+
+from ..models import DocumentSection
+
+
+def _safe_int(value: object) -> int | None:
+    """Return ``value`` coerced to ``int`` when possible."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def _normalise_text(text: str) -> str:
+    """Return a lower-cased, whitespace-collapsed representation of ``text``."""
+
+    return re.sub(r"\s+", " ", text or "").strip().lower()
+
+
+def _score_text(query: str, candidate: str) -> float:
+    """Return a similarity score between ``query`` and ``candidate``."""
+
+    if not query or not candidate:
+        return 0.0
+
+    try:  # pragma: no cover - rapidfuzz optional dependency
+        from rapidfuzz import fuzz
+
+        return float(fuzz.partial_ratio(query, candidate))
+    except Exception:  # noqa: BLE001 - fallback when rapidfuzz unavailable
+        ratio = SequenceMatcher(None, query.lower(), candidate.lower()).ratio()
+        return float(ratio * 100)
+
+
+def make_section_key(
+    number: str | None,
+    title: str,
+    *,
+    anchor: int | None = None,
+) -> str:
+    """Return a deterministic identifier for a section."""
+
+    number_part = re.sub(r"\s+", "-", (number or "").strip())
+    title_part = re.sub(r"[^a-z0-9]+", "-", _normalise_text(title))
+    title_part = re.sub(r"-+", "-", title_part).strip("-") or "section"
+    parts: list[str] = []
+    if number_part:
+        parts.append(number_part)
+    parts.append(title_part)
+    if anchor is not None:
+        parts.append(str(anchor))
+    return "::".join(parts)
+
+
+@dataclass(slots=True)
+class _ResolvedHeader:
+    """Normalised header representation used when deriving spans."""
+
+    text: str
+    number: str | None
+    level: int
+    page: int | None
+    line_idx: int | None
+    global_idx: int
+
+
+def _resolve_headers(
+    headers: Sequence[Mapping[str, object]],
+    lines: Sequence[Mapping[str, object]],
+) -> list[_ResolvedHeader]:
+    """Return header entries with reliable ``global_idx`` values."""
+
+    if not headers:
+        return []
+
+    line_by_gid: dict[int, Mapping[str, object]] = {}
+    lookup_page_line: dict[tuple[int, int], int] = {}
+    for line in lines:
+        gid = _safe_int(line.get("global_idx"))
+        if gid is None:
+            continue
+        line_by_gid.setdefault(gid, line)
+        page = _safe_int(line.get("page"))
+        line_idx = _safe_int(line.get("line_idx"))
+        if page is not None and line_idx is not None:
+            lookup_page_line.setdefault((page, line_idx), gid)
+
+    resolved: list[_ResolvedHeader] = []
+    for entry in headers:
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        number_raw = entry.get("number")
+        number = str(number_raw).strip() if number_raw not in (None, "") else None
+        level = int(entry.get("level") or 1)
+        page = _safe_int(entry.get("page"))
+        line_idx = _safe_int(entry.get("line_idx"))
+        gid = _safe_int(entry.get("global_idx"))
+
+        if gid is None and page is not None and line_idx is not None:
+            gid = lookup_page_line.get((page, line_idx))
+
+        if gid is None:
+            continue
+
+        resolved.append(
+            _ResolvedHeader(
+                text=text,
+                number=number,
+                level=level,
+                page=page,
+                line_idx=line_idx,
+                global_idx=gid,
+            )
+        )
+
+    if not resolved:
+        return []
+
+    # Prefer the last occurrence of each header (TOC/Index exclusion guard).
+    dedup: dict[tuple[str | None, str, int], _ResolvedHeader] = {}
+    for header in resolved:
+        key = (header.number, _normalise_text(header.text), header.level)
+        existing = dedup.get(key)
+        if existing is None or existing.global_idx <= header.global_idx:
+            dedup[key] = header
+
+    resolved = list(dedup.values())
+    resolved.sort(
+        key=lambda item: (
+            item.global_idx,
+            item.page if item.page is not None else math.inf,
+            item.line_idx if item.line_idx is not None else math.inf,
+        )
+    )
+
+    # Ensure strictly increasing ``global_idx`` values.
+    used: set[int] = set()
+    line_order = sorted(line_by_gid)
+    for entry in resolved:
+        gid = entry.global_idx
+        if gid not in used:
+            used.add(gid)
+            continue
+
+        # Scan forward within a small window to locate the actual heading line.
+        start_idx = 0
+        if gid in line_by_gid:
+            start_idx = line_order.index(gid) + 1
+        for candidate_gid in line_order[start_idx:start_idx + 6]:
+            line = line_by_gid.get(candidate_gid)
+            if line is None:
+                continue
+            text = _normalise_text(str(line.get("text", "")))
+            if text and text == _normalise_text(entry.text):
+                gid = candidate_gid
+                break
+        while gid in used:
+            gid += 1
+        entry.global_idx = gid
+        used.add(gid)
+
+    return resolved
+
+
+def build_section_spans(
+    simpleheaders: Sequence[Mapping[str, object]],
+    lines: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Return half-open ranges describing each section span."""
+
+    resolved = _resolve_headers(simpleheaders, lines)
+    if not resolved:
+        return []
+
+    ordered_lines = sorted(
+        (
+            line
+            for line in lines
+            if _safe_int(line.get("global_idx")) is not None
+        ),
+        key=lambda line: _safe_int(line.get("global_idx")),
+    )
+    line_index_by_gid = {
+        int(line["global_idx"]): index for index, line in enumerate(ordered_lines)
+    }
+
+    if ordered_lines:
+        last_gid = int(ordered_lines[-1]["global_idx"])
+        document_end = last_gid + 1
+    else:
+        document_end = 0
+
+    spans: list[dict[str, object]] = []
+    for position, header in enumerate(resolved):
+        start_gid = header.global_idx
+        if position + 1 < len(resolved):
+            end_gid = resolved[position + 1].global_idx
+        else:
+            end_gid = document_end
+        if end_gid < start_gid:
+            end_gid = start_gid
+
+        start_line = ordered_lines[line_index_by_gid.get(start_gid, 0)] if ordered_lines else None
+        end_lookup = line_index_by_gid.get(end_gid - 1)
+        end_line = ordered_lines[end_lookup] if end_lookup is not None else start_line
+
+        spans.append(
+            {
+                "section_key": make_section_key(
+                    header.number,
+                    header.text,
+                    anchor=start_gid,
+                ),
+                "title": header.text,
+                "number": header.number,
+                "level": header.level,
+                "start_global_idx": start_gid,
+                "end_global_idx": end_gid,
+                "start_page": _safe_int(start_line.get("page")) if start_line else header.page,
+                "end_page": _safe_int(end_line.get("page")) if end_line else header.page,
+            }
+        )
+
+    return spans
+
+
+def persist_sections(
+    *,
+    session: Session,
+    document_id: int,
+    spans: Sequence[Mapping[str, object]],
+) -> list[DocumentSection]:
+    """Persist the derived section spans for ``document_id``."""
+
+    session.exec(
+        delete(DocumentSection).where(DocumentSection.document_id == document_id)
+    )
+    created: list[DocumentSection] = []
+    for span in spans:
+        section = DocumentSection(
+            document_id=document_id,
+            section_key=str(span["section_key"]),
+            title=str(span.get("title", "")),
+            number=span.get("number"),
+            level=int(span.get("level", 1)),
+            start_global_idx=int(span.get("start_global_idx", 0)),
+            end_global_idx=int(span.get("end_global_idx", 0)),
+            start_page=_safe_int(span.get("start_page")),
+            end_page=_safe_int(span.get("end_page")),
+        )
+        session.add(section)
+        created.append(section)
+    session.commit()
+    for section in created:
+        session.refresh(section)
+    return created
+
+
+def build_and_store_sections(
+    *,
+    session: Session,
+    document_id: int,
+    simpleheaders: Sequence[Mapping[str, object]],
+    lines: Sequence[Mapping[str, object]],
+) -> list[DocumentSection]:
+    """Construct section spans from ``simpleheaders`` and persist them."""
+
+    spans = build_section_spans(simpleheaders, lines)
+    if not spans:
+        session.exec(
+            delete(DocumentSection).where(DocumentSection.document_id == document_id)
+        )
+        session.commit()
+        return []
+
+    return persist_sections(session=session, document_id=document_id, spans=spans)
+
+
+def chunk_document_by_sections(
+    lines: Sequence[Mapping[str, object]],
+    spans: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Return text chunks bounded by the supplied section spans."""
+
+    if not lines or not spans:
+        return []
+
+    by_gid = defaultdict(list)
+    for line in lines:
+        gid = _safe_int(line.get("global_idx"))
+        if gid is None:
+            continue
+        by_gid[gid].append(str(line.get("text", "")))
+
+    chunks: list[dict[str, object]] = []
+    for span in spans:
+        start = int(span.get("start_global_idx", 0))
+        end = int(span.get("end_global_idx", start))
+        collected: list[str] = []
+        for gid in range(start, end):
+            collected.extend(by_gid.get(gid, []))
+        chunks.append(
+            {
+                "section_key": span.get("section_key"),
+                "start_global_idx": start,
+                "end_global_idx": end,
+                "text": "\n".join(part for part in collected if part.strip()),
+            }
+        )
+    return chunks
+
+
+def route_query_to_sections(
+    *,
+    session: Session,
+    document_id: int,
+    query: str,
+    limit: int = 3,
+) -> list[str]:
+    """Return the top ``limit`` section keys that match ``query``."""
+
+    if not query.strip():
+        return []
+
+    statement = select(DocumentSection).where(
+        DocumentSection.document_id == document_id
+    )
+    candidates = session.exec(statement).all()
+    scored: list[tuple[float, str]] = []
+    for section in candidates:
+        label_parts = [section.number or "", section.title]
+        label = " ".join(part for part in label_parts if part).strip()
+        score = _score_text(query, label)
+        if score <= 0:
+            continue
+        scored.append((score, section.section_key))
+
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [section_key for _, section_key in scored[:limit]]
+
+
+def search_in_sections(
+    *,
+    session: Session,
+    document_id: int,
+    query: str,
+    section_keys: Sequence[str],
+    lines: Sequence[Mapping[str, object]],
+    limit: int = 10,
+) -> list[dict[str, object]]:
+    """Return the top ``limit`` line matches for ``query`` within ``section_keys``."""
+
+    if not query.strip() or not section_keys:
+        return []
+
+    statement = select(DocumentSection).where(
+        DocumentSection.document_id == document_id,
+        DocumentSection.section_key.in_(section_keys),
+    )
+    sections = {section.section_key: section for section in session.exec(statement)}
+    if not sections:
+        return []
+
+    lines_by_gid = {
+        int(line["global_idx"]): line
+        for line in lines
+        if _safe_int(line.get("global_idx")) is not None
+    }
+
+    matches: list[dict[str, object]] = []
+    for section_key in section_keys:
+        section = sections.get(section_key)
+        if section is None:
+            continue
+        for gid in range(section.start_global_idx, section.end_global_idx):
+            line = lines_by_gid.get(gid)
+            if not line:
+                continue
+            text = str(line.get("text", "")).strip()
+            if not text:
+                continue
+            score = _score_text(query, text)
+            if score <= 0:
+                continue
+            matches.append(
+                {
+                    "section_key": section.section_key,
+                    "section_title": section.title,
+                    "section_number": section.number,
+                    "score": score,
+                    "text": text,
+                    "line_global_idx": gid,
+                    "page": _safe_int(line.get("page")),
+                    "start_global_idx": section.start_global_idx,
+                    "end_global_idx": section.end_global_idx,
+                    "start_page": section.start_page,
+                    "end_page": section.end_page,
+                }
+            )
+
+    matches.sort(key=lambda item: item["score"], reverse=True)
+    return matches[:limit]
+
+
+__all__ = [
+    "build_and_store_sections",
+    "build_section_spans",
+    "chunk_document_by_sections",
+    "make_section_key",
+    "persist_sections",
+    "route_query_to_sections",
+    "search_in_sections",
+]
+

--- a/backend/tests/test_headers_section_text.py
+++ b/backend/tests/test_headers_section_text.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import delete
 from sqlmodel import Session
 
 pytest.importorskip("rapidfuzz")
 
-from backend.database import get_engine
+from backend.database import get_engine, init_db
 from backend.models.document import Document
 from backend.services.simpleheaders_state import SimpleHeadersState
 from backend.main import app
@@ -16,13 +17,17 @@ from backend.main import app
 def test_section_text_accepts_reversed_bounds() -> None:
     """The endpoint should gracefully handle ranges where start > end."""
 
+    init_db()
     engine = get_engine()
 
     with Session(engine) as session:
-        document = Document(filename="example.pdf", checksum="checksum")
+        session.exec(delete(Document).where(Document.checksum == "checksum-section"))
+        session.commit()
+        document = Document(filename="example.pdf", checksum="checksum-section")
         session.add(document)
         session.commit()
         session.refresh(document)
+        doc_id = int(document.id or 0)
 
     lines = [
         {"global_idx": 36, "text": "First"},
@@ -40,6 +45,10 @@ def test_section_text_accepts_reversed_bounds() -> None:
             )
     finally:
         SimpleHeadersState._store.pop(document.id, None)  # type: ignore[attr-defined]
+        with Session(engine) as cleanup:
+            if doc_id:
+                cleanup.exec(delete(Document).where(Document.id == doc_id))
+                cleanup.commit()
 
     assert response.status_code == 200
     assert response.text == "First\nSecond"

--- a/backend/tests/test_search_router.py
+++ b/backend/tests/test_search_router.py
@@ -1,0 +1,98 @@
+"""Tests for the section-gated search endpoint."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete
+from sqlmodel import Session
+
+from backend.database import get_engine, init_db
+from backend.main import app
+from backend.models import Document, DocumentSection
+from backend.services.simpleheaders_state import SimpleHeadersState
+
+
+def test_search_endpoint_filters_by_section() -> None:
+    """Search results should be restricted to the requested section."""
+
+    init_db()
+    engine = get_engine()
+
+    with Session(engine) as session:
+        document = Document(filename="sample.pdf", checksum="abc-search")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+        doc_id = int(document.id or 0)
+        assert doc_id
+
+        section_a = DocumentSection(
+            document_id=doc_id,
+            section_key="1-intro::10",
+            title="Introduction",
+            number="1",
+            level=1,
+            start_global_idx=10,
+            end_global_idx=20,
+            start_page=0,
+            end_page=0,
+        )
+        section_b = DocumentSection(
+            document_id=doc_id,
+            section_key="2-apparatus::30",
+            title="Apparatus",
+            number="2",
+            level=1,
+            start_global_idx=30,
+            end_global_idx=40,
+            start_page=1,
+            end_page=1,
+        )
+        session.add(section_a)
+        session.add(section_b)
+        session.commit()
+
+    lines = [
+        {"global_idx": 10, "text": "Introduction", "page": 0},
+        {"global_idx": 12, "text": "Diverter delay is calibrated", "page": 0},
+        {"global_idx": 30, "text": "Apparatus", "page": 1},
+        {"global_idx": 32, "text": "Time measuring apparatus specifications", "page": 1},
+    ]
+    SimpleHeadersState.set(doc_id, "hash", lines)
+
+    try:
+        from fastapi.testclient import TestClient
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/search",
+                params={
+                    "doc": doc_id,
+                    "q": "diverter delay",
+                    "section_key": "1-intro::10",
+                },
+            )
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload["matches"], payload
+            assert payload["matches"][0]["section_key"] == "1-intro::10"
+
+            routed = client.get(
+                "/api/search",
+                params={"doc": doc_id, "q": "apparatus"},
+            )
+            assert routed.status_code == 200
+            routed_payload = routed.json()
+            assert routed_payload["routed_section_keys"]
+            assert any(
+                match["section_key"] == "2-apparatus::30"
+                for match in routed_payload.get("matches", [])
+            )
+    finally:
+        SimpleHeadersState._store.pop(doc_id, None)  # type: ignore[attr-defined]
+        with Session(engine) as cleanup:
+            cleanup.exec(
+                delete(DocumentSection).where(DocumentSection.document_id == doc_id)
+            )
+            cleanup.exec(delete(Document).where(Document.id == doc_id))
+            cleanup.commit()
+

--- a/backend/tests/test_sections_service.py
+++ b/backend/tests/test_sections_service.py
@@ -1,0 +1,37 @@
+"""Unit tests for section span helpers."""
+
+from __future__ import annotations
+
+from backend.services.sections import build_section_spans
+
+
+def test_build_section_spans_prefers_last_occurrence() -> None:
+    """The span builder should ignore early TOC duplicates."""
+
+    lines = [
+        {"global_idx": 5, "text": "1 PRINCIPLES", "page": 0, "line_idx": 0},
+        {"global_idx": 50, "text": "1 PRINCIPLES", "page": 2, "line_idx": 1},
+        {"global_idx": 55, "text": "Body text", "page": 2, "line_idx": 2},
+        {"global_idx": 60, "text": "1.1 Diverter", "page": 2, "line_idx": 3},
+        {"global_idx": 70, "text": "Content", "page": 3, "line_idx": 4},
+    ]
+
+    simpleheaders = [
+        {"text": "PRINCIPLES", "number": "1", "level": 1, "global_idx": 5, "page": 0, "line_idx": 0},
+        {"text": "PRINCIPLES", "number": "1", "level": 1, "global_idx": 50, "page": 2, "line_idx": 1},
+        {"text": "Diverter", "number": "1.1", "level": 2, "global_idx": 60, "page": 2, "line_idx": 3},
+    ]
+
+    spans = build_section_spans(simpleheaders, lines)
+    assert len(spans) == 2
+
+    top = spans[0]
+    assert top["start_global_idx"] == 50
+    assert top["end_global_idx"] == 60
+    assert top["section_key"].endswith("::50")
+
+    child = spans[1]
+    assert child["start_global_idx"] == 60
+    assert child["end_global_idx"] == 71  # last line gid + 1
+    assert child["section_key"].endswith("::60")
+

--- a/frontend/static/js/api.js
+++ b/frontend/static/js/api.js
@@ -146,8 +146,11 @@ export async function fetchHeaders(documentId) {
   return request(`/api/headers/${documentId}`, { method: "POST" });
 }
 
-export async function fetchSectionText(documentId, start, end) {
+export async function fetchSectionText(documentId, start, end, sectionKey) {
   const params = new URLSearchParams({ start: String(start), end: String(end) });
+  if (sectionKey) {
+    params.set("section_key", String(sectionKey));
+  }
   const response = await fetch(
     buildUrl(`/api/headers/${documentId}/section-text?${params}`)
   );

--- a/frontend/static/js/ui.js
+++ b/frontend/static/js/ui.js
@@ -249,6 +249,16 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
   let activeIndex = -1;
   let requestToken = 0;
 
+  const formatPageRange = (section) => {
+    const startPage = Number(section?.start_page ?? 0) + 1;
+    const endPageRaw = section?.end_page ?? section?.start_page ?? 0;
+    const endPage = Number(endPageRaw) + 1;
+    if (!Number.isFinite(startPage) || !Number.isFinite(endPage)) {
+      return 'Pages unknown';
+    }
+    return startPage === endPage ? `Page ${startPage}` : `Pages ${startPage}–${endPage}`;
+  };
+
   const items = headers.map((header, index) => {
     const button = document.createElement('button');
     button.type = 'button';
@@ -257,7 +267,10 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
     const label = header.number ? `${header.number} ${header.text}` : header.text;
     button.textContent = label;
     button.style.paddingLeft = `${Math.max(0, Number(header.level || 1) - 1) * 12}px`;
-    button.title = `Page ${Number(header.page ?? 0) + 1}`;
+    button.title = formatPageRange(sections[index]) ?? `Page ${Number(header.page ?? 0) + 1}`;
+    if (header.section_key) {
+      button.dataset.sectionKey = String(header.section_key);
+    }
     button.addEventListener('click', () => selectIndex(index));
     list.append(button);
     return button;
@@ -267,6 +280,8 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
     if (index === activeIndex) return;
     activeIndex = index;
     const section = sections[index];
+    const sectionKey = headerKeyForIndex(index);
+    const pageLabel = formatPageRange(section);
     items.forEach((item, idx) => {
       if (idx === index) {
         item.dataset.active = 'true';
@@ -284,18 +299,20 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
 
     const token = ++requestToken;
     viewer.dataset.loading = 'true';
-    viewer.textContent = 'Loading section…';
+    viewer.textContent = `Loading section…\n${pageLabel}`;
 
     try {
       const text = await fetchSection(
         documentId,
         section.start_global_idx,
         section.end_global_idx,
+        sectionKey,
       );
       if (token !== requestToken) {
         return;
       }
-      viewer.textContent = text?.trim() ? text : '(Empty section)';
+      const finalText = text?.trim() ? text : '(Empty section)';
+      viewer.textContent = `${pageLabel}\n\n${finalText}`;
     } catch (error) {
       if (token !== requestToken) {
         return;
@@ -307,6 +324,15 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
         delete viewer.dataset.loading;
       }
     }
+  }
+
+  function headerKeyForIndex(index) {
+    const header = headers[index];
+    if (header && header.section_key) {
+      return header.section_key;
+    }
+    const section = sections[index];
+    return section?.section_key ?? null;
   }
 
   wrapper.append(list, viewer);

--- a/tests/test_headers_golden.py
+++ b/tests/test_headers_golden.py
@@ -321,4 +321,8 @@ def test_headers_endpoint_returns_outline(
     assert payload["outline"][0]["children"][0]["title"] == "Scope"
     assert payload["mode"] == "llm_full"
     assert payload["simpleheaders"][0]["text"] == "General Requirements"
-    assert payload["sections"][0]["start_global_idx"] == 0
+    assert payload["simpleheaders"][0]["section_key"]
+    section = payload["sections"][0]
+    assert section["start_global_idx"] == 0
+    assert section["end_global_idx"] == 0
+    assert section["section_key"] == payload["simpleheaders"][0]["section_key"]


### PR DESCRIPTION
## Summary
- add a dedicated `DocumentSection` model and persistence helpers that normalise simple header spans
- update header orchestration and section text retrieval to surface stable section keys and enforce bounds
- introduce section-gated `/api/search` endpoint and UI wiring so searches and previews filter by the selected section

## Testing
- `pytest backend/tests/test_sections_service.py backend/tests/test_search_router.py backend/tests/test_headers_section_text.py tests/test_headers_golden.py`


------
https://chatgpt.com/codex/tasks/task_e_690562c86f0c832497ad7e064c17c07e