### PR TITLE
Refine parse pipeline to reuse cached artifacts

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -18,6 +18,7 @@ from ..services.headers_llm_simple import (
     get_headers_llm_json,
 )
 from ..services.headers_orchestrator import extract_headers_and_chunks
+from ..services.artifact_store import get_or_create_parse_result
 from ..services.pdf_native import parse_pdf
 from ..services.sections import build_and_store_sections
 from ..services.simpleheaders_state import SimpleHeadersState
@@ -82,7 +83,13 @@ async def compute_headers(
     parse_impl = parse_pdf
     if headers_router is not None:
         parse_impl = getattr(headers_router, "parse_pdf", parse_pdf)
-    parse_result = parse_impl(document_path, settings=settings)
+    parse_result, _ = get_or_create_parse_result(
+        session=session,
+        document=document,
+        document_path=document_path,
+        settings=settings,
+        parse_func=parse_impl,
+    )
 
     client_factory = HeadersLLMClient
     if headers_router is not None:

--- a/backend/routers/compare.py
+++ b/backend/routers/compare.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
+from ..services.artifact_store import get_or_create_parse_result
 from ..services.pdf_native import parse_pdf
 from ..services.spec_compare import (
     ClauseMatch,
@@ -107,7 +108,13 @@ async def compare_specifications(
             status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
         )
 
-    parse_result = parse_pdf(document_path, settings=settings)
+    parse_result, _ = get_or_create_parse_result(
+        session=session,
+        document=document,
+        document_path=document_path,
+        settings=settings,
+        parse_func=parse_pdf,
+    )
     spec_llm = SpecLLMClient(settings)
     extraction = extract_specifications(
         parse_result, settings=settings, llm_client=spec_llm

--- a/backend/routers/parse.py
+++ b/backend/routers/parse.py
@@ -9,10 +9,7 @@ from sqlmodel import Session
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
-from ..services.artifact_store import (
-    get_cached_parse_payload,
-    persist_parse_result,
-)
+from ..services.artifact_store import get_or_create_parse_result
 from ..services.pdf_native import ParseResult, parse_pdf
 
 router = APIRouter(prefix="/api", tags=["parse"])
@@ -84,12 +81,13 @@ async def parse_document(
             status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
         )
 
-    cached_payload = get_cached_parse_payload(session=session, document=document)
-    if cached_payload is not None:
-        return ParseResponse(document_id=doc_id, **cached_payload)
-
-    result: ParseResult = parse_pdf(document_path, settings=settings)
-    persist_parse_result(session=session, document=document, parse_result=result)
+    result, _ = get_or_create_parse_result(
+        session=session,
+        document=document,
+        document_path=document_path,
+        settings=settings,
+        parse_func=parse_pdf,
+    )
     payload = result.to_dict()
     return ParseResponse(document_id=doc_id, **payload)
 

--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -13,6 +13,7 @@ from sqlmodel import Session
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document
+from ..services.artifact_store import get_or_create_parse_result
 from ..services.pdf_native import parse_pdf
 from ..services.spec_extraction import (
     SpecExtractionResult,
@@ -115,7 +116,13 @@ async def extract_specs_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="Document contents missing"
         )
 
-    parse_result = parse_pdf(document_path, settings=settings)
+    parse_result, _ = get_or_create_parse_result(
+        session=session,
+        document=document,
+        document_path=document_path,
+        settings=settings,
+        parse_func=parse_pdf,
+    )
     llm_client = SpecLLMClient(settings)
     extraction = extract_specifications(
         parse_result, settings=settings, llm_client=llm_client

--- a/backend/services/artifact_store.py
+++ b/backend/services/artifact_store.py
@@ -7,11 +7,12 @@ import json
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from sqlalchemy import delete, select
 from sqlmodel import Session
 
+from ..config import Settings
 from ..models import (
     Document,
     DocumentArtifact,
@@ -19,7 +20,7 @@ from ..models import (
     DocumentPage,
     DocumentTable,
 )
-from ..services.pdf_native import ParseResult
+from ..services.pdf_native import ParseResult, parse_pdf
 
 PARSER_VERSION = "2025.01"
 PARSE_RESULT_ARTIFACT_KEY = "parse-result"
@@ -239,6 +240,29 @@ def cache_parse_result(
     )
 
 
+def get_or_create_parse_result(
+    *,
+    session: Session,
+    document: Document,
+    document_path: Path,
+    settings: Settings,
+    parse_func: Callable[[Path, Settings], ParseResult] | None = None,
+) -> tuple[ParseResult, bool]:
+    """Return a parse result, reusing cached artifacts when available."""
+
+    if document.id is None:
+        raise ValueError("Document must be persisted before parsing")
+
+    cached_payload = get_cached_parse_payload(session=session, document=document)
+    if cached_payload is not None:
+        return ParseResult.from_dict(cached_payload), True
+
+    parse_impl = parse_func or parse_pdf
+    result = parse_impl(document_path, settings=settings)
+    persist_parse_result(session=session, document=document, parse_result=result)
+    return result, False
+
+
 def get_cached_artifact(
     *,
     session: Session,
@@ -320,6 +344,7 @@ __all__ = [
     "PARSER_VERSION",
     "PARSE_RESULT_ARTIFACT_KEY",
     "cache_parse_result",
+    "get_or_create_parse_result",
     "get_cached_artifact",
     "get_cached_parse_payload",
     "persist_parse_result",

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -12,6 +12,7 @@ import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 import fitz  # type: ignore
 import pdfplumber  # type: ignore
@@ -38,6 +39,17 @@ from .text_extraction import extract_lines
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="pytesseract")
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _coerce_optional_float(value: Any) -> float | None:
+    """Return ``value`` as a float when possible, otherwise ``None``."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 @dataclass
@@ -115,6 +127,87 @@ class ParseResult:
             "has_ocr": self.has_ocr,
             "used_mineru": self.used_mineru,
         }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ParseResult":
+        """Rehydrate a :class:`ParseResult` instance from a cached payload."""
+
+        pages_payload = payload.get("pages") or []
+        pages: list[ParsedPage] = []
+        for entry in pages_payload:
+            if not isinstance(entry, Mapping):
+                continue
+            blocks_payload = entry.get("blocks") or []
+            blocks: list[ParsedBlock] = []
+            for block_entry in blocks_payload:
+                if not isinstance(block_entry, Mapping):
+                    continue
+                bbox_values = block_entry.get("bbox", (0.0, 0.0, 0.0, 0.0))
+                bbox_tuple = (0.0, 0.0, 0.0, 0.0)
+                if isinstance(bbox_values, Iterable) and not isinstance(
+                    bbox_values, (str, bytes)
+                ):
+                    try:
+                        coords = [float(value) for value in bbox_values]
+                    except (TypeError, ValueError):
+                        coords = []
+                    if len(coords) == 4:
+                        bbox_tuple = tuple(coords)
+                blocks.append(
+                    ParsedBlock(
+                        text=str(block_entry.get("text", "")),
+                        bbox=bbox_tuple,  # type: ignore[arg-type]
+                        font=block_entry.get("font"),
+                        font_size=_coerce_optional_float(block_entry.get("font_size")),
+                        source=str(block_entry.get("source", "")),
+                    )
+                )
+
+            tables_payload = entry.get("tables") or []
+            tables: list[ParsedTable] = []
+            for table_entry in tables_payload:
+                if not isinstance(table_entry, Mapping):
+                    continue
+                bbox_values = table_entry.get("bbox", (0.0, 0.0, 0.0, 0.0))
+                bbox_tuple = (0.0, 0.0, 0.0, 0.0)
+                if isinstance(bbox_values, Iterable) and not isinstance(
+                    bbox_values, (str, bytes)
+                ):
+                    try:
+                        coords = [float(value) for value in bbox_values]
+                    except (TypeError, ValueError):
+                        coords = []
+                    if len(coords) == 4:
+                        bbox_tuple = tuple(coords)
+                tables.append(
+                    ParsedTable(
+                        page_number=int(entry.get("page_number", 0)),
+                        bbox=bbox_tuple,  # type: ignore[arg-type]
+                        flavor=(
+                            str(table_entry.get("flavor"))
+                            if table_entry.get("flavor") is not None
+                            else None
+                        ),
+                        accuracy=_coerce_optional_float(table_entry.get("accuracy")),
+                    )
+                )
+
+            pages.append(
+                ParsedPage(
+                    page_number=int(entry.get("page_number", 0)),
+                    width=float(entry.get("width", 0.0)),
+                    height=float(entry.get("height", 0.0)),
+                    blocks=blocks,
+                    tables=tables,
+                    is_toc=bool(entry.get("is_toc", False)),
+                )
+            )
+
+        return cls(
+            pages=pages,
+            has_ocr=bool(payload.get("has_ocr", False)),
+            used_mineru=bool(payload.get("used_mineru", False)),
+        )
 
 
 class ParseError(RuntimeError):


### PR DESCRIPTION
## Summary
- add ParseResult.from_dict and a get_or_create_parse_result helper so services can rehydrate cached parse artifacts before parsing again
- refactor parse, headers, specs, and compare endpoints to call the shared helper, aligning the flow with the cache-first design

## Testing
- pytest backend/tests/test_parse_cache.py
- pytest backend/tests/test_artifact_store.py

------
https://chatgpt.com/codex/tasks/task_e_6908aa70d04c8324af4cdfa6df1393e0