### PR TITLE
Rework headers API to surface orchestrator payload

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlmodel import Session, select
@@ -10,19 +12,24 @@ from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document, DocumentSection
 from ..services.header_match import find_header_occurrences
+from ..services.headers import HeadersLLMClient, extract_headers, flatten_outline
 from ..services.headers_llm_simple import (
     InvalidLLMJSONError,
     get_headers_llm_json,
 )
+from ..services.headers_orchestrator import extract_headers_and_chunks
+from ..services.pdf_native import parse_pdf
+from ..services.sections import build_and_store_sections
 from ..services.simpleheaders_state import SimpleHeadersState
 
 router = APIRouter(prefix="/api", tags=["headers"])
 
 
 @router.post("/headers/{document_id}")
-def compute_headers(
+async def compute_headers(
     document_id: int,
     *,
+    trace: bool = Query(False, description="Return inline trace events when available"),
     session: Session = Depends(get_session),
     settings: Settings = Depends(get_settings),
 ):
@@ -35,18 +42,216 @@ def compute_headers(
             detail="Document not found",
         )
 
-    try:
-        llm_obj = get_headers_llm_json(document_id, session, settings)
-    except InvalidLLMJSONError:
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={"error": "invalid_llm_json"},
+    if document.id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Document is missing a primary key",
         )
 
