### PR TITLE
Improve strict header matching for MFC outline

### DIFF
--- a/backend/services/header_match.py
+++ b/backend/services/header_match.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
 
 from ..config import get_settings
 from .lines import Line, iter_lines
+from .headers_llm_strict import align_headers_llm_strict
+from .headers_sequential import extract_number
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
@@ -60,6 +62,67 @@ def _find_match(
     return None
 
 
+def _prepare_strict_lines(lines: Iterable[Line]) -> List[Dict[str, Any]]:
+    """Return line dictionaries compatible with the strict header locator."""
+
+    prepared: List[Dict[str, Any]] = []
+    for idx, line in enumerate(lines):
+        text = str(line.get("text", ""))
+        try:
+            page = int(line.get("page", 0))
+        except (TypeError, ValueError):
+            page = 0
+        try:
+            line_in_page = int(line.get("line_in_page", 0))
+        except (TypeError, ValueError):
+            line_in_page = 0
+        prepared.append(
+            {
+                "text": text,
+                "page": page,
+                "line_in_page": line_in_page,
+                "global_idx": idx,
+                "line_idx": idx,
+                "is_toc": False,
+                "is_index": False,
+                "is_running": False,
+            }
+        )
+    return prepared
+
+
+def _prepare_strict_headers(
+    llm_headers: Iterable[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Coerce LLM headers into dictionaries understood by the strict locator."""
+
+    strict_headers: List[Dict[str, Any]] = []
+    for idx, header in enumerate(llm_headers):
+        title = str(header.get("title", "")).strip()
+        if not title:
+            continue
+        try:
+            level = int(header.get("level", 1))
+        except (TypeError, ValueError):
+            level = 1
+        number = header.get("number")
+        if isinstance(number, str):
+            number = number.strip() or None
+        else:
+            number = None
+        if number is None:
+            number = extract_number(title)
+        strict_headers.append(
+            {
+                "text": title,
+                "number": number,
+                "level": level,
+                "_orig_index": idx,
+            }
+        )
+    return strict_headers
+
+
 def find_header_occurrences(
     session,
     document_id: int,
@@ -73,11 +136,26 @@ def find_header_occurrences(
     lines = list(iter_lines(session, document_id))
     normalised = [(_normalise(str(line["text"])), line) for line in lines]
 
+    strict_mode = settings.headers_llm_strict
+    strict_lines = _prepare_strict_lines(lines) if strict_mode else []
+    strict_headers = _prepare_strict_headers(llm_headers or []) if strict_mode else []
+    resolved_by_index: Dict[int, Dict[str, Any]] = {}
+
+    if strict_mode and strict_lines and any(
+        header.get("text") for header in strict_headers
+    ):
+        resolved = align_headers_llm_strict(strict_headers, strict_lines, tracer=None)
+        for item in resolved:
+            header = item.get("header", {})
+            orig_index = header.get("_orig_index")
+            if isinstance(orig_index, int):
+                resolved_by_index[orig_index] = item
+
     matches: List[Dict] = []
     log_path = settings.headers_log_dir / f"header_matches_{document_id}.jsonl"
 
     with log_path.open("w", encoding="utf-8") as handle:
-        for header in llm_headers or []:
+        for index, header in enumerate(llm_headers or []):
             title = str(header.get("title", ""))
             try:
                 level = int(header.get("level", 1))
@@ -88,15 +166,23 @@ def find_header_occurrences(
             except (TypeError, ValueError):
                 expected_page = 0
 
-            match = _find_match(lines, normalised, title, expected_page)
+            strict_match = resolved_by_index.get(index)
+            match_line: Dict[str, Any] | None = None
+            if strict_match is not None:
+                match_line = strict_match.get("line")
+            if match_line is None:
+                match_line = _find_match(lines, normalised, title, expected_page)
+
             result = {
                 "llm_title": title,
                 "level": level,
                 "expected_page": expected_page,
-                "found": match is not None,
-                "found_page": int(match["page"]) if match else None,
-                "line_in_page": int(match["line_in_page"]) if match else None,
-                "matched_text": str(match["text"]) if match else None,
+                "found": match_line is not None,
+                "found_page": int(match_line.get("page", 0)) if match_line else None,
+                "line_in_page": (
+                    int(match_line.get("line_in_page", 0)) if match_line else None
+                ),
+                "matched_text": str(match_line.get("text", "")) if match_line else None,
             }
 
             matches.append(result)

--- a/backend/tests/test_header_match_strict.py
+++ b/backend/tests/test_header_match_strict.py
@@ -1,0 +1,156 @@
+"""Tests for strict header alignment when HEADERS_LLM_STRICT is enabled."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from backend.config import reset_settings_cache
+from backend.services.header_match import find_header_occurrences
+from backend.services.pdf_native import parse_pdf_to_lines
+
+GOLDEN_HEADERS = [
+    {"title": "1 General", "number": "1", "level": 1, "page": 0},
+    {
+        "title": "1.1 Scope and Field of Application",
+        "number": "1.1",
+        "level": 2,
+        "page": 0,
+    },
+    {"title": "1.2 References", "number": "1.2", "level": 2, "page": 0},
+    {"title": "1.3 Definitions", "number": "1.3", "level": 2, "page": 0},
+    {"title": "1.4 Symbols", "number": "1.4", "level": 2, "page": 0},
+    {"title": "2 Principles", "number": "2", "level": 1, "page": 0},
+    {
+        "title": "2.1 Statement of the Principles",
+        "number": "2.1",
+        "level": 2,
+        "page": 0,
+    },
+    {"title": "2.1.1 Static Weighing", "number": "2.1.1", "level": 3, "page": 0},
+    {"title": "2.1.2 Dynamic Weighing", "number": "2.1.2", "level": 3, "page": 0},
+    {
+        "title": "2.1.3 Comparison of Instantaneous and Mean Flow Rate",
+        "number": "2.1.3",
+        "level": 3,
+        "page": 0,
+    },
+    {
+        "title": "2.2 Accuracy of the Method",
+        "number": "2.2",
+        "level": 2,
+        "page": 0,
+    },
+    {
+        "title": "2.2.1 Overall Uncertainty on the Weighing Measurement",
+        "number": "2.2.1",
+        "level": 3,
+        "page": 0,
+    },
+    {
+        "title": "2.2.2 Requirements for Accurate Measurements",
+        "number": "2.2.2",
+        "level": 3,
+        "page": 0,
+    },
+    {"title": "3 Apparatus", "number": "3", "level": 1, "page": 0},
+    {"title": "3.1 Diverter", "number": "3.1", "level": 2, "page": 0},
+    {
+        "title": "3.2 Time-Measuring Apparatus",
+        "number": "3.2",
+        "level": 2,
+        "page": 0,
+    },
+    {"title": "3.3 Weighing Tank", "number": "3.3", "level": 2, "page": 0},
+    {"title": "3.4 Weighing Device", "number": "3.4", "level": 2, "page": 0},
+    {
+        "title": "3.5 Auxiliary Measurements",
+        "number": "3.5",
+        "level": 2,
+        "page": 0,
+    },
+    {"title": "4 Procedure", "number": "4", "level": 1, "page": 0},
+    {
+        "title": "4.1 Static Weighing Method",
+        "number": "4.1",
+        "level": 2,
+        "page": 0,
+    },
+    {
+        "title": "4.2 Dynamic Weighing Method",
+        "number": "4.2",
+        "level": 2,
+        "page": 0,
+    },
+    {
+        "title": "4.3 Common Provisions",
+        "number": "4.3",
+        "level": 2,
+        "page": 0,
+    },
+    {"title": "5 Calculation of Flow Rate", "number": "5", "level": 1, "page": 0},
+    {
+        "title": "5.1 Calculation of Mass Flow Rate",
+        "number": "5.1",
+        "level": 2,
+        "page": 0,
+    },
+    {
+        "title": "5.2 Calculation of Volume Flow Rate",
+        "number": "5.2",
+        "level": 2,
+        "page": 0,
+    },
+    {
+        "title": "6 Uncertainties in the Measurement of Flow Rate",
+        "number": "6",
+        "level": 1,
+        "page": 0,
+    },
+]
+
+
+def test_strict_header_search_matches_golden_outline(monkeypatch, tmp_path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    pdf_path = repo_root / "MFC-5M_R2001_E1985.pdf"
+    if not pdf_path.exists():
+        pytest.skip("Sample document MFC-5M_R2001_E1985.pdf missing")
+
+    export_dir = tmp_path / "exports"
+    upload_dir = tmp_path / "uploads"
+    log_dir = tmp_path / "logs"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("EXPORT_DIR", str(export_dir))
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("HEADERS_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("HEADERS_LLM_STRICT", "1")
+    reset_settings_cache()
+
+    lines = parse_pdf_to_lines(pdf_path)
+    doc_id = 101
+    doc_dir = export_dir / str(doc_id)
+    doc_dir.mkdir(parents=True, exist_ok=True)
+
+    per_page_counts: dict[int, int] = defaultdict(int)
+    with (doc_dir / "lines.jsonl").open("w", encoding="utf-8") as handle:
+        for entry in lines:
+            page = int(entry.get("page", 0))
+            per_page_counts[page] += 1
+            payload = {
+                "page": page,
+                "line_in_page": per_page_counts[page],
+                "text": str(entry.get("text", "")),
+            }
+            handle.write(json.dumps(payload, ensure_ascii=False))
+            handle.write("\n")
+
+    matches = find_header_occurrences(None, doc_id, GOLDEN_HEADERS)
+
+    assert matches
+    assert len(matches) == len(GOLDEN_HEADERS)
+    assert all(match["found"] for match in matches)


### PR DESCRIPTION
## Summary
- integrate the strict header alignment pipeline into the post-LLM header matcher when `HEADERS_LLM_STRICT` is enabled so numbered headings are found in noisy layouts
- add a regression test that parses `MFC-5M_R2001_E1985.pdf` and ensures the golden outline is located under strict mode

## Testing
- pytest backend/tests/test_header_match_strict.py

------
https://chatgpt.com/codex/tasks/task_e_69060d99ca448324baaedcaf6a26852d