### PR TITLE
Cache parsed documents and reuse stored results

### DIFF
--- a/backend/migrations.py
+++ b/backend/migrations.py
@@ -28,8 +28,30 @@ def _ensure_document_mime_type(engine: Engine) -> None:
         connection.execute(text("ALTER TABLE document ADD COLUMN mime_type VARCHAR"))
 
 
+def _ensure_document_page_is_toc(engine: Engine) -> None:
+    """Add the ``is_toc`` flag to ``document_pages`` when absent."""
+
+    with engine.begin() as connection:
+        inspector = inspect(connection)
+        try:
+            columns = inspector.get_columns("document_pages")
+        except NoSuchTableError:
+            return
+
+        if any(column["name"] == "is_toc" for column in columns):
+            return
+
+        connection.execute(
+            text(
+                "ALTER TABLE document_pages "
+                "ADD COLUMN is_toc BOOLEAN NOT NULL DEFAULT 0"
+            )
+        )
+
+
 _MIGRATIONS: tuple[MigrationFunc, ...] = (
     _ensure_document_mime_type,
+    _ensure_document_page_is_toc,
 )
 
 

--- a/backend/models/artifacts.py
+++ b/backend/models/artifacts.py
@@ -46,6 +46,11 @@ class DocumentPage(SQLModel, table=True):
     page_index: int = Field(nullable=False)
     width: float = Field(nullable=False)
     height: float = Field(nullable=False)
