### PR TITLE
Fix headers endpoint fallback to page layouts

### DIFF
--- a/backend/services/lines.py
+++ b/backend/services/lines.py
@@ -87,12 +87,69 @@ def _iter_db_lines(session, document_id: int) -> Iterator[Line]:
     return _generator()
 
 
+def _iter_page_layout_lines(session, document_id: int) -> Iterator[Line]:
+    """Yield lines reconstructed from persisted page layouts."""
+
+    document_page_model = getattr(models_pkg, "DocumentPage", None)
+    if document_page_model is None or session is None:
+        return iter(())
+
+    try:
+        statement = (
+            select(document_page_model)
+            .where(document_page_model.document_id == document_id)
+            .order_by(getattr(document_page_model, "page_index", 0))
+        )
+        rows = session.exec(statement).all()
+    except Exception:  # pragma: no cover - optional table might be unavailable
+        return iter(())
+
+    if not rows:
+        return iter(())
+
+    def _generator() -> Iterator[Line]:
+        for row in rows:
+            page_index = int(getattr(row, "page_index", 0))
+            layout = list(getattr(row, "layout", []) or [])
+            line_counter = 1
+
+            def _emit_from_strings(chunks: Iterable[str]) -> Iterator[Line]:
+                nonlocal line_counter
+                for chunk in chunks:
+                    cleaned = str(chunk).strip()
+                    if not cleaned:
+                        continue
+                    yield Line(
+                        page=page_index, line_in_page=line_counter, text=cleaned
+                    )
+                    line_counter += 1
+
+            if layout:
+                for block in layout:
+                    text_value = block.get("text") if isinstance(block, dict) else None
+                    if not isinstance(text_value, str):
+                        continue
+                    pieces = text_value.splitlines() or [text_value]
+                    yield from _emit_from_strings(pieces)
+                continue
+
+            text_raw = getattr(row, "text_raw", "")
+            if isinstance(text_raw, str):
+                yield from _emit_from_strings(text_raw.splitlines())
+
+    return _generator()
+
+
 def iter_lines(session, document_id: int) -> Iterable[Line]:
     """Return the parsed lines for ``document_id``."""
 
     db_lines = list(_iter_db_lines(session, document_id))
     if db_lines:
         return db_lines
+
+    page_layout_lines = list(_iter_page_layout_lines(session, document_id))
+    if page_layout_lines:
+        return page_layout_lines
 
     settings = get_settings()
     export_path = settings.export_dir / str(document_id) / "lines.jsonl"

--- a/tests/test_headers_llm_simple.py
+++ b/tests/test_headers_llm_simple.py
@@ -13,6 +13,8 @@ from backend.config import get_settings, reset_settings_cache
 from backend.database import get_engine, init_db
 from backend.models import Document
 from backend.services import openrouter_client
+from backend.services.artifact_store import persist_parse_result
+from backend.services.pdf_native import ParsedBlock, ParsedPage, ParseResult
 from backend.main import app
 
 
@@ -119,3 +121,91 @@ def test_headers_endpoint_strict_invalid_json(monkeypatch: pytest.MonkeyPatch, t
     raw_log = log_dir / f"headers_{document_id}_llm.json"
     assert raw_log.exists()
     assert raw_log.read_text(encoding="utf-8") == "not-json"
+
+
+def test_headers_endpoint_uses_document_pages_when_lines_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HEADERS_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("HEADERS_MODE", "llm_simple")
+    monkeypatch.setenv("HEADERS_LLM_STRICT", "0")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    reset_settings_cache()
+
+    init_db()
+    engine = get_engine()
+
+    with Session(engine) as session:
+        document = Document(filename="sample.pdf", checksum="checksum-pages")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+        parse_result = ParseResult(
+            pages=[
+                ParsedPage(
+                    page_number=1,
+                    width=612.0,
+                    height=792.0,
+                    blocks=[
+                        ParsedBlock(
+                            text="Introduction",
+                            bbox=(0.0, 0.0, 100.0, 24.0),
+                        ),
+                        ParsedBlock(
+                            text="Overview of the system",
+                            bbox=(0.0, 24.0, 100.0, 48.0),
+                        ),
+                    ],
+                ),
+                ParsedPage(
+                    page_number=2,
+                    width=612.0,
+                    height=792.0,
+                    blocks=[
+                        ParsedBlock(
+                            text="Scope",
+                            bbox=(0.0, 0.0, 100.0, 24.0),
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        persist_parse_result(
+            session=session, document=document, parse_result=parse_result
+        )
+        document_id = int(document.id or 0)
+
+    settings = get_settings()
+    export_lines = settings.export_dir / str(document_id) / "lines.jsonl"
+    if export_lines.exists():
+        export_lines.unlink()
+
+    response_payload = {
+        "headers": [
+            {"title": "Introduction", "level": 1, "page": 1},
+            {"title": "Scope", "level": 2, "page": 2},
+        ]
+    }
+
+    monkeypatch.setattr(
+        openrouter_client,
+        "chat",
+        lambda *_, **__: json.dumps(response_payload),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(f"/api/headers/{document_id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["llm_headers"] == response_payload["headers"]
+    assert any(match["found"] for match in data["matches"])
+
+    log_dir = tmp_path / "logs"
+    raw_log = log_dir / f"headers_{document_id}_llm.json"
+    match_log = log_dir / f"header_matches_{document_id}.jsonl"
+    assert raw_log.exists()
+    assert match_log.exists()
+    assert not export_lines.exists()


### PR DESCRIPTION
## Summary
- fall back to document page layouts when iterating lines so the headers API works without exported line files
- add coverage ensuring the headers endpoint succeeds when only page layouts are available

## Testing
- pytest tests/test_headers_llm_simple.py -q

------
https://chatgpt.com/codex/tasks/task_e_69060aac16d48324bacfe71327696767