### PR TITLE
Capture raw LLM output in header trace summaries

### DIFF
--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -261,12 +261,11 @@ async def extract_headers_and_chunks(
                     count=len(llm_headers),
                     headers=llm_headers,
                 )
-                if app_config.HEADERS_TRACE_EMBED_RESPONSE:
-                    tracer.ev(
-                        "llm_raw_response",
-                        parts=llm_result.raw_responses,
-                        fenced=llm_result.fenced_blocks,
-                    )
+                tracer.ev(
+                    "llm_raw_response",
+                    parts=llm_result.raw_responses,
+                    fenced=llm_result.fenced_blocks,
+                )
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -90,6 +90,10 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
     assert summary_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["llm_headers"]
+    assert summary["llm_raw_responses"] == ["raw"]
+    assert summary["llm_fenced_blocks"] == [
+        "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
+    ]
     assert summary["final_outline"]["headers"]
 
 
@@ -149,6 +153,10 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
     assert summary_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["llm_headers"][0]["text"] == "Intro"
+    assert summary["llm_raw_responses"] == ["raw"]
+    assert summary["llm_fenced_blocks"] == [
+        "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
+    ]
     assert summary["final_outline"]["headers"][0]["text"] == "Intro"
     assert payload["headers"]
 

--- a/backend/utils/trace.py
+++ b/backend/utils/trace.py
@@ -63,6 +63,8 @@ class HeaderTracer:
         events = self.as_list()
         metadata: Dict[str, Any] = {}
         llm_headers: List[Dict[str, Any]] = []
+        llm_raw_responses: List[str] = []
+        llm_fenced_blocks: List[str] = []
         final_outline: Dict[str, Any] = {}
         decisions: List[Dict[str, Any]] = []
         elapsed: float | None = None
@@ -93,6 +95,22 @@ class HeaderTracer:
                 }
                 if "elapsed_s" in event:
                     elapsed = event.get("elapsed_s")
+            elif event_type == "llm_raw_response":
+                raw_parts = event.get("parts")
+                if isinstance(raw_parts, list):
+                    llm_raw_responses.extend(
+                        str(part) for part in raw_parts if isinstance(part, str)
+                    )
+                elif isinstance(raw_parts, str):
+                    llm_raw_responses.append(raw_parts)
+
+                fenced_parts = event.get("fenced")
+                if isinstance(fenced_parts, list):
+                    llm_fenced_blocks.extend(
+                        str(entry) for entry in fenced_parts if isinstance(entry, str)
+                    )
+                elif isinstance(fenced_parts, str):
+                    llm_fenced_blocks.append(fenced_parts)
             elif event_type == "end_run":
                 if elapsed is None:
                     elapsed = event.get("elapsed_s")
@@ -105,6 +123,8 @@ class HeaderTracer:
             "run_id": self.run_id,
             "metadata": metadata,
             "llm_headers": llm_headers,
+            "llm_raw_responses": llm_raw_responses,
+            "llm_fenced_blocks": llm_fenced_blocks,
             "decisions": decisions,
             "final_outline": final_outline,
             "elapsed_s": elapsed,


### PR DESCRIPTION
## Summary
- always record the llm_raw_response event in header traces
- persist full raw responses and fenced blocks in the header trace summary JSON
- extend header trace tests to assert the new summary fields

## Testing
- pytest backend/tests/test_header_trace.py

------
https://chatgpt.com/codex/tasks/task_e_6908b1dd294c83248f926b319436b2a8