### PR TITLE
Surface raw LLM output when header parsing fails

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -181,6 +181,10 @@ async def compute_headers(
         "excluded_pages": orchestrated.get("excluded_pages", []),
     }
 
+    failure_raw = orchestrated.get("llm_failure_raw_response")
+    if isinstance(failure_raw, str) and failure_raw:
+        response_payload["llm_failure_raw_response"] = failure_raw
+
     if trace and tracer is not None:
         response_payload["trace"] = {
             "events": tracer.as_list(),

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -17,7 +17,11 @@ from .header_locate_vector import locate_headers_with_vectors
 from .header_locator import locate_headers_in_lines
 from .headers_llm_strict import align_headers_llm_strict
 from .headers_sequential import number_key
-from .pdf_headers_llm_full import LLMFullHeadersResult, get_headers_llm_full
+from .pdf_headers_llm_full import (
+    LLMFullHeadersParseError,
+    LLMFullHeadersResult,
+    get_headers_llm_full,
+)
 from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
 from ..utils.logging import configure_logging
@@ -104,6 +108,7 @@ async def extract_headers_and_chunks(
     mode_used = "llm_full"
     messages: list[str] = []
     fenced_text: str | None = None
+    llm_failure_raw_response: str | None = None
 
     doc_id = document.id if document and document.id is not None else None
     cache_inputs = {
@@ -131,6 +136,7 @@ async def extract_headers_and_chunks(
             messages = list(payload.get("messages", []))
             mode_used = payload.get("mode", "cache")
             fenced_text = payload.get("fenced_text")
+            llm_failure_raw_response = payload.get("llm_failure_raw_response")
             matched_titles = {str(item.get("text", "")).strip() for item in located}
             expected_titles = [str(item.get("text", "")) for item in (native_headers or [])]
             unresolved = [
@@ -171,6 +177,7 @@ async def extract_headers_and_chunks(
                 "excluded_pages": sorted(excluded_pages),
                 "messages": messages,
                 "fenced_text": fenced_text,
+                "llm_failure_raw_response": llm_failure_raw_response,
             }, tracer
 
     if settings.headers_mode.lower() == "llm_full":
@@ -266,11 +273,34 @@ async def extract_headers_and_chunks(
                     parts=llm_result.raw_responses,
                     fenced=llm_result.fenced_blocks,
                 )
+        except LLMFullHeadersParseError as exc:
+            LOGGER.warning("LLM response parse failed: %s", exc)
+            located_headers = []
+            mode_used = "llm_full_error"
+            llm_failure_raw_response = exc.content
+            fenced_text = exc.content
+            message = (
+                "LLM header extraction returned an invalid response; raw output "
+                "is available for review."
+            )
+            messages.append(message)
+            if tracer:
+                tracer.ev("llm_outline_received", count=0, headers=[])
+                tracer.ev(
+                    "fallback_triggered",
+                    method="llm_full",
+                    reason="invalid_response",
+                    message=str(exc),
+                )
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             LOGGER.warning("LLM header extraction failed: %s", exc)
             located_headers = []
             messages.append(_format_llm_failure(exc))
             mode_used = "llm_full_error"
+            raw_from_exc = getattr(exc, "content", None)
+            if isinstance(raw_from_exc, str) and raw_from_exc.strip():
+                llm_failure_raw_response = raw_from_exc
+                fenced_text = raw_from_exc
             if tracer:
                 tracer.ev("llm_outline_received", count=0, headers=[])
                 tracer.ev(
@@ -308,6 +338,7 @@ async def extract_headers_and_chunks(
                 "messages": messages,
                 "doc_hash": doc_hash,
                 "fenced_text": fenced_text,
+                "llm_failure_raw_response": llm_failure_raw_response,
             },
         )
 
@@ -346,6 +377,7 @@ async def extract_headers_and_chunks(
         "excluded_pages": sorted(excluded_pages),
         "messages": messages,
         "fenced_text": fenced_text,
+        "llm_failure_raw_response": llm_failure_raw_response,
     }, tracer
 
 

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -46,6 +46,15 @@ def _cache_path(cache_dir: Path, doc_hash: str) -> Path:
     return cache_dir / f"{doc_hash}.simpleheaders.json"
 
 
+class LLMFullHeadersParseError(RuntimeError):
+    """Raised when the LLM returns an unparsable headers payload."""
+
+    def __init__(self, message: str, *, content: str, part_index: int | None = None) -> None:
+        super().__init__(message)
+        self.content = content
+        self.part_index = part_index
+
+
 def _extract_fenced_json(content: str) -> tuple[Dict, str]:
     match = re.search(
         re.escape(FENCE_START) + r"(.*?)" + re.escape(FENCE_END), content, re.S
@@ -188,7 +197,14 @@ async def get_headers_llm_full(
             content.strip(),
         )
         raw_responses.append(content)
-        data, fenced_block = _extract_fenced_json(content)
+        try:
+            data, fenced_block = _extract_fenced_json(content)
+        except ValueError as exc:  # pragma: no cover - requires malformed provider output
+            raise LLMFullHeadersParseError(
+                str(exc) or "LLM response missing fenced SIMPLEHEADERS JSON",
+                content=content,
+                part_index=index,
+            ) from exc
         fenced_blocks.append(fenced_block)
         merged.extend(data.get("headers", []))
 
@@ -232,6 +248,7 @@ async def get_headers_llm_full(
 __all__ = [
     "LLMFullHeadersResult",
     "get_headers_llm_full",
+    "LLMFullHeadersParseError",
     "FENCE_START",
     "FENCE_END",
 ]

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -2,7 +2,10 @@ import asyncio
 
 from backend.config import Settings
 from backend.services import headers_orchestrator
-from backend.services.pdf_headers_llm_full import LLMFullHeadersResult
+from backend.services.pdf_headers_llm_full import (
+    LLMFullHeadersParseError,
+    LLMFullHeadersResult,
+)
 
 
 async def _run_extract(
@@ -141,6 +144,29 @@ def test_extract_headers_llm_failure_emits_message(monkeypatch, tmp_path) -> Non
     assert result["mode"] == "llm_full_error"
     assert result["messages"]
     assert "HTTP 403" in result["messages"][0]
+
+
+def test_extract_headers_llm_parse_error_returns_raw(monkeypatch, tmp_path) -> None:
+    raw_payload = "LLM output without fences"
+
+    result = asyncio.run(
+        _run_extract(
+            monkeypatch,
+            tmp_path,
+            llm_exception=LLMFullHeadersParseError(
+                "missing fences",
+                content=raw_payload,
+                part_index=1,
+            ),
+        )
+    )
+
+    assert result["mode"] == "llm_full_error"
+    assert result["llm_failure_raw_response"] == raw_payload
+    assert result["fenced_text"] == raw_payload
+    assert any(
+        "invalid response" in message.lower() for message in result["messages"]
+    )
 
 
 def test_extract_headers_llm_success_has_no_messages(monkeypatch, tmp_path) -> None:

--- a/frontend/static/js/ui.js
+++ b/frontend/static/js/ui.js
@@ -212,6 +212,24 @@ export function renderHeaderRawResponse(container, text) {
 
 export function renderHeaderOutline(container, payload, options = {}) {
   if (!container) return;
+  if (
+    payload?.mode === 'llm_full_error' &&
+    payload?.llm_failure_raw_response &&
+    String(payload.llm_failure_raw_response).trim()
+  ) {
+    const message = document.createElement('p');
+    message.className = 'panel-error';
+    message.textContent =
+      'LLM returned an invalid response. Review the raw output below to diagnose the fault.';
+
+    const pre = document.createElement('pre');
+    pre.className = 'raw-response';
+    pre.textContent = String(payload.llm_failure_raw_response);
+
+    container.innerHTML = '';
+    container.append(message, pre);
+    return;
+  }
   if (Array.isArray(payload?.simpleheaders) && payload.simpleheaders.length && Array.isArray(payload.sections) && payload.sections.length) {
     renderSimpleHeaders(container, payload, options);
     return;


### PR DESCRIPTION
## Summary
- capture parse errors from the headers LLM and expose the raw response for diagnostics
- propagate the failure payload through the orchestrator, API, and UI so the headers panel shows the raw output when available
- add regression coverage for invalid LLM responses during header extraction

## Testing
- pytest backend/tests/test_headers_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_6908b58767588324bdab19df61864552