### PR TITLE
feat(headers): vector locator with embeddings ensemble

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,6 +38,11 @@ HEADERS_LLM_MODEL=anthropic/claude-3.5-sonnet
 HEADERS_LLM_MAX_INPUT_TOKENS=120000
 HEADERS_LLM_TIMEOUT_S=120
 HEADERS_LLM_CACHE_DIR=./.cache/headers
+HEADER_LOCATE_USE_EMBEDDINGS=0
+HEADER_LOCATE_FUSE_WEIGHTS=0.55,0.30,0.10,0.05
+HEADER_LOCATE_MIN_LEXICAL=0.30
+HEADER_LOCATE_MIN_COSINE=0.25
+HEADER_LOCATE_PREFER_LAST_MATCH=1
 
 # Specification extraction tuning
 SPEC_TERMS_DIR=backend/resources/terms
@@ -46,3 +51,10 @@ SPEC_MULTI_LABEL_MARGIN=0.0
 
 # Risk scoring baselines
 RISK_BASELINES_PATH=backend/resources/baselines/mandatory_clauses.json
+
+# Embeddings provider configuration
+EMBEDDINGS_PROVIDER=local
+EMBEDDINGS_MODEL=sentence-transformers/all-MiniLM-L6-v2
+EMBEDDINGS_CACHE_DIR=.cache/emb
+EMBEDDINGS_OPENROUTER_MODEL=openai/text-embedding-3-small
+EMBEDDINGS_OPENROUTER_TIMEOUT_S=60

--- a/README.md
+++ b/README.md
@@ -95,6 +95,33 @@ When tracing (`?trace=1`) the sequential tracer records the corrective steps tak
 Clients can override the active strategy per request with `POST /api/headers/{document_id}?align=sequential` (or `align=legacy`). When tracing is enabled the sequential locator emits events such as `anchor_candidate_top`, `window_top`, and `anchor_resolved_child` to aid debugging.
 
 