+    is_toc: bool = Field(
+        default=False,
+        nullable=False,
+        description="Flag indicating whether the page was classified as table of contents.",
+    )
     text_raw: str = Field(
         default="",
         sa_column=Column(Text, nullable=False),

--- a/backend/services/artifact_store.py
+++ b/backend/services/artifact_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -77,6 +78,7 @@ def persist_parse_result(
                 page_index=page.page_number,
                 width=page.width,
                 height=page.height,
+                is_toc=page.is_toc,
                 text_raw=text_content,
                 layout=layout,
             )
@@ -129,9 +131,94 @@ def get_cached_parse_payload(
         key=PARSE_RESULT_ARTIFACT_KEY,
         inputs=_cache_inputs_for_document(document),
     )
-    if artifact is None:
+    if artifact is not None:
+        return artifact.body
+
+    payload = _hydrate_payload_from_pages(session=session, document=document)
+    if payload is None:
         return None
-    return artifact.body
+
+    store_artifact(
+        session=session,
+        document_id=document.id,
+        artifact_type=DocumentArtifactType.PAGE_LAYOUT,
+        key=PARSE_RESULT_ARTIFACT_KEY,
+        inputs=_cache_inputs_for_document(document),
+        body=payload,
+    )
+    return payload
+
+
+def _hydrate_payload_from_pages(
+    *, session: Session, document: Document
+) -> Mapping[str, Any] | None:
+    """Reconstruct a parse payload from persisted page and table records."""
+
+    if document.id is None:
+        return None
+
+    page_statement = (
+        select(DocumentPage)
+        .where(DocumentPage.document_id == document.id)
+        .order_by(DocumentPage.page_index)
+    )
+    pages = list(session.exec(page_statement).scalars().all())
+    if not pages:
+        return None
+
+    table_statement = select(DocumentTable).where(
+        DocumentTable.document_id == document.id
+    )
+    table_rows = list(session.exec(table_statement).scalars().all())
+    tables_by_page: dict[int, list[DocumentTable]] = defaultdict(list)
+    for table in table_rows:
+        tables_by_page[table.page_index].append(table)
+
+    payload_pages: list[dict[str, Any]] = []
+    for page in pages:
+        layout_blocks: Iterable[Mapping[str, Any]] = page.layout or []
+        blocks: list[dict[str, Any]] = []
+        for block in layout_blocks:
+            bbox = block.get("bbox", (0.0, 0.0, 0.0, 0.0))
+            if isinstance(bbox, list):
+                bbox_tuple = tuple(float(value) for value in bbox)
+            else:
+                bbox_tuple = tuple(float(value) for value in bbox)
+            blocks.append(
+                {
+                    "text": block.get("text", ""),
+                    "bbox": bbox_tuple,
+                    "font": block.get("font"),
+                    "font_size": block.get("font_size"),
+                    "source": block.get("source", ""),
+                }
+            )
+
+        tables_payload = [
+            {
+                "bbox": tuple(float(value) for value in table.bbox),
+                "flavor": table.flavor,
+                "accuracy": table.accuracy,
+            }
+            for table in tables_by_page.get(page.page_index, [])
+        ]
+
+        payload_pages.append(
+            {
+                "page_number": page.page_index,
+                "width": page.width,
+                "height": page.height,
+                "blocks": blocks,
+                "tables": tables_payload,
+                "is_toc": bool(page.is_toc),
+            }
+        )
+
+    return {
+        "has_ocr": bool(document.has_ocr),
+        "used_mineru": bool(document.used_mineru),
+        "pages": payload_pages,
+    }
 
 
 def cache_parse_result(

--- a/backend/tests/test_artifact_store.py
+++ b/backend/tests/test_artifact_store.py
@@ -62,6 +62,7 @@ def test_persist_parse_result_stores_pages_and_tables() -> None:
 
         assert len(stored_pages) == 1
         assert stored_pages[0].text_raw.strip() == "Heading"
+        assert stored_pages[0].is_toc is False
         assert len(stored_tables) == 1
         assert refreshed is not None
         assert refreshed.page_count == 1

--- a/backend/tests/test_parse_cache.py
+++ b/backend/tests/test_parse_cache.py
@@ -1,0 +1,169 @@
+import importlib
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+from sqlmodel import Session, select
+
+from backend.config import get_settings, reset_settings_cache
+from backend.database import get_engine, reset_database_state
+from backend.models import Document, DocumentArtifact
+from backend.services.pdf_native import (
+    ParsedBlock,
+    ParsedPage,
+    ParsedTable,
+    ParseResult,
+)
+
+
+def _reload_app_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "app.db"
+    upload_dir = tmp_path / "uploads"
+    export_dir = tmp_path / "exports"
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("EXPORT_DIR", str(export_dir))
+
+    reset_settings_cache()
+    reset_database_state()
+
+    import backend.paths as paths
+
+    importlib.reload(paths)
+    import backend.main as main
+
+    importlib.reload(main)
+
+
+def _create_document(session: Session) -> Document:
+    document = Document(filename="doc.pdf", checksum="cache-checksum")
+    session.add(document)
+    session.commit()
+    session.refresh(document)
+    return document
+
+
+def _stub_parse_factory(counter: list[int]) -> Callable:
+    def _stub_parse(document_path, *, settings):  # noqa: ANN001 - FastAPI dependency signature
+        counter[0] += 1
+        block = ParsedBlock(
+            text="Heading",
+            bbox=(0.0, 0.0, 10.0, 5.0),
+            font="Arial",
+            font_size=12.0,
+            source="pymupdf",
+        )
+        table = ParsedTable(
+            page_number=0,
+            bbox=(1.0, 1.0, 4.0, 4.0),
+            flavor="stream",
+            accuracy=0.9,
+        )
+        page = ParsedPage(
+            page_number=0,
+            width=612.0,
+            height=792.0,
+            blocks=[block],
+            tables=[table],
+            is_toc=True,
+        )
+        return ParseResult(pages=[page], has_ocr=True, used_mineru=False)
+
+    return _stub_parse
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_parse_document_reuses_cached_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_app_environment(tmp_path, monkeypatch)
+
+    from backend.main import app
+
+    parse_calls = [0]
+    monkeypatch.setattr(
+        "backend.routers.parse.parse_pdf",
+        _stub_parse_factory(parse_calls),
+    )
+
+    settings = get_settings()
+
+    try:
+        with TestClient(app) as client:
+            engine = get_engine()
+            with Session(engine) as session:
+                document = _create_document(session)
+                document_id = document.id
+
+            assert document_id is not None
+            document_dir = settings.upload_dir / str(document_id)
+            document_dir.mkdir(parents=True, exist_ok=True)
+            (document_dir / "doc.pdf").write_bytes(b"PDF")
+
+            response_first = client.post(f"/api/parse/{document_id}")
+            assert response_first.status_code == 200
+            assert parse_calls[0] == 1
+
+            response_second = client.post(f"/api/parse/{document_id}")
+            assert response_second.status_code == 200
+            assert parse_calls[0] == 1
+
+            payload = response_second.json()
+            assert payload["has_ocr"] is True
+            assert payload["pages"][0]["is_toc"] is True
+            assert payload["pages"][0]["blocks"][0]["text"] == "Heading"
+    finally:
+        reset_settings_cache()
+        reset_database_state()
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_parse_document_rehydrates_from_stored_pages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_app_environment(tmp_path, monkeypatch)
+
+    from backend.main import app
+
+    parse_calls = [0]
+    monkeypatch.setattr(
+        "backend.routers.parse.parse_pdf",
+        _stub_parse_factory(parse_calls),
+    )
+
+    settings = get_settings()
+
+    try:
+        with TestClient(app) as client:
+            engine = get_engine()
+            with Session(engine) as session:
+                document = _create_document(session)
+                document_id = document.id
+
+            assert document_id is not None
+            document_dir = settings.upload_dir / str(document_id)
+            document_dir.mkdir(parents=True, exist_ok=True)
+            (document_dir / "doc.pdf").write_bytes(b"PDF")
+
+            response_first = client.post(f"/api/parse/{document_id}")
+            assert response_first.status_code == 200
+            assert parse_calls[0] == 1
+
+            with Session(engine) as session:
+                session.exec(delete(DocumentArtifact))
+                session.commit()
+
+            response_second = client.post(f"/api/parse/{document_id}")
+            assert response_second.status_code == 200
+            assert parse_calls[0] == 1
+
+            payload = response_second.json()
+            assert payload["used_mineru"] is False
+            assert payload["pages"][0]["tables"][0]["flavor"] == "stream"
+            assert payload["pages"][0]["is_toc"] is True
+
+            with Session(engine) as session:
+                artifacts = session.exec(select(DocumentArtifact)).all()
+                assert len(artifacts) == 1
+    finally:
+        reset_settings_cache()
+        reset_database_state()


### PR DESCRIPTION
## Summary
- persist the table-of-contents flag for parsed pages and add a migration guard
- hydrate parse responses from stored pages/tables and rebuild the artifact cache when available
- add regression coverage to ensure the parse endpoint reuses cached payloads

## Testing
- pytest backend/tests/test_artifact_store.py backend/tests/test_parse_cache.py

------
https://chatgpt.com/codex/tasks/task_e_6906218fc2a48324989c302d647402a1