### PR TITLE
Refine header extraction pipeline

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -12,7 +12,12 @@ from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document, DocumentSection
 from ..services.header_match import find_header_occurrences
-from ..services.headers import HeadersLLMClient, extract_headers, flatten_outline
+from ..services.headers import (
+    HeadersLLMClient,
+    build_outline_from_simpleheaders,
+    extract_headers,
+    flatten_outline,
+)
 from ..services.headers_llm_simple import (
     InvalidLLMJSONError,
     get_headers_llm_json,
@@ -132,6 +137,10 @@ async def compute_headers(
     lines = list(orchestrated.get("lines", []))
     SimpleHeadersState.set(doc_id, doc_hash, lines)
 
+    llm_headers = list(orchestrated.get("llm_headers", []))
+    llm_raw_responses = list(orchestrated.get("llm_raw_responses", []))
+    llm_fenced_blocks = list(orchestrated.get("llm_fenced_blocks", []))
+
     persisted_sections = build_and_store_sections(
         session=session,
         document_id=doc_id,
@@ -161,17 +170,23 @@ async def compute_headers(
     else:
         sections_payload = [_serialise_section(section) for section in persisted_sections]
 
+    simpleheaders_source = orchestrated.get("headers", [])
     simpleheaders_payload = _serialise_simpleheaders(
-        orchestrated.get("headers", []), section_key_by_gid
+        simpleheaders_source, section_key_by_gid
     )
 
     fenced_text = orchestrated.get("fenced_text") or header_result.fenced_text
     messages = list(header_result.messages) + list(orchestrated.get("messages", []))
 
+    outline_payload = header_result.to_json()
+    if llm_headers:
+        outline_nodes = build_outline_from_simpleheaders(llm_headers)
+        outline_payload = [node.to_dict() for node in outline_nodes]
+
     response_payload: dict[str, object] = {
         "source": header_result.source,
         "document_id": doc_id,
-        "outline": header_result.to_json(),
+        "outline": outline_payload,
         "simpleheaders": simpleheaders_payload,
         "sections": sections_payload,
         "mode": orchestrated.get("mode"),
@@ -179,6 +194,9 @@ async def compute_headers(
         "fenced_text": fenced_text,
         "doc_hash": doc_hash,
         "excluded_pages": orchestrated.get("excluded_pages", []),
+        "llm_headers": llm_headers,
+        "llm_raw_responses": llm_raw_responses,
+        "llm_fenced_blocks": llm_fenced_blocks,
     }
 
     failure_raw = orchestrated.get("llm_failure_raw_response")

--- a/backend/services/headers.py
+++ b/backend/services/headers.py
@@ -136,6 +136,38 @@ def flatten_outline(nodes: Sequence[HeaderNode]) -> list[dict[str, object]]:
     return flattened
 
 
+def build_outline_from_simpleheaders(
+    entries: Sequence[Mapping[str, object]]
+) -> list[HeaderNode]:
+    """Convert a simple header list into ``HeaderNode`` hierarchy."""
+
+    payload: list[dict[str, object]] = []
+    for entry in entries:
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+
+        number = entry.get("number")
+        level = entry.get("level")
+        try:
+            level_int = int(level) if level is not None else 1
+        except (TypeError, ValueError):
+            level_int = 1
+        page = entry.get("page")
+        page_int = page if isinstance(page, int) else None
+
+        payload.append(
+            {
+                "title": text,
+                "number": number,
+                "level": max(1, level_int),
+                "page": page_int,
+            }
+        )
+
+    return _build_outline_from_flat_entries(payload)
+
+
 def _normalise_text(text: str) -> str:
     """Normalise whitespace within a block."""
 
@@ -456,4 +488,5 @@ __all__ = [
     "HeadersLLMClient",
     "extract_headers",
     "flatten_outline",
+    "build_outline_from_simpleheaders",
 ]

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -109,6 +109,9 @@ async def extract_headers_and_chunks(
     messages: list[str] = []
     fenced_text: str | None = None
     llm_failure_raw_response: str | None = None
+    llm_headers: list[dict] = []
+    llm_raw_responses: list[str] = []
+    llm_fenced_blocks: list[str] = []
 
     doc_id = document.id if document and document.id is not None else None
     cache_inputs = {
@@ -137,6 +140,9 @@ async def extract_headers_and_chunks(
             mode_used = payload.get("mode", "cache")
             fenced_text = payload.get("fenced_text")
             llm_failure_raw_response = payload.get("llm_failure_raw_response")
+            llm_headers = list(payload.get("llm_headers", []))
+            llm_raw_responses = list(payload.get("llm_raw_responses", []))
+            llm_fenced_blocks = list(payload.get("llm_fenced_blocks", []))
             matched_titles = {str(item.get("text", "")).strip() for item in located}
             expected_titles = [str(item.get("text", "")) for item in (native_headers or [])]
             unresolved = [
@@ -190,6 +196,8 @@ async def extract_headers_and_chunks(
                 tracer=tracer,
             )
             llm_headers = llm_result.headers or []
+            llm_raw_responses = list(llm_result.raw_responses)
+            llm_fenced_blocks = list(llm_result.fenced_blocks)
             fenced_text = llm_result.combined_fenced()
             strict_attempted = False
             vector_attempted = False
@@ -340,6 +348,9 @@ async def extract_headers_and_chunks(
                 "doc_hash": doc_hash,
                 "fenced_text": fenced_text,
                 "llm_failure_raw_response": llm_failure_raw_response,
+                "llm_headers": llm_headers,
+                "llm_raw_responses": llm_raw_responses,
+                "llm_fenced_blocks": llm_fenced_blocks,
             },
         )
 
@@ -379,6 +390,9 @@ async def extract_headers_and_chunks(
         "messages": messages,
         "fenced_text": fenced_text,
         "llm_failure_raw_response": llm_failure_raw_response,
+        "llm_headers": llm_headers,
+        "llm_raw_responses": llm_raw_responses,
+        "llm_fenced_blocks": llm_fenced_blocks,
     }, tracer
 
 

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 FENCE_START = "-----BEGIN SIMPLEHEADERS JSON-----"
 FENCE_END = "-----END SIMPLEHEADERS JSON-----"
 
+HEADER_CHUNK_TOKEN_LIMIT = 120_000
+
 
 LOGGER = configure_logging().getChild(__name__)
 
@@ -138,9 +140,8 @@ async def get_headers_llm_full(
             )
 
     text_blocks = _build_text_blocks(lines, excluded_pages)
-    parts = split_by_token_limit(
-        text_blocks, settings.headers_llm_max_input_tokens
-    )
+    token_limit = min(settings.headers_llm_max_input_tokens, HEADER_CHUNK_TOKEN_LIMIT)
+    parts = split_by_token_limit(text_blocks, token_limit)
     if not parts:
         parts = ["\n".join(text_blocks)]
 
@@ -266,4 +267,6 @@ __all__ = [
     "LLMFullHeadersParseError",
     "FENCE_START",
     "FENCE_END",
+    "HEADER_CHUNK_TOKEN_LIMIT",
 ]
+

--- a/backend/tests/test_headers_orchestrator.py
+++ b/backend/tests/test_headers_orchestrator.py
@@ -156,6 +156,9 @@ def test_extract_headers_llm_failure_emits_message(monkeypatch, tmp_path) -> Non
     assert result["mode"] == "llm_full_error"
     assert result["messages"]
     assert "HTTP 403" in result["messages"][0]
+    assert result["llm_headers"] == []
+    assert result["llm_raw_responses"] == []
+    assert result["llm_fenced_blocks"] == []
 
 
 def test_extract_headers_llm_parse_error_returns_raw(monkeypatch, tmp_path) -> None:
@@ -179,6 +182,9 @@ def test_extract_headers_llm_parse_error_returns_raw(monkeypatch, tmp_path) -> N
     assert any(
         "invalid response" in message.lower() for message in result["messages"]
     )
+    assert result["llm_headers"] == []
+    assert result["llm_raw_responses"] == []
+    assert result["llm_fenced_blocks"] == []
 
 
 def test_extract_headers_llm_success_has_no_messages(monkeypatch, tmp_path) -> None:
@@ -187,6 +193,10 @@ def test_extract_headers_llm_success_has_no_messages(monkeypatch, tmp_path) -> N
     assert result["mode"] == "llm_full"
     assert result["messages"] == []
     assert result["fenced_text"]
+    assert result["llm_headers"]
+    assert result["llm_headers"][0]["text"] == "Intro"
+    assert result["llm_raw_responses"] == ["raw-response"]
+    assert result["llm_fenced_blocks"]
 
 
 def test_extract_headers_strict_mode(monkeypatch, tmp_path) -> None:
@@ -195,3 +205,5 @@ def test_extract_headers_strict_mode(monkeypatch, tmp_path) -> None:
     assert result["mode"] == "llm_strict"
     assert result["messages"] == []
     assert result["fenced_text"]
+    assert result["llm_headers"]
+    assert result["llm_raw_responses"] == ["raw-response"]

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -39,6 +39,7 @@ const state = {
   approvalLoading: false,
   headerSearchAttempted: false,
   specsSearchAttempted: false,
+  headerMatches: [],
 };
 
 const elements = {
@@ -91,6 +92,31 @@ function renderPanelStartPrompt(container, { message, buttonLabel, onStart }) {
   wrapper.append(button);
 
   container.append(wrapper);
+}
+
+function deriveHeaderMatches(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const headers = Array.isArray(payload.simpleheaders) ? payload.simpleheaders : [];
+  return headers
+    .map((header) => {
+      const text = typeof header.text === 'string' ? header.text : '';
+      const number = header.number != null ? header.number : null;
+      const page = Number(header.page);
+      const line = Number(header.line_idx);
+      const globalIdx = Number(header.global_idx);
+
+      return {
+        text,
+        number,
+        page: Number.isFinite(page) ? page : null,
+        line: Number.isFinite(line) ? line : null,
+        globalIdx: Number.isFinite(globalIdx) ? globalIdx : null,
+      };
+    })
+    .filter((entry) => entry.text);
 }
 
 function updateHeaderModeTag(mode) {
@@ -240,6 +266,7 @@ async function selectDocument(documentId) {
   state.risk = null;
   state.headerSearchAttempted = false;
   state.specsSearchAttempted = false;
+  state.headerMatches = [];
 
   if (elements.workspaceSubtitle) {
     elements.workspaceSubtitle.textContent = 'Loading analysis results…';
@@ -342,7 +369,8 @@ async function refreshHeaders() {
   try {
     const headersResult = await fetchHeaders(documentId);
     state.headers = headersResult;
-    renderHeaderRawResponse(elements.headersRawContent, state.headers?.fenced_text ?? '');
+    state.headerMatches = deriveHeaderMatches(state.headers);
+    renderHeaderRawResponse(elements.headersRawContent, state.headers);
     renderHeaderOutline(elements.headersContent, state.headers, {
       documentId,
       fetchSection: fetchSectionText,
@@ -362,16 +390,15 @@ async function refreshHeaders() {
     showToast(message, 'error');
     if (previousHeaders) {
       state.headers = previousHeaders;
-      renderHeaderRawResponse(
-        elements.headersRawContent,
-        previousHeaders?.fenced_text ?? '',
-      );
+      state.headerMatches = deriveHeaderMatches(previousHeaders);
+      renderHeaderRawResponse(elements.headersRawContent, previousHeaders);
       renderHeaderOutline(elements.headersContent, previousHeaders, {
         documentId,
         fetchSection: fetchSectionText,
       });
       updateHeaderModeTag(previousHeaders?.mode ?? null);
     } else {
+      state.headerMatches = [];
       setPanelError(elements.headersRawContent, message);
       setPanelError(elements.headersContent, message);
       updateHeaderModeTag(null);

--- a/frontend/static/js/ui.js
+++ b/frontend/static/js/ui.js
@@ -195,18 +195,98 @@ export function renderParseSummary(container, payload) {
   container.append(grid);
 }
 
-export function renderHeaderRawResponse(container, text) {
+export function renderHeaderRawResponse(container, payload) {
   if (!container) return;
-  if (!text || !String(text).trim()) {
+
+  let rawParts = [];
+  let fencedParts = [];
+  let fallbackText = '';
+
+  if (typeof payload === 'string') {
+    fallbackText = payload;
+  } else if (payload && typeof payload === 'object') {
+    if (Array.isArray(payload.llm_raw_responses)) {
+      rawParts = payload.llm_raw_responses
+        .map((part) => String(part ?? ''))
+        .filter((part) => part.trim().length);
+    }
+    if (Array.isArray(payload.llm_fenced_blocks)) {
+      fencedParts = payload.llm_fenced_blocks
+        .map((part) => String(part ?? ''))
+        .filter((part) => part.trim().length);
+    }
+    if (payload.fenced_text != null) {
+      fallbackText = String(payload.fenced_text);
+    }
+  } else {
+    fallbackText = '';
+  }
+
+  container.innerHTML = '';
+
+  if (rawParts.length) {
+    rawParts.forEach((part, index) => {
+      const details = document.createElement('details');
+      details.className = 'raw-response__details';
+      if (index === 0) {
+        details.open = true;
+      }
+      const summary = document.createElement('summary');
+      summary.textContent =
+        rawParts.length === 1
+          ? 'LLM raw response'
+          : `LLM raw response (part ${index + 1})`;
+      const pre = document.createElement('pre');
+      pre.className = 'raw-response';
+      pre.textContent = part;
+      details.append(summary, pre);
+      container.append(details);
+    });
+
+    if (fencedParts.length) {
+      fencedParts.forEach((block, index) => {
+        const details = document.createElement('details');
+        details.className = 'raw-response__details';
+        const summary = document.createElement('summary');
+        summary.textContent =
+          fencedParts.length === 1
+            ? 'Parsed SIMPLEHEADERS JSON'
+            : `Parsed SIMPLEHEADERS JSON (part ${index + 1})`;
+        const pre = document.createElement('pre');
+        pre.className = 'raw-response';
+        pre.textContent = block;
+        details.append(summary, pre);
+        container.append(details);
+      });
+    } else if (fallbackText && fallbackText.trim()) {
+      const details = document.createElement('details');
+      details.className = 'raw-response__details';
+      const summary = document.createElement('summary');
+      summary.textContent = 'Parsed SIMPLEHEADERS JSON';
+      const pre = document.createElement('pre');
+      pre.className = 'raw-response';
+      pre.textContent = fallbackText;
+      details.append(summary, pre);
+      container.append(details);
+    }
+
+    if (!container.childElementCount) {
+      container.innerHTML = '<p class="panel-status">Raw response unavailable.</p>';
+    }
+
+    return;
+  }
+
+  const fallback = fencedParts.length ? fencedParts.join('\n\n') : fallbackText;
+
+  if (!fallback || !String(fallback).trim()) {
     container.innerHTML = '<p class="panel-status">Raw response unavailable.</p>';
     return;
   }
 
   const pre = document.createElement('pre');
   pre.className = 'raw-response';
-  pre.textContent = String(text);
-
-  container.innerHTML = '';
+  pre.textContent = String(fallback);
   container.append(pre);
 }
 
@@ -283,12 +363,41 @@ function renderSimpleHeaders(container, payload, { documentId, fetchSection } = 
     button.className = 'simpleheaders__item';
     button.dataset.index = String(index);
     const label = header.number ? `${header.number} ${header.text}` : header.text;
-    button.textContent = label;
     button.style.paddingLeft = `${Math.max(0, Number(header.level || 1) - 1) * 12}px`;
     button.title = formatPageRange(sections[index]) ?? `Page ${Number(header.page ?? 0) + 1}`;
     if (header.section_key) {
       button.dataset.sectionKey = String(header.section_key);
     }
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'simpleheaders__item-label';
+    labelEl.textContent = label;
+
+    const metaEl = document.createElement('span');
+    metaEl.className = 'simpleheaders__item-meta';
+    const metaParts = [];
+    const pageNumber = Number(header.page);
+    if (Number.isFinite(pageNumber)) {
+      metaParts.push(`Page ${pageNumber + 1}`);
+    }
+    const lineNumber = Number(header.line_idx);
+    if (Number.isFinite(lineNumber)) {
+      metaParts.push(`Line ${lineNumber + 1}`);
+    }
+    const pageLabel = formatPageRange(sections[index]) ?? '';
+    if (!metaParts.length && pageLabel) {
+      metaParts.push(pageLabel);
+    }
+    if (metaParts.length) {
+      metaEl.textContent = metaParts.join(' · ');
+    }
+
+    button.textContent = '';
+    button.append(labelEl);
+    if (metaEl.textContent) {
+      button.append(metaEl);
+    }
+
     button.addEventListener('click', () => selectIndex(index));
     list.append(button);
     return button;

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -394,6 +394,32 @@ body {
   margin: 0;
 }
 
+.raw-response__details {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 0.65rem 0.85rem;
+  background: color-mix(in srgb, var(--bg-panel) 96%, CanvasText 4%);
+  margin: 0 0 0.75rem;
+}
+
+.raw-response__details:last-child {
+  margin-bottom: 0;
+}
+
+.raw-response__details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  outline: none;
+}
+
+.raw-response__details[open] > summary {
+  margin-bottom: 0.5rem;
+}
+
+.raw-response__details > .raw-response {
+  margin-top: 0.35rem;
+}
+
 .simpleheaders {
   display: grid;
   gap: 1.25rem;
@@ -423,6 +449,18 @@ body {
   padding: 0.45rem 0.65rem;
   cursor: pointer;
   transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.simpleheaders__item-label {
+  display: block;
+  font-weight: 600;
+}
+
+.simpleheaders__item-meta {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
 }
 
 .simpleheaders__item:hover,


### PR DESCRIPTION
## Summary
- cap full-document header requests to 120k-token parts and persist the raw LLM output alongside computed headers
- treat the LLM header JSON as the golden outline in the API, returning raw responses and section-aligned matches for clients
- refresh the front-end header workflow to show raw responses, header locations, and section previews driven by the new data

## Testing
- pytest backend/tests/test_headers_orchestrator.py backend/tests/test_header_trace.py backend/tests/test_llm_full_headers.py

------
https://chatgpt.com/codex/tasks/task_e_6908c73194488324b73255f12048ff5d