+#### Vector-enhanced locator (opt-in)
+
+Set `HEADER_LOCATE_USE_EMBEDDINGS=1` to swap the sequential window search for a vector-guided locator. The LLM outline remains the source of truth—each header is matched against sliding line windows scored via lexical BM25/fuzzy matching, cosine similarity, font size, and page position. Candidates that resemble TOC entries (dot leaders, "contents", index terms) or running headers are discarded before selection.
+
+Key tuning knobs:
+
+```
+HEADER_LOCATE_USE_EMBEDDINGS=1           # enable vector fusion
+HEADER_LOCATE_FUSE_WEIGHTS=0.55,0.30,0.10,0.05  # lexical, cosine, font-rank, vertical bonuses
+HEADER_LOCATE_MIN_LEXICAL=0.30           # minimum lexical score to keep a candidate
+HEADER_LOCATE_MIN_COSINE=0.25            # minimum cosine similarity
+HEADER_LOCATE_PREFER_LAST_MATCH=1        # favour later matches when scores tie (avoids TOC hits)
+```
+
+Embeddings default to the local `sentence-transformers/all-MiniLM-L6-v2` model. Override the provider or remote model via:
+
+```
+EMBEDDINGS_PROVIDER=local                # or 'openrouter'
+EMBEDDINGS_MODEL=sentence-transformers/all-MiniLM-L6-v2
+EMBEDDINGS_CACHE_DIR=.cache/emb          # per-text + per-document vector cache
+EMBEDDINGS_OPENROUTER_MODEL=openai/text-embedding-3-small
+EMBEDDINGS_OPENROUTER_TIMEOUT_S=60
+```
+
+When `HEADERS_TRACE=1` (or `?trace=1`), the vector locator logs ranked candidates per header and writes `exports/{doc_id}/header_locations.json` with the top three matches and their component scores for offline analysis.
+
+
 #### Strict Lockdown mode
 
 The strict LLM-backed locator hardens matching for tricky numbering and appendix layouts:

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,6 +39,23 @@ HEADERS_TRACE_EMBED_RESPONSE: bool = (
 HEADERS_TRACE_DIR: str = os.getenv("HEADERS_TRACE_DIR", "backend/logs/headers")
 HEADERS_LOG_LEVEL: str = os.getenv("HEADERS_LOG_LEVEL", "DEBUG")
 
+
+def _parse_weights(raw: str | None) -> tuple[float, ...]:
+    """Return a tuple of floats parsed from a comma-delimited string."""
+
+    if not raw:
+        return (0.55, 0.30, 0.10, 0.05)
+    parts: list[float] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            parts.append(float(chunk))
+        except ValueError:
+            continue
+    return tuple(parts) if parts else (0.55, 0.30, 0.10, 0.05)
+
 HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
 HEADERS_SUPPRESS_TOC: bool = os.getenv("HEADERS_SUPPRESS_TOC", "1") in (
     "1",
@@ -60,6 +77,9 @@ HEADERS_NORMALIZE_CONFUSABLES: bool = os.getenv(
 HEADERS_FUZZY_THRESHOLD: int = int(os.getenv("HEADERS_FUZZY_THRESHOLD", "80"))
 HEADERS_WINDOW_PAD_LINES: int = int(os.getenv("HEADERS_WINDOW_PAD_LINES", "40"))
 HEADERS_BAND_LINES: int = int(os.getenv("HEADERS_BAND_LINES", "5"))
+HEADERS_FUZZY_TITLE: int = int(os.getenv("HEADERS_FUZZY_TITLE", "80"))
+HEADERS_FUZZY_TITLE_ONLY: int = int(os.getenv("HEADERS_FUZZY_TITLE_ONLY", "78"))
+HEADERS_FUZZY_NUMTITLE: int = int(os.getenv("HEADERS_FUZZY_NUMTITLE", "82"))
 HEADERS_L1_REQUIRE_NUMERIC: bool = os.getenv("HEADERS_L1_REQUIRE_NUMERIC", "1") in (
     "1",
     "true",
@@ -84,6 +104,11 @@ HEADERS_REANCHOR_PASS: bool = os.getenv("HEADERS_REANCHOR_PASS", "1") in (
     "YES",
     "yes",
 )
+HEADERS_AFTER_ANCHOR_ONLY: bool = _env_flag("HEADERS_AFTER_ANCHOR_ONLY", True)
+HEADERS_LAST_OCCURRENCE_FALLBACK: bool = _env_flag("HEADERS_LAST_OCCURRENCE_FALLBACK", True)
+HEADERS_PENALTY_BAND: float = float(os.getenv("HEADERS_PENALTY_BAND", "0.25"))
+HEADERS_PENALTY_TOC: float = float(os.getenv("HEADERS_PENALTY_TOC", "0.45"))
+HEADERS_RUNNER_MIN_PAGES: int = int(os.getenv("HEADERS_RUNNER_MIN_PAGES", "2"))
 HEADERS_STRICT_INVARIANTS: bool = os.getenv("HEADERS_STRICT_INVARIANTS", "1") in (
     "1",
     "true",
@@ -100,6 +125,28 @@ HEADERS_TITLE_ONLY_REANCHOR: bool = os.getenv("HEADERS_TITLE_ONLY_REANCHOR", "1"
 )
 HEADERS_RESCAN_PASSES: int = int(os.getenv("HEADERS_RESCAN_PASSES", "2"))
 HEADERS_DEDUPE_POLICY: str = os.getenv("HEADERS_DEDUPE_POLICY", "best")
+
+HEADER_LOCATE_USE_EMBEDDINGS: bool = _env_flag("HEADER_LOCATE_USE_EMBEDDINGS", False)
+HEADER_LOCATE_FUSE_WEIGHTS: tuple[float, ...] = _parse_weights(
+    os.getenv("HEADER_LOCATE_FUSE_WEIGHTS")
+)
+HEADER_LOCATE_MIN_LEXICAL: float = float(os.getenv("HEADER_LOCATE_MIN_LEXICAL", "0.3"))
+HEADER_LOCATE_MIN_COSINE: float = float(os.getenv("HEADER_LOCATE_MIN_COSINE", "0.25"))
+HEADER_LOCATE_PREFER_LAST_MATCH: bool = _env_flag(
+    "HEADER_LOCATE_PREFER_LAST_MATCH", True
+)
+
+EMBEDDINGS_PROVIDER: str = os.getenv("EMBEDDINGS_PROVIDER", "local")
+EMBEDDINGS_MODEL: str = os.getenv(
+    "EMBEDDINGS_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+)
+EMBEDDINGS_CACHE_DIR: Path = Path(os.getenv("EMBEDDINGS_CACHE_DIR", ".cache/emb"))
+EMBEDDINGS_OPENROUTER_MODEL: str = os.getenv(
+    "EMBEDDINGS_OPENROUTER_MODEL", "openai/text-embedding-3-small"
+)
+EMBEDDINGS_OPENROUTER_TIMEOUT_S: int = int(
+    os.getenv("EMBEDDINGS_OPENROUTER_TIMEOUT_S", "60")
+)
 
 # Strict/LLM matcher hardening
 HEADERS_STRICT_FUZZY_THRESH: int = int(
@@ -126,6 +173,15 @@ HEADERS_STRICT_LAST_OCCURRENCE_FALLBACK: bool = os.getenv(
 HEADERS_FINAL_MONOTONIC_GUARD: bool = os.getenv(
     "HEADERS_FINAL_MONOTONIC_GUARD", "1"
 ) in ("1", "true", "True", "YES", "yes")
+HEADERS_TOC_MIN_SECTION_TOKENS: int = int(
+    os.getenv("HEADERS_TOC_MIN_SECTION_TOKENS", "6")
+)
+HEADERS_TOC_MIN_DOT_LEADERS: int = int(
+    os.getenv("HEADERS_TOC_MIN_DOT_LEADERS", "4")
+)
+HEADERS_W_FUZZY: float = float(os.getenv("HEADERS_W_FUZZY", "0.6"))
+HEADERS_W_POS: float = float(os.getenv("HEADERS_W_POS", "0.25"))
+HEADERS_W_TYPO: float = float(os.getenv("HEADERS_W_TYPO", "0.15"))
 
 # Extractor selection
 PARSER_ENGINE: str = os.getenv("PARSER_ENGINE", "auto")
@@ -267,6 +323,25 @@ class Settings(BaseModel):
             os.getenv("HEADERS_LLM_CACHE_DIR", "./.cache/headers")
         )
     )
+    header_locate_use_embeddings: bool = Field(
+        default_factory=lambda: _env_flag("HEADER_LOCATE_USE_EMBEDDINGS", False)
+    )
+    header_locate_fuse_weights: Tuple[float, float, float, float] = Field(
+        default_factory=lambda: tuple(
+            HEADER_LOCATE_FUSE_WEIGHTS[:4]
+            if len(HEADER_LOCATE_FUSE_WEIGHTS) >= 4
+            else (0.55, 0.30, 0.10, 0.05)
+        )
+    )
+    header_locate_min_lexical: float = Field(
+        default_factory=lambda: float(os.getenv("HEADER_LOCATE_MIN_LEXICAL", "0.3"))
+    )
+    header_locate_min_cosine: float = Field(
+        default_factory=lambda: float(os.getenv("HEADER_LOCATE_MIN_COSINE", "0.25"))
+    )
+    header_locate_prefer_last_match: bool = Field(
+        default_factory=lambda: _env_flag("HEADER_LOCATE_PREFER_LAST_MATCH", True)
+    )
     mineru_fallback: bool = Field(
         default_factory=lambda: _env_flag("MINERU_FALLBACK", False)
     )
@@ -311,6 +386,29 @@ class Settings(BaseModel):
     export_retention_days: int = Field(
         default_factory=lambda: int(os.getenv("EXPORT_RETENTION_DAYS", "30"))
     )
+    embeddings_provider: str = Field(
+        default_factory=lambda: os.getenv("EMBEDDINGS_PROVIDER", "local")
+    )
+    embeddings_model: str = Field(
+        default_factory=lambda: os.getenv(
+            "EMBEDDINGS_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+        )
+    )
+    embeddings_cache_dir: Path = Field(
+        default_factory=lambda: Path(
+            os.getenv("EMBEDDINGS_CACHE_DIR", ".cache/emb")
+        )
+    )
+    embeddings_openrouter_model: str = Field(
+        default_factory=lambda: os.getenv(
+            "EMBEDDINGS_OPENROUTER_MODEL", "openai/text-embedding-3-small"
+        )
+    )
+    embeddings_openrouter_timeout_s: int = Field(
+        default_factory=lambda: int(
+            os.getenv("EMBEDDINGS_OPENROUTER_TIMEOUT_S", "60")
+        )
+    )
 
     @field_validator("upload_dir", mode="after")
     @classmethod
@@ -346,6 +444,35 @@ class Settings(BaseModel):
     @field_validator("headers_llm_cache_dir", mode="after")
     @classmethod
     def _ensure_headers_cache_dir(cls, value: Path) -> Path:
+        value.mkdir(parents=True, exist_ok=True)
+        return value
+
+    @field_validator("header_locate_fuse_weights", mode="after")
+    @classmethod
+    def _normalise_fuse_weights(
+        cls, value: Tuple[float, float, float, float]
+    ) -> Tuple[float, float, float, float]:
+        weights = tuple(value)
+        if len(weights) != 4:
+            weights = (0.55, 0.30, 0.10, 0.05)
+        total = sum(weights)
+        if total <= 0:
+            return (0.55, 0.30, 0.10, 0.05)
+        return tuple(weight / total for weight in weights)
+
+    @field_validator("header_locate_min_lexical", mode="after")
+    @classmethod
+    def _clamp_lexical(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+    @field_validator("header_locate_min_cosine", mode="after")
+    @classmethod
+    def _clamp_cosine(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+    @field_validator("embeddings_cache_dir", mode="after")
+    @classmethod
+    def _ensure_embeddings_cache_dir(cls, value: Path) -> Path:
         value.mkdir(parents=True, exist_ok=True)
         return value
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -55,6 +55,7 @@ def init_db() -> None:
     from .models import (  # noqa: F401  Ensures models are registered with SQLModel metadata.
         artifacts,
         document,
+        header_anchor,
         section,
         spec_record,
     )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -11,6 +11,7 @@ from .artifacts import (
     PromptResponse,
 )
 from .document import Document
+from .header_anchor import HeaderAnchor
 from .section import DocumentSection
 from .spec_record import SpecAuditEntry, SpecRecord
 
@@ -24,6 +25,7 @@ __all__ = [
     "DocumentPage",
     "DocumentTable",
     "DocumentSection",
+    "HeaderAnchor",
     "PromptResponse",
     "SpecRecord",
     "SpecAuditEntry",

--- a/backend/models/header_anchor.py
+++ b/backend/models/header_anchor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC timestamp."""
+
+    return datetime.now(UTC)
+
+
+class HeaderAnchor(SQLModel, table=True):
+    """Resolved anchor for a header located via the vector locator."""
+
+    __tablename__ = "header_anchors"
+    __table_args__ = (
+        UniqueConstraint("document_id", "header_uid", name="uq_header_anchor_uid"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    header_uid: str = Field(index=True, nullable=False)
+    level: int = Field(default=1, nullable=False)
+    title: str = Field(nullable=False)
+    page: int | None = Field(default=None, nullable=True)
+    y_top: float | None = Field(default=None, nullable=True)
+    start_line_id: int = Field(nullable=False)
+    end_line_id: int = Field(nullable=False)
+    lexical: float = Field(default=0.0, nullable=False)
+    cosine: float = Field(default=0.0, nullable=False)
+    font_rank: float = Field(default=0.0, nullable=False)
+    y_bonus: float = Field(default=0.0, nullable=False)
+    fused: float = Field(default=0.0, nullable=False)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+
+
+__all__ = ["HeaderAnchor"]
+

--- a/backend/services/embeddings.py
+++ b/backend/services/embeddings.py
@@ -1,0 +1,181 @@
+"""Embedding utilities for the vector-based header locator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import requests
+
+from backend.config import EMBEDDINGS_CACHE_DIR, EMBEDDINGS_PROVIDER
+from backend.config import EMBEDDINGS_MODEL as DEFAULT_EMBEDDINGS_MODEL
+from backend.config import EMBEDDINGS_OPENROUTER_MODEL
+from backend.config import EMBEDDINGS_OPENROUTER_TIMEOUT_S
+from backend.config import Settings
+
+
+def _normalise_query(text: str) -> str:
+    """Return the text prepared for embedding requests."""
+
+    text = (text or "").strip()
+    if not text:
+        return "heading: (empty)"
+    if len(text.split()) < 4:
+        return f"heading: {text}"
+    return text
+
+
+class EmbeddingsClient:
+    """Lightweight embeddings helper with local and OpenRouter providers."""
+
+    _model_lock = threading.Lock()
+    _local_model = None
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.provider = (settings.embeddings_provider or EMBEDDINGS_PROVIDER).strip().lower()
+        self.model_name = settings.embeddings_model or DEFAULT_EMBEDDINGS_MODEL
+        self.remote_model = (
+            settings.embeddings_openrouter_model or EMBEDDINGS_OPENROUTER_MODEL
+        )
+        self.remote_timeout = (
+            settings.embeddings_openrouter_timeout_s or EMBEDDINGS_OPENROUTER_TIMEOUT_S
+        )
+        cache_dir = settings.embeddings_cache_dir or Path(EMBEDDINGS_CACHE_DIR)
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def embed(self, text: str) -> np.ndarray:
+        """Return the embedding for ``text``."""
+
+        vectors = self.embed_batch([text])
+        return vectors[0]
+
+    def embed_batch(self, texts: Sequence[str]) -> np.ndarray:
+        """Return embeddings for ``texts`` with caching."""
+
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+
+        prepared = [_normalise_query(text) for text in texts]
+        cached: list[np.ndarray | None] = [None] * len(prepared)
+        pending: list[str] = []
+        pending_indices: list[int] = []
+
+        for index, text in enumerate(prepared):
+            cache_path = self._cache_path(text)
+            if cache_path.exists():
+                try:
+                    cached[index] = np.load(cache_path)
+                    continue
+                except Exception:
+                    cache_path.unlink(missing_ok=True)
+            pending.append(text)
+            pending_indices.append(index)
+
+        if pending:
+            fresh = self._embed_uncached(pending)
+            if fresh.shape[0] != len(pending_indices):
+                raise RuntimeError("Embedding provider returned unexpected vector count")
+            for offset, index in enumerate(pending_indices):
+                cached[index] = fresh[offset]
+                self._store_cache(prepared[index], fresh[offset])
+
+        stacked = [vector for vector in cached if vector is not None]
+        if len(stacked) != len(prepared):
+            raise RuntimeError("Failed to resolve all embeddings from cache/provider")
+
+        return np.vstack(stacked).astype(np.float32, copy=False)
+
+    # Internal helpers -------------------------------------------------
+
+    def _cache_path(self, text: str) -> Path:
+        digest = hashlib.sha1(text.encode("utf-8")).hexdigest()
+        return self.cache_dir / f"{digest}.npy"
+
+    def _store_cache(self, text: str, vector: np.ndarray) -> None:
+        cache_path = self._cache_path(text)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        np.save(cache_path, vector.astype(np.float32, copy=False))
+
+    def _embed_uncached(self, texts: Sequence[str]) -> np.ndarray:
+        if self.provider == "openrouter":
+            return self._embed_via_openrouter(texts)
+        return self._embed_via_local(texts)
+
+    def _embed_via_local(self, texts: Sequence[str]) -> np.ndarray:
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "sentence-transformers is required for local embeddings"
+            ) from exc
+
+        with self._model_lock:
+            if self._local_model is None:
+                self._local_model = SentenceTransformer(self.model_name)
+        vectors = self._local_model.encode(  # type: ignore[operator]
+            list(texts),
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+        )
+        return np.asarray(vectors, dtype=np.float32)
+
+    def _embed_via_openrouter(self, texts: Sequence[str]) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+
+        api_key = (self.settings.openrouter_api_key or "").strip()
+        if not api_key:
+            raise RuntimeError("OPENROUTER_API_KEY is required for remote embeddings")
+
+        url = "https://openrouter.ai/api/v1/embeddings"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        if self.settings.openrouter_http_referer:
+            headers["HTTP-Referer"] = self.settings.openrouter_http_referer
+            headers["Referer"] = self.settings.openrouter_http_referer
+        if self.settings.openrouter_title:
+            headers["X-Title"] = self.settings.openrouter_title
+
+        payload = {
+            "model": self.remote_model,
+            "input": list(texts),
+        }
+
+        response = requests.post(
+            url,
+            headers=headers,
+            data=json.dumps(payload),
+            timeout=self.remote_timeout,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"OpenRouter embeddings request failed ({response.status_code})"
+            )
+
+        data = response.json()
+        vectors: list[list[float]] = []
+        for item in data.get("data", []):
+            vector = item.get("embedding")
+            if isinstance(vector, Iterable):
+                vectors.append(list(vector))
+
+        if len(vectors) != len(texts):
+            raise RuntimeError("OpenRouter embeddings response mismatch")
+
+        arr = np.asarray(vectors, dtype=np.float32)
+        norms = np.linalg.norm(arr, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return arr / norms
+
+
+__all__ = ["EmbeddingsClient"]
+

--- a/backend/services/header_locate_vector.py
+++ b/backend/services/header_locate_vector.py
@@ -1,0 +1,223 @@
+"""Vector-based header locator integrating lexical and layout cues."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+from sqlmodel import Session, delete
+
+from backend.config import (
+    HEADER_LOCATE_FUSE_WEIGHTS,
+    HEADER_LOCATE_MIN_COSINE,
+    HEADER_LOCATE_MIN_LEXICAL,
+    HEADER_LOCATE_PREFER_LAST_MATCH,
+    Settings,
+)
+from backend.models import HeaderAnchor
+
+from ..utils.trace import HeaderTracer
+from .embeddings import EmbeddingsClient
+from .vector_index import (
+    build_line_windows,
+    embed_windows,
+    export_trace,
+    score_candidates,
+)
+
+
+def _canonical_headers(headers: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    canonical: list[dict[str, object]] = []
+    for index, header in enumerate(headers):
+        title = str(header.get("text", "")).strip()
+        if not title:
+            continue
+        canonical.append(
+            {
+                "uid": str(header.get("uid") or index + 1),
+                "text": title,
+                "number": (header.get("number") or None),
+                "level": int(header.get("level") or 1),
+            }
+        )
+    return canonical
+
+
+def locate_headers_with_vectors(
+    *,
+    session: Session | None,
+    document_id: int,
+    simple_headers: Sequence[Mapping[str, object]],
+    lines: Sequence[Mapping[str, object]],
+    settings: Settings,
+    excluded_pages: Iterable[int] | None = None,
+    tracer: HeaderTracer | None = None,
+    doc_hash: str | None = None,
+    embeddings_client: EmbeddingsClient | None = None,
+    write_trace_json: bool = False,
+) -> list[dict[str, object]]:
+    """Return located headers using the vector locator."""
+
+    canonical = _canonical_headers(simple_headers)
+    if not canonical:
+        return []
+
+    windows = build_line_windows(lines, excluded_pages=excluded_pages)
+    if not windows:
+        return []
+
+    embedder = embeddings_client or EmbeddingsClient(settings)
+    cache_key = f"{doc_hash or document_id}-windows"
+    window_embeddings = embed_windows(windows, embedder, cache_key=cache_key)
+    header_texts = [entry["text"] for entry in canonical]
+    header_embeddings = (
+        embedder.embed_batch(header_texts) if header_texts else np.zeros((0, 0), dtype=np.float32)
+    )
+
+    weights = settings.header_locate_fuse_weights or HEADER_LOCATE_FUSE_WEIGHTS
+    thresholds = (
+        settings.header_locate_min_lexical or HEADER_LOCATE_MIN_LEXICAL,
+        settings.header_locate_min_cosine or HEADER_LOCATE_MIN_COSINE,
+    )
+    prefer_last = settings.header_locate_prefer_last_match or HEADER_LOCATE_PREFER_LAST_MATCH
+
+    resolved: list[dict[str, object]] = []
+    trace_payload: list[dict[str, object]] = []
+    previous_anchor = -1
+
+    if session is not None:
+        session.exec(delete(HeaderAnchor).where(HeaderAnchor.document_id == document_id))
+
+    for index, entry in enumerate(canonical):
+        header_vector = (
+            header_embeddings[index]
+            if index < header_embeddings.shape[0]
+            else np.zeros(window_embeddings.shape[1] if window_embeddings.size else 0)
+        )
+        candidates = score_candidates(
+            entry["text"],
+            entry["level"],
+            windows,
+            window_embeddings,
+            header_vector,
+            weights=weights,
+            thresholds=thresholds,
+            prefer_last=prefer_last,
+        )
+
+        diag_candidates: list[dict[str, object]] = []
+        for rank, candidate in enumerate(candidates[:3], start=1):
+            diag_candidates.append(
+                {
+                    "rank": rank,
+                    "page": candidate.window.page,
+                    "start": candidate.window.start_line_id,
+                    "end": candidate.window.end_line_id,
+                    "fused": round(candidate.fused, 3),
+                    "lex": round(candidate.lexical, 3),
+                    "cos": round(candidate.cosine, 3),
+                    "font": round(candidate.font_rank, 3),
+                    "y": round(candidate.y_bonus, 3),
+                }
+            )
+
+        if tracer is not None:
+            tracer.ev(
+                "vector_candidates",
+                header=entry["text"],
+                level=entry["level"],
+                candidates=diag_candidates,
+            )
+
+        anchor = None
+        for candidate in candidates:
+            if candidate.window.start_line_id > previous_anchor:
+                anchor = candidate
+                break
+
+        if anchor is None and candidates:
+            ascending = sorted(candidates, key=lambda item: item.window.start_line_id)
+            for candidate in ascending:
+                if candidate.window.start_line_id > previous_anchor:
+                    anchor = candidate
+                    break
+
+        if anchor is None:
+            if tracer is not None:
+                tracer.ev(
+                    "vector_missing_anchor",
+                    header=entry["text"],
+                    level=entry["level"],
+                )
+            continue
+
+        previous_anchor = max(previous_anchor, anchor.window.start_line_id)
+
+        resolved.append(
+            {
+                "text": entry["text"],
+                "number": entry.get("number"),
+                "level": entry["level"],
+                "page": anchor.window.page,
+                "line_idx": anchor.window.start_line_idx,
+                "global_idx": anchor.window.start_line_id,
+                "source_idx": index,
+            }
+        )
+
+        if tracer is not None:
+            tracer.ev(
+                "vector_anchor",
+                header=entry["text"],
+                level=entry["level"],
+                page=anchor.window.page,
+                line_idx=anchor.window.start_line_idx,
+                global_idx=anchor.window.start_line_id,
+                fused=anchor.fused,
+                lexical=anchor.lexical,
+                cosine=anchor.cosine,
+                font=anchor.font_rank,
+                y_bonus=anchor.y_bonus,
+            )
+
+        if session is not None:
+            session.add(
+                HeaderAnchor(
+                    document_id=document_id,
+                    header_uid=str(entry["uid"]),
+                    level=entry["level"],
+                    title=entry["text"],
+                    page=anchor.window.page,
+                    y_top=anchor.window.y_top,
+                    start_line_id=anchor.window.start_line_id,
+                    end_line_id=anchor.window.end_line_id,
+                    lexical=anchor.lexical,
+                    cosine=anchor.cosine,
+                    font_rank=anchor.font_rank,
+                    y_bonus=anchor.y_bonus,
+                    fused=anchor.fused,
+                )
+            )
+
+        trace_payload.append(
+            {
+                "header_uid": str(entry["uid"]),
+                "title": entry["text"],
+                "level": entry["level"],
+                "best": diag_candidates[0] if diag_candidates else None,
+                "alts": diag_candidates[1:] if len(diag_candidates) > 1 else [],
+            }
+        )
+
+    if session is not None:
+        session.commit()
+
+    if write_trace_json and trace_payload:
+        output_path = settings.export_dir / str(document_id) / "header_locations.json"
+        export_trace(output_path, anchors=trace_payload)
+
+    return resolved
+
+
+__all__ = ["locate_headers_with_vectors"]
+

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -14,6 +14,7 @@ from backend.config import Settings
 from backend.models import Document, DocumentArtifactType
 
 from .artifact_store import PARSER_VERSION, get_cached_artifact, store_artifact
+from .header_locate_vector import locate_headers_with_vectors
 from .header_locator import locate_headers_in_lines
 from .headers_sequential import number_key
 from .pdf_headers_llm_full import get_headers_llm_full
@@ -177,12 +178,48 @@ async def extract_headers_and_chunks(
                 excluded_pages=excluded_pages,
             )
             llm_headers = llm_headers or []
-            located_headers = locate_headers_in_lines(
-                llm_headers,
-                lines,
-                excluded_pages=excluded_pages,
-                tracer=tracer,
-            )
+            vector_attempted = False
+            if settings.header_locate_use_embeddings:
+                try:
+                    vector_attempted = True
+                    located_headers = locate_headers_with_vectors(
+                        session=session,
+                        document_id=doc_id or 0,
+                        simple_headers=llm_headers,
+                        lines=lines,
+                        settings=settings,
+                        excluded_pages=excluded_pages,
+                        tracer=tracer,
+                        doc_hash=doc_hash,
+                        write_trace_json=trace_requested,
+                    )
+                    if located_headers:
+                        mode_used = "llm_vector"
+                except Exception as exc:  # pragma: no cover - defensive log
+                    LOGGER.warning("Vector header locator failed: %s", exc, exc_info=True)
+                    if tracer:
+                        tracer.ev(
+                            "fallback_triggered",
+                            method="vector",
+                            reason="exception",
+                            message=str(exc),
+                        )
+                    messages.append("Vector header locator unavailable; using sequential alignment.")
+                    located_headers = []
+
+            if not located_headers:
+                located_headers = locate_headers_in_lines(
+                    llm_headers,
+                    lines,
+                    excluded_pages=excluded_pages,
+                    tracer=tracer,
+                )
+                if vector_attempted and tracer:
+                    tracer.ev(
+                        "fallback_triggered",
+                        method="vector",
+                        reason="no_candidates",
+                    )
             if tracer:
                 tracer.ev(
                     "llm_outline_received",

--- a/backend/services/vector_index.py
+++ b/backend/services/vector_index.py
@@ -1,0 +1,343 @@
+"""Scoring helpers for the vector-based header locator."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency guard
+    from rank_bm25 import BM25Okapi
+except Exception:  # pragma: no cover - fallback without BM25
+    BM25Okapi = None  # type: ignore[assignment]
+
+from backend.config import PROJECT_ROOT
+from backend.services.embeddings import EmbeddingsClient
+
+
+TOKEN_PATTERN = re.compile(r"[\w\-']+")
+TOC_PATTERN = re.compile(r"\.{2,}\s*\d{1,4}\s*$")
+
+
+def _tokenize(text: str) -> list[str]:
+    return [match.group(0).lower() for match in TOKEN_PATTERN.finditer(text or "")]
+
+
+@dataclass(slots=True)
+class LineWindow:
+    """Sliding window of document lines used for ranking."""
+
+    text: str
+    tokens: list[str]
+    page: int
+    start_line_id: int
+    end_line_id: int
+    start_line_idx: int
+    end_line_idx: int
+    y_top: float | None
+    font_max: float | None
+    is_toc: bool
+    is_index: bool
+    is_running: bool
+
+
+@dataclass(slots=True)
+class ScoredCandidate:
+    """Scored window candidate for a header."""
+
+    window: LineWindow
+    lexical: float
+    cosine: float
+    font_rank: float
+    y_bonus: float
+    fused: float
+
+
+def build_line_windows(
+    lines: Sequence[dict],
+    *,
+    excluded_pages: Iterable[int] | None = None,
+) -> list[LineWindow]:
+    """Return sliding windows (size 1 and 3) for ``lines``."""
+
+    excluded = {int(page) for page in excluded_pages or ()}
+    ordered = sorted(lines, key=lambda item: int(item.get("global_idx", 0)))
+
+    usable: list[dict] = []
+    for entry in ordered:
+        page = int(entry.get("page", 0) or 0)
+        if page in excluded:
+            continue
+        if not str(entry.get("text", "")).strip():
+            continue
+        if entry.get("is_toc") or entry.get("is_index"):
+            continue
+        usable.append(entry)
+
+    windows: list[LineWindow] = []
+
+    def _make_window(chunk: Sequence[dict]) -> LineWindow | None:
+        if not chunk:
+            return None
+        pages = {int(item.get("page", 0) or 0) for item in chunk}
+        if len(pages) != 1:
+            return None
+        text = "\n".join(str(item.get("text", "")) for item in chunk)
+        tokens = _tokenize(text)
+        if not tokens:
+            return None
+        tops = [float(item.get("top")) for item in chunk if item.get("top") is not None]
+        fonts = [float(item.get("font_size")) for item in chunk if item.get("font_size")]
+        return LineWindow(
+            text=text,
+            tokens=tokens,
+            page=pages.pop(),
+            start_line_id=int(chunk[0].get("global_idx", 0)),
+            end_line_id=int(chunk[-1].get("global_idx", 0)),
+            start_line_idx=int(chunk[0].get("line_idx", 0)),
+            end_line_idx=int(chunk[-1].get("line_idx", 0)),
+            y_top=float(sum(tops) / len(tops)) if tops else None,
+            font_max=max(fonts) if fonts else None,
+            is_toc=bool(chunk[0].get("is_toc")),
+            is_index=bool(chunk[0].get("is_index")),
+            is_running=any(bool(item.get("is_running")) for item in chunk),
+        )
+
+    for index in range(len(usable)):
+        single = _make_window([usable[index]])
+        if single is not None:
+            windows.append(single)
+        span = usable[index : index + 3]
+        if len(span) == 3:
+            multi = _make_window(span)
+            if multi is not None:
+                windows.append(multi)
+
+    return windows
+
+
+def _bm25_index(windows: Sequence[LineWindow]) -> BM25Okapi | None:
+    if BM25Okapi is None or not windows:
+        return None
+    corpus = [window.tokens for window in windows]
+    total_tokens = sum(len(tokens) for tokens in corpus)
+    if total_tokens < 5:
+        return None
+    return BM25Okapi(corpus)
+
+
+def embed_windows(
+    windows: Sequence[LineWindow],
+    emb: EmbeddingsClient,
+    *,
+    cache_key: str | None = None,
+) -> np.ndarray:
+    """Return embeddings for ``windows`` texts with optional doc-level caching."""
+
+    texts = [window.text for window in windows]
+    if not texts:
+        return np.zeros((0, 0), dtype=np.float32)
+
+    if cache_key:
+        cache_path = _window_cache_path(cache_key, emb.settings.embeddings_cache_dir)
+        if cache_path.exists():
+            try:
+                cached = np.load(cache_path)
+                if cached.shape[0] == len(texts):
+                    return cached
+            except Exception:
+                cache_path.unlink(missing_ok=True)
+
+    vectors = emb.embed_batch(texts)
+
+    if cache_key:
+        cache_path = _window_cache_path(cache_key, emb.settings.embeddings_cache_dir)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        np.save(cache_path, vectors.astype(np.float32, copy=False))
+
+    return vectors
+
+
+def _window_cache_path(cache_key: str, cache_dir: Path) -> Path:
+    safe = re.sub(r"[^a-zA-Z0-9_.-]+", "-", cache_key)
+    base = Path(cache_dir)
+    if not base.is_absolute():
+        base = PROJECT_ROOT / base
+    return base / f"{safe}.windows.npy"
+
+
+def _font_rank(window: LineWindow, page_fonts: dict[int, float]) -> float:
+    max_font = page_fonts.get(window.page)
+    if max_font is None or not window.font_max:
+        return 0.0
+    return min(1.0, float(window.font_max) / max_font)
+
+
+def _y_bonus(window: LineWindow, page_tops: dict[int, tuple[float, float]]) -> float:
+    bounds = page_tops.get(window.page)
+    if bounds is None or window.y_top is None:
+        return 0.0
+    top_min, top_max = bounds
+    if math.isclose(top_min, top_max):
+        return 0.0
+    norm = (window.y_top - top_min) / max(top_max - top_min, 1e-6)
+    return max(0.0, min(1.0, 1.0 - norm))
+
+
+def _lexical_scores(
+    header_text: str,
+    windows: Sequence[LineWindow],
+    bm25: BM25Okapi | None,
+) -> np.ndarray:
+    tokens = _tokenize(header_text)
+    if not tokens:
+        return np.zeros(len(windows), dtype=np.float32)
+    if bm25 is not None:
+        scores = bm25.get_scores(tokens)
+        if scores.size:
+            max_score = float(scores.max())
+            if max_score > 0:
+                return (scores / max_score).astype(np.float32)
+
+    try:
+        from rapidfuzz import fuzz
+    except Exception:  # pragma: no cover - rapidfuzz optional
+        return np.zeros(len(windows), dtype=np.float32)
+
+    ratios = [float(fuzz.token_set_ratio(header_text, window.text) / 100.0) for window in windows]
+    return np.asarray(ratios, dtype=np.float32)
+
+
+def score_candidates(
+    header_text: str,
+    header_level: int,
+    windows: Sequence[LineWindow],
+    window_embeddings: np.ndarray,
+    header_embedding: np.ndarray,
+    *,
+    weights: Sequence[float],
+    thresholds: tuple[float, float],
+    prefer_last: bool,
+) -> list[ScoredCandidate]:
+    """Return scored candidates for ``header_text`` over ``windows``."""
+
+    if not windows:
+        return []
+
+    lexical_weight, cosine_weight, font_weight, y_weight = (
+        (list(weights) + [0.0, 0.0, 0.0, 0.0])[:4]
+    )
+
+    bm25 = _bm25_index(windows)
+    lexical_scores = _lexical_scores(header_text, windows, bm25)
+
+    if window_embeddings.size == 0 or header_embedding.size == 0:
+        cosine_scores = np.zeros(len(windows), dtype=np.float32)
+    else:
+        dots = window_embeddings @ header_embedding
+        cosine_scores = np.clip(dots, -1.0, 1.0)
+
+    page_fonts: dict[int, float] = {}
+    page_tops: dict[int, tuple[float, float]] = {}
+    for window in windows:
+        if window.font_max:
+            page_fonts[window.page] = max(page_fonts.get(window.page, 0.0), float(window.font_max))
+        if window.y_top is not None:
+            top_min, top_max = page_tops.get(window.page, (window.y_top, window.y_top))
+            top_min = min(top_min, window.y_top)
+            top_max = max(top_max, window.y_top)
+            page_tops[window.page] = (top_min, top_max)
+
+    threshold_lexical, threshold_cosine = thresholds
+    candidates: list[ScoredCandidate] = []
+
+    for index, window in enumerate(windows):
+        lexical = float(lexical_scores[index])
+        cosine = float(cosine_scores[index]) if index < cosine_scores.size else 0.0
+        if lexical < threshold_lexical or cosine < threshold_cosine:
+            continue
+        if window.is_running:
+            continue
+        if is_probably_toc(window.text):
+            continue
+        font_rank = _font_rank(window, page_fonts)
+        y_bonus = _y_bonus(window, page_tops)
+        fused = (
+            lexical_weight * lexical
+            + cosine_weight * cosine
+            + font_weight * font_rank
+            + y_weight * y_bonus
+        )
+        candidates.append(
+            ScoredCandidate(
+                window=window,
+                lexical=lexical,
+                cosine=cosine,
+                font_rank=font_rank,
+                y_bonus=y_bonus,
+                fused=fused,
+            )
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            item.fused,
+            item.window.end_line_id if prefer_last else item.window.start_line_id,
+        ),
+        reverse=True,
+    )
+
+    return candidates
+
+
+def select_anchor(candidates: Sequence[ScoredCandidate]) -> ScoredCandidate | None:
+    """Return the highest-ranked candidate or ``None``."""
+
+    if not candidates:
+        return None
+    return candidates[0]
+
+
+def is_probably_toc(window_text: str) -> bool:
+    """Return True when ``window_text`` resembles a TOC entry."""
+
+    text = (window_text or "").strip()
+    if not text:
+        return False
+    lower = text.lower()
+    if "table of contents" in lower or lower.startswith("contents"):
+        return True
+    if lower.startswith("index ") or lower.startswith("index\n"):
+        return True
+    if TOC_PATTERN.search(text):
+        return True
+    return False
+
+
+def export_trace(
+    output_path: Path,
+    *,
+    anchors: list[dict],
+) -> None:
+    """Persist the locator diagnostics to ``output_path``."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(anchors, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+__all__ = [
+    "LineWindow",
+    "ScoredCandidate",
+    "build_line_windows",
+    "embed_windows",
+    "score_candidates",
+    "select_anchor",
+    "is_probably_toc",
+    "export_trace",
+]
+

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,3 +11,7 @@ httpx==0.27.0
 requests==2.32.3
 pytest==8.2.2
 python-docx==1.1.0
+rapidfuzz==3.9.6
+rank-bm25==0.2.2
+sentence-transformers==2.7.0
+numpy==1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ requests==2.32.3
 pytest==8.2.2
 python-docx==1.1.0
 rapidfuzz>=3.9.6
+rank-bm25>=0.2.2
+sentence-transformers>=2.7
+numpy>=1.26

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import numpy as np
+
+from backend.config import Settings
+from backend.services.header_locate_vector import locate_headers_with_vectors
+
+
+class StubEmbeddings:
+    def __init__(self, vectors: dict[str, np.ndarray], settings: Settings) -> None:
+        self._vectors = vectors
+        self.settings = settings
+
+    def embed_batch(self, texts: list[str]) -> np.ndarray:
+        return np.vstack(
+            [self._vectors.get(text, np.zeros(2, dtype=np.float32)) for text in texts]
+        ).astype(np.float32)
+
+
+def test_vector_locator_enforces_monotonicity() -> None:
+    settings = Settings()
+    settings = settings.model_copy(
+        update={
+            "header_locate_fuse_weights": (0.9, 0.1, 0.0, 0.0),
+            "header_locate_min_lexical": 0.0,
+            "header_locate_min_cosine": 0.0,
+            "header_locate_prefer_last_match": False,
+        }
+    )
+
+    lines = [
+        {"global_idx": 0, "page": 1, "line_idx": 0, "text": "Introduction", "top": 10.0},
+        {"global_idx": 1, "page": 1, "line_idx": 1, "text": "Section B", "top": 20.0},
+        {"global_idx": 2, "page": 2, "line_idx": 0, "text": "Introduction", "top": 15.0},
+    ]
+
+    headers = [
+        {"text": "Section B", "level": 1},
+        {"text": "Introduction", "level": 1},
+    ]
+
+    vectors = {
+        "Section B": np.array([0.0, 1.0], dtype=np.float32),
+        "Introduction": np.array([1.0, 0.0], dtype=np.float32),
+    }
+
+    embedder = StubEmbeddings(vectors, settings)
+
+    located = locate_headers_with_vectors(
+        session=None,
+        document_id=1,
+        simple_headers=headers,
+        lines=lines,
+        settings=settings,
+        tracer=None,
+        embeddings_client=embedder,
+    )
+
+    assert [entry["global_idx"] for entry in located] == [1, 2]

--- a/tests/test_toc_filter.py
+++ b/tests/test_toc_filter.py
@@ -1,0 +1,13 @@
+from backend.services.vector_index import is_probably_toc
+
+
+def test_detects_dot_leader_toc_entry() -> None:
+    assert is_probably_toc("1. Scope.............12")
+
+
+def test_detects_table_of_contents_phrase() -> None:
+    assert is_probably_toc("Table of Contents")
+
+
+def test_ignores_regular_heading() -> None:
+    assert not is_probably_toc("1. Scope")

--- a/tests/test_vector_ranker_fuses_scores.py
+++ b/tests/test_vector_ranker_fuses_scores.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import numpy as np
+
+from backend.services.vector_index import LineWindow, score_candidates
+
+
+def _window(global_idx: int, text: str) -> LineWindow:
+    return LineWindow(
+        text=text,
+        tokens=text.lower().split(),
+        page=1,
+        start_line_id=global_idx,
+        end_line_id=global_idx,
+        start_line_idx=global_idx,
+        end_line_idx=global_idx,
+        y_top=None,
+        font_max=None,
+        is_toc=False,
+        is_index=False,
+        is_running=False,
+    )
+
+
+def test_vector_ranker_prefers_high_fused_score() -> None:
+    windows = [_window(5, "Safety Requirements"), _window(10, "Safety Overview")]
+    window_embeddings = np.array(
+        [
+            [0.8, 0.2],
+            [0.1, 0.9],
+        ],
+        dtype=np.float32,
+    )
+    header_embedding = np.array([0.85, 0.15], dtype=np.float32)
+
+    candidates = score_candidates(
+        "Safety Requirements",
+        1,
+        windows,
+        window_embeddings,
+        header_embedding,
+        weights=(0.5, 0.5, 0.0, 0.0),
+        thresholds=(0.0, 0.0),
+        prefer_last=False,
+    )
+
+    assert candidates, "expected scored candidates"
+    chosen = candidates[0]
+    assert chosen.window.start_line_id == 5
+    assert chosen.fused > candidates[1].fused


### PR DESCRIPTION
## Summary
- add an embeddings client with local/openrouter providers and caching
- introduce a vector-based header locator that fuses lexical, cosine, and layout signals and persists header anchors
- document the new configuration toggles and add unit tests covering fusion, TOC filtering, and monotonic placement

## Testing
- pytest -q *(fails: legacy normalization thresholds and sqlite schema expectations need follow-up)*

------
https://chatgpt.com/codex/tasks/task_e_6905ebc285d08324a0931d7719ee153b