-    matches = find_header_occurrences(
-        session, document_id, llm_obj.get("headers", [])
+    use_simple_llm = (
+        settings.headers_mode.lower() == "llm_simple"
+        and settings.llm_provider.lower() != "disabled"
     )
-    return {"llm_headers": llm_obj.get("headers", []), "matches": matches}
+    if use_simple_llm:
+        try:
+            llm_obj = get_headers_llm_json(document_id, session, settings)
+        except InvalidLLMJSONError:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={"error": "invalid_llm_json"},
+            )
+
+        matches = find_header_occurrences(
+            session, document_id, llm_obj.get("headers", [])
+        )
+        return {"llm_headers": llm_obj.get("headers", []), "matches": matches}
+
+    doc_id = int(document.id)
+    document_path = settings.upload_dir / str(doc_id) / document.filename
+    if not document_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document contents missing",
+        )
+
+    try:
+        from ..routers import headers as headers_router
+    except Exception:  # pragma: no cover - defensive fallback
+        headers_router = None
+
+    parse_impl = parse_pdf
+    if headers_router is not None:
+        parse_impl = getattr(headers_router, "parse_pdf", parse_pdf)
+    parse_result = parse_impl(document_path, settings=settings)
+
+    client_factory = HeadersLLMClient
+    if headers_router is not None:
+        client_factory = getattr(headers_router, "HeadersLLMClient", HeadersLLMClient)
+    llm_client = client_factory(settings)
+    header_result = extract_headers(
+        parse_result,
+        settings=settings,
+        llm_client=llm_client,
+    )
+    native_headers = flatten_outline(header_result.outline)
+
+    document_bytes = document_path.read_bytes()
+    orchestrator_impl = extract_headers_and_chunks
+    if headers_router is not None:
+        orchestrator_impl = getattr(
+            headers_router, "extract_headers_and_chunks", extract_headers_and_chunks
+        )
+
+    orchestrator_kwargs = {
+        "settings": settings,
+        "native_headers": native_headers,
+        "metadata": {
+            "filename": document.filename,
+            "document_id": doc_id,
+        },
+        "session": session,
+        "document": document,
+        "want_trace": trace,
+    }
+    accepted_params = set(inspect.signature(orchestrator_impl).parameters)
+    for key in list(orchestrator_kwargs.keys()):
+        if key not in accepted_params:
+            orchestrator_kwargs.pop(key)
+
+    orchestrated, tracer = await orchestrator_impl(document_bytes, **orchestrator_kwargs)
+
+    raw_doc_hash = orchestrated.get("doc_hash")
+    doc_hash = str(raw_doc_hash) if raw_doc_hash not in {None, ""} else ""
+    lines = list(orchestrated.get("lines", []))
+    SimpleHeadersState.set(doc_id, doc_hash, lines)
+
+    persisted_sections = build_and_store_sections(
+        session=session,
+        document_id=doc_id,
+        simpleheaders=orchestrated.get("headers", []),
+        lines=lines,
+    )
+    section_key_by_gid = {
+        int(section.start_global_idx): section.section_key for section in persisted_sections
+    }
+    raw_sections = orchestrated.get("sections", []) or []
+    if raw_sections:
+        sections_payload: list[dict[str, object | None]] = []
+        for section in raw_sections:
+            start_idx = _coerce_optional_int(section.get("start_global_idx")) or 0
+            entry = {
+                "section_key": section_key_by_gid.get(start_idx),
+                "header_text": section.get("header_text"),
+                "header_number": section.get("header_number"),
+                "level": _coerce_int(section.get("level"), default=1),
+                "start_global_idx": start_idx,
+                "end_global_idx": _coerce_optional_int(section.get("end_global_idx"))
+                or start_idx,
+                "start_page": _coerce_optional_int(section.get("start_page")),
+                "end_page": _coerce_optional_int(section.get("end_page")),
+            }
+            sections_payload.append(entry)
+    else:
+        sections_payload = [_serialise_section(section) for section in persisted_sections]
+
+    simpleheaders_payload = _serialise_simpleheaders(
+        orchestrated.get("headers", []), section_key_by_gid
+    )
+
+    fenced_text = orchestrated.get("fenced_text") or header_result.fenced_text
+    messages = list(header_result.messages) + list(orchestrated.get("messages", []))
+
+    response_payload: dict[str, object] = {
+        "source": header_result.source,
+        "document_id": doc_id,
+        "outline": header_result.to_json(),
+        "simpleheaders": simpleheaders_payload,
+        "sections": sections_payload,
+        "mode": orchestrated.get("mode"),
+        "messages": messages,
+        "fenced_text": fenced_text,
+        "doc_hash": doc_hash,
+        "excluded_pages": orchestrated.get("excluded_pages", []),
+    }
+
+    if trace and tracer is not None:
+        response_payload["trace"] = {
+            "events": tracer.as_list(),
+            "path": tracer.path,
+            "summary_path": tracer.summary_path,
+        }
+
+    return response_payload
+
+
+def _serialise_simpleheaders(headers: list[dict], section_keys: dict[int, str]) -> list[dict]:
+    """Return API-ready simple header entries with section keys."""
+
+    serialised: list[dict] = []
+    for header in headers:
+        text = str(header.get("text", "")).strip()
+        if not text:
+            continue
+
+        number = header.get("number")
+        level = _coerce_int(header.get("level"), default=1)
+        page = _coerce_optional_int(header.get("page"))
+        line_idx = _coerce_optional_int(header.get("line_idx"))
+        global_idx = _coerce_optional_int(header.get("global_idx"))
+        section_key = (
+        section_keys.get(global_idx) if global_idx is not None else None
+        )
+
+        entry: dict[str, object | None] = {
+            "text": text,
+            "number": number if number not in {"", None} else None,
+            "level": level,
+            "page": page,
+            "line_idx": line_idx,
+            "global_idx": global_idx,
+            "section_key": section_key,
+        }
+
+        if "source_idx" in header:
+            entry["source_idx"] = _coerce_optional_int(header.get("source_idx"))
+        if "strategy" in header:
+            entry["strategy"] = header.get("strategy")
+        if "score" in header:
+            entry["score"] = header.get("score")
+
+        serialised.append(entry)
+
+    return serialised
+
+
+def _serialise_section(section: DocumentSection) -> dict:
+    """Convert a ``DocumentSection`` ORM model into a serialisable payload."""
+
+    return {
+        "section_key": section.section_key,
+        "title": section.title,
+        "number": section.number,
+        "level": section.level,
+        "start_global_idx": section.start_global_idx,
+        "end_global_idx": section.end_global_idx,
+        "start_page": section.start_page,
+        "end_page": section.end_page,
+    }
+
+
+def _coerce_int(value, *, default: int) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    return coerced
+
+
+def _coerce_optional_int(value) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 @router.get("/headers/{document_id}/section-text", response_class=PlainTextResponse)

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,5 +1,15 @@
-"""Compat shim importing the headers API router."""
+"""Compat shim exposing the headers API router and patch points for tests."""
 
-from ..api.headers import router
+from ..api import headers as headers_api
 
-__all__ = ["router"]
+router = headers_api.router
+parse_pdf = headers_api.parse_pdf
+extract_headers_and_chunks = headers_api.extract_headers_and_chunks
+HeadersLLMClient = headers_api.HeadersLLMClient
+
+__all__ = [
+    "router",
+    "parse_pdf",
+    "extract_headers_and_chunks",
+    "HeadersLLMClient",
+]

--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -350,6 +350,19 @@ def align_headers_llm_strict(
 
         score, line, strategy, band_flag = chosen
         prev_idx = line["global_idx"]
+        if tracer is not None:
+            tracer.ev(
+                "candidate_found",
+                number=number,
+                title=title,
+                page=line.get("page"),
+                idx=line.get("global_idx"),
+                line_index=line.get("line_index"),
+                score=score,
+                strategy=strategy,
+                band=band_flag,
+                toc_page=line.get("page") in toc_pages,
+            )
         resolved.append(
             {
                 "header": header,

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -18,7 +18,7 @@ from .header_locate_vector import locate_headers_with_vectors
 from .header_locator import locate_headers_in_lines
 from .headers_llm_strict import align_headers_llm_strict
 from .headers_sequential import number_key
-from .pdf_headers_llm_full import get_headers_llm_full
+from .pdf_headers_llm_full import LLMFullHeadersResult, get_headers_llm_full
 from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
 from ..utils.logging import configure_logging
@@ -64,6 +64,7 @@ async def extract_headers_and_chunks(
 ) -> tuple[dict, HeaderTracer | None]:
     """Return located headers and section ranges for the provided document."""
 
+    trace_requested = want_trace or app_config.HEADERS_TRACE
     tracer: HeaderTracer | None = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
 
     start_time = time.perf_counter()
@@ -103,6 +104,7 @@ async def extract_headers_and_chunks(
     located_headers: list[dict] = []
     mode_used = "llm_full"
     messages: list[str] = []
+    fenced_text: str | None = None
 
     doc_id = document.id if document and document.id is not None else None
     cache_inputs = {
@@ -129,6 +131,7 @@ async def extract_headers_and_chunks(
             sections = list(payload.get("sections", []))
             messages = list(payload.get("messages", []))
             mode_used = payload.get("mode", "cache")
+            fenced_text = payload.get("fenced_text")
             matched_titles = {str(item.get("text", "")).strip() for item in located}
             expected_titles = [str(item.get("text", "")) for item in (native_headers or [])]
             unresolved = [
@@ -168,17 +171,19 @@ async def extract_headers_and_chunks(
                 "doc_hash": doc_hash,
                 "excluded_pages": sorted(excluded_pages),
                 "messages": messages,
+                "fenced_text": fenced_text,
             }, tracer
 
     if settings.headers_mode.lower() == "llm_full":
         try:
-            llm_headers = await get_headers_llm_full(
+            llm_result: LLMFullHeadersResult = await get_headers_llm_full(
                 lines,
                 doc_hash,
                 settings=settings,
                 excluded_pages=excluded_pages,
             )
-            llm_headers = llm_headers or []
+            llm_headers = llm_result.headers or []
+            fenced_text = llm_result.combined_fenced()
             strict_attempted = False
             vector_attempted = False
             if settings.headers_llm_strict and llm_headers:
@@ -257,6 +262,12 @@ async def extract_headers_and_chunks(
                     count=len(llm_headers),
                     headers=llm_headers,
                 )
+                if app_config.HEADERS_TRACE_EMBED_RESPONSE:
+                    tracer.ev(
+                        "llm_raw_response",
+                        parts=llm_result.raw_responses,
+                        fenced=llm_result.fenced_blocks,
+                    )
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []
@@ -298,6 +309,7 @@ async def extract_headers_and_chunks(
                 "mode": mode_used,
                 "messages": messages,
                 "doc_hash": doc_hash,
+                "fenced_text": fenced_text,
             },
         )
 
@@ -335,6 +347,7 @@ async def extract_headers_and_chunks(
         "doc_hash": doc_hash,
         "excluded_pages": sorted(excluded_pages),
         "messages": messages,
+        "fenced_text": fenced_text,
     }, tracer
 
 

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence
 
 from backend.config import Settings
 
+from ..utils.logging import configure_logging
 from .openrouter_client import chat
 from .token_chunk import split_by_token_limit
 
@@ -17,19 +19,42 @@ FENCE_START = "-----BEGIN SIMPLEHEADERS JSON-----"
 FENCE_END = "-----END SIMPLEHEADERS JSON-----"
 
 
+LOGGER = configure_logging().getChild(__name__)
+
+
+@dataclass(slots=True)
+class LLMFullHeadersResult:
+    """Container for the full-LLM header extraction response."""
+
+    headers: List[Dict]
+    raw_responses: List[str]
+    fenced_blocks: List[str]
+
+    def combined_fenced(self) -> str:
+        """Return a single fenced block for downstream consumers."""
+
+        if self.fenced_blocks:
+            cleaned = [block.strip("\n") for block in self.fenced_blocks if block.strip()]
+            if cleaned:
+                return "\n\n".join(cleaned)
+        payload = json.dumps({"headers": self.headers}, ensure_ascii=False, indent=2)
+        return "\n".join([FENCE_START, payload, FENCE_END])
+
+
 def _cache_path(cache_dir: Path, doc_hash: str) -> Path:
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir / f"{doc_hash}.simpleheaders.json"
 
 
-def _extract_fenced_json(content: str) -> Dict:
+def _extract_fenced_json(content: str) -> tuple[Dict, str]:
     match = re.search(
         re.escape(FENCE_START) + r"(.*?)" + re.escape(FENCE_END), content, re.S
     )
     if not match:
         raise ValueError("LLM response missing fenced SIMPLEHEADERS JSON")
     payload = match.group(1)
-    return json.loads(payload)
+    fenced_block = match.group(0)
+    return json.loads(payload), fenced_block
 
 
 def _build_text_blocks(
@@ -92,6 +117,8 @@ async def get_headers_llm_full(
         client_params["x_title"] = settings.openrouter_title
 
     merged: list[Dict] = []
+    raw_responses: list[str] = []
+    fenced_blocks: list[str] = []
     total_parts = len(parts)
 
     for index, part in enumerate(parts, start=1):
@@ -133,7 +160,15 @@ async def get_headers_llm_full(
                 timeout_read=settings.headers_llm_timeout_s,
             ),
         )
-        data = _extract_fenced_json(content)
+        LOGGER.info(
+            "[headers.llm_full] Raw LLM response part %s/%s:\n%s",
+            index,
+            total_parts,
+            content.strip(),
+        )
+        raw_responses.append(content)
+        data, fenced_block = _extract_fenced_json(content)
+        fenced_blocks.append(fenced_block)
         merged.extend(data.get("headers", []))
 
     deduped: list[Dict] = []
@@ -158,7 +193,16 @@ async def get_headers_llm_full(
         encoding="utf-8",
     )
 
-    return deduped
+    return LLMFullHeadersResult(
+        headers=deduped,
+        raw_responses=raw_responses,
+        fenced_blocks=fenced_blocks,
+    )
 
 
-__all__ = ["get_headers_llm_full", "FENCE_START", "FENCE_END"]
+__all__ = [
+    "LLMFullHeadersResult",
+    "get_headers_llm_full",
+    "FENCE_START",
+    "FENCE_END",
+]

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -6,6 +6,7 @@ import backend.config as app_config
 from backend.config import Settings
 from backend.services import headers_orchestrator
 from backend.services.headers_llm_strict import extract_headers_and_sections_strict
+from backend.services.pdf_headers_llm_full import LLMFullHeadersResult
 from backend.utils.trace import HeaderTracer
 
 
@@ -35,7 +36,13 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
         return sample_lines, set(), "hash-value"
 
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
-        return [{"text": "Introduction", "number": "1", "level": 1}]
+        return LLMFullHeadersResult(
+            headers=[{"text": "Introduction", "number": "1", "level": 1}],
+            raw_responses=["raw"],
+            fenced_blocks=[
+                "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
+            ],
+        )
 
     monkeypatch.setattr(
         "backend.services.headers_orchestrator.collect_line_metrics", _fake_collect
@@ -112,7 +119,13 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
         return sample_lines, set(), "hash-value"
 
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
-        return [{"text": "Intro", "number": "1", "level": 1}]
+        return LLMFullHeadersResult(
+            headers=[{"text": "Intro", "number": "1", "level": 1}],
+            raw_responses=["raw"],
+            fenced_blocks=[
+                "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
+            ],
+        )
 
     monkeypatch.setattr(
         "backend.services.headers_orchestrator.collect_line_metrics", _fake_collect

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -2,6 +2,7 @@ import asyncio
 
 from backend.config import Settings
 from backend.services import headers_orchestrator
+from backend.services.pdf_headers_llm_full import LLMFullHeadersResult
 
 
 async def _run_extract(
@@ -35,9 +36,13 @@ async def _run_extract(
     async def _fake_llm(*args, **kwargs):  # noqa: ANN001 - test stub
         if llm_exception is not None:
             raise llm_exception
-        return [
-            {"text": "Intro", "number": "1", "level": 1},
-        ]
+        return LLMFullHeadersResult(
+            headers=[{"text": "Intro", "number": "1", "level": 1}],
+            raw_responses=["raw-response"],
+            fenced_blocks=[
+                "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
+            ],
+        )
 
     def _fake_locate(headers, *_args, tracer=None, **_kwargs):  # noqa: ANN001 - test stub
         if tracer is not None:
@@ -143,6 +148,7 @@ def test_extract_headers_llm_success_has_no_messages(monkeypatch, tmp_path) -> N
 
     assert result["mode"] == "llm_full"
     assert result["messages"] == []
+    assert result["fenced_text"]
 
 
 def test_extract_headers_strict_mode(monkeypatch, tmp_path) -> None:
@@ -150,3 +156,4 @@ def test_extract_headers_strict_mode(monkeypatch, tmp_path) -> None:
 
     assert result["mode"] == "llm_strict"
     assert result["messages"] == []
+    assert result["fenced_text"]

--- a/backend/tests/test_llm_full_headers.py
+++ b/backend/tests/test_llm_full_headers.py
@@ -125,16 +125,18 @@ def test_get_headers_llm_full_uses_cache(monkeypatch, tmp_path) -> None:
     ]
 
     async def _run() -> None:
-        headers = await get_headers_llm_full(
+        result = await get_headers_llm_full(
             lines,
             "hash-value",
             settings=settings,
             excluded_pages=set(),
         )
 
-        assert headers[0]["text"] == "Alpha"
+        assert result.headers[0]["text"] == "Alpha"
+        assert result.fenced_blocks
+        assert result.raw_responses
 
-        cached_headers = await get_headers_llm_full(
+        cached_result = await get_headers_llm_full(
             lines,
             "hash-value",
             settings=settings,
@@ -142,6 +144,6 @@ def test_get_headers_llm_full_uses_cache(monkeypatch, tmp_path) -> None:
         )
 
         assert calls == 1
-        assert cached_headers == headers
+        assert cached_result.headers == result.headers
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- refactor the `/api/headers` route to consume the orchestrator, returning outline/simpleheaders/sections/fenced text while preserving the legacy simple LLM fallback
- expose the router shim for monkeypatching and ensure the orchestrator/strict locator emit trace events and candidate logs
- extend the LLM full headers result container and unit tests to retain raw responses and fenced blocks

## Testing
- pytest tests/test_headers_golden.py tests/test_headers_llm_simple.py backend/tests/test_headers_orchestrator.py backend/tests/test_header_trace.py

------
https://chatgpt.com/codex/tasks/task_e_69062742801883249ee448ca7ab501b9