### PR TITLE
Clarify LLM header prompt to ignore TOC previews

### DIFF
--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -301,6 +301,7 @@ def _render_prompt(
         "- Every header must include \"title\" and integer \"level\" (1 = top level).\n"
         "- Include \"number\" when the source shows one; otherwise use null.\n"
         "- Preserve document order and exclude tables of contents or running headers.\n"
+        "- Ignore any previewed or summarised TOC items; use only headers from the main body context.\n"
         "- Do not omit appendices; include them as headers when present.\n"
         "- If no headers exist, return {\"headers\": []}.\n\n"
         "Context:\n"


### PR DESCRIPTION
## Summary
- reinforce the header-extraction LLM prompt to ignore table-of-contents previews and rely on body context only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690619b0aa3c83248d6ca336e794b820