### PR TITLE
Include LLM requests in header trace summaries

### DIFF
--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -187,6 +187,7 @@ async def extract_headers_and_chunks(
                 doc_hash,
                 settings=settings,
                 excluded_pages=excluded_pages,
+                tracer=tracer,
             )
             llm_headers = llm_result.headers or []
             fenced_text = llm_result.combined_fenced()

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -7,13 +7,16 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, List, Sequence, TYPE_CHECKING
 
 from backend.config import Settings
 
 from ..utils.logging import configure_logging
 from .openrouter_client import chat
 from .token_chunk import split_by_token_limit
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..utils.trace import HeaderTracer
 
 FENCE_START = "-----BEGIN SIMPLEHEADERS JSON-----"
 FENCE_END = "-----END SIMPLEHEADERS JSON-----"
@@ -102,6 +105,7 @@ async def get_headers_llm_full(
     *,
     settings: Settings,
     excluded_pages: Iterable[int] = (),
+    tracer: "HeaderTracer | None" = None,
 ) -> LLMFullHeadersResult:
     """Return LLM extracted headers for a document."""
 
@@ -180,6 +184,17 @@ async def get_headers_llm_full(
         ]
 
         loop = asyncio.get_running_loop()
+        if tracer is not None:
+            tracer.ev(
+                "llm_request",
+                part=index,
+                total_parts=total_parts,
+                model=settings.headers_llm_model,
+                temperature=0.2,
+                params=dict(client_params),
+                timeout_read=settings.headers_llm_timeout_s,
+                messages=[dict(message) for message in messages],
+            )
         content = await loop.run_in_executor(
             None,
             lambda: chat(

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -36,6 +36,18 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
         return sample_lines, set(), "hash-value"
 
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
+        tracer = _kwargs.get("tracer")
+        if tracer is not None:
+            tracer.ev(
+                "llm_request",
+                part=1,
+                total_parts=1,
+                model="stub-model",
+                temperature=0.0,
+                timeout_read=0,
+                params={},
+                messages=[{"role": "user", "content": "stub"}],
+            )
         return LLMFullHeadersResult(
             headers=[{"text": "Introduction", "number": "1", "level": 1}],
             raw_responses=["raw"],
@@ -90,6 +102,8 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
     assert summary_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["llm_headers"]
+    assert summary["llm_requests"]
+    assert summary["llm_requests"][0]["messages"][0]["content"] == "stub"
     assert summary["llm_raw_responses"] == ["raw"]
     assert summary["llm_fenced_blocks"] == [
         "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
@@ -123,6 +137,18 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
         return sample_lines, set(), "hash-value"
 
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
+        tracer = _kwargs.get("tracer")
+        if tracer is not None:
+            tracer.ev(
+                "llm_request",
+                part=1,
+                total_parts=1,
+                model="stub-model",
+                temperature=0.0,
+                timeout_read=0,
+                params={},
+                messages=[{"role": "user", "content": "stub"}],
+            )
         return LLMFullHeadersResult(
             headers=[{"text": "Intro", "number": "1", "level": 1}],
             raw_responses=["raw"],
@@ -153,6 +179,8 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
     assert summary_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["llm_headers"][0]["text"] == "Intro"
+    assert summary["llm_requests"]
+    assert summary["llm_requests"][0]["messages"][0]["content"] == "stub"
     assert summary["llm_raw_responses"] == ["raw"]
     assert summary["llm_fenced_blocks"] == [
         "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -37,6 +37,18 @@ async def _run_extract(
         return lines, set(), "hash-value"
 
     async def _fake_llm(*args, **kwargs):  # noqa: ANN001 - test stub
+        tracer = kwargs.get("tracer")
+        if tracer is not None:
+            tracer.ev(
+                "llm_request",
+                part=1,
+                total_parts=1,
+                model="stub-model",
+                temperature=0.0,
+                timeout_read=0,
+                params={},
+                messages=[{"role": "user", "content": "stub"}],
+            )
         if llm_exception is not None:
             raise llm_exception
         return LLMFullHeadersResult(

--- a/backend/utils/trace.py
+++ b/backend/utils/trace.py
@@ -63,6 +63,7 @@ class HeaderTracer:
         events = self.as_list()
         metadata: Dict[str, Any] = {}
         llm_headers: List[Dict[str, Any]] = []
+        llm_requests: List[Dict[str, Any]] = []
         llm_raw_responses: List[str] = []
         llm_fenced_blocks: List[str] = []
         final_outline: Dict[str, Any] = {}
@@ -86,6 +87,18 @@ class HeaderTracer:
                 }
             elif event_type == "llm_outline_received":
                 llm_headers = list(event.get("headers", []))
+            elif event_type == "llm_request":
+                llm_requests.append(
+                    {
+                        "part": event.get("part"),
+                        "total_parts": event.get("total_parts"),
+                        "model": event.get("model"),
+                        "temperature": event.get("temperature"),
+                        "timeout_read": event.get("timeout_read"),
+                        "params": event.get("params"),
+                        "messages": event.get("messages", []),
+                    }
+                )
             elif event_type == "final_outline":
                 final_outline = {
                     "headers": list(event.get("headers", [])),
@@ -123,6 +136,7 @@ class HeaderTracer:
             "run_id": self.run_id,
             "metadata": metadata,
             "llm_headers": llm_headers,
+            "llm_requests": llm_requests,
             "llm_raw_responses": llm_raw_responses,
             "llm_fenced_blocks": llm_fenced_blocks,
             "decisions": decisions,


### PR DESCRIPTION
## Summary
- add optional tracer plumbing to the full-header LLM client so requests are recorded as trace events
- capture LLM request metadata in header trace summaries alongside the existing response payloads
- update unit tests to validate the new trace contents and ensure orchestrator stubs emit request events

## Testing
- pytest backend/tests/test_header_trace.py backend/tests/test_headers_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_6908b7d54158832497e44346d5c173a9