### PR TITLE
Log header search call order

### DIFF
--- a/backend/services/header_align_bp.py
+++ b/backend/services/header_align_bp.py
@@ -130,7 +130,14 @@ def _in_band(line: Line, positions: Dict[int, Dict[int, int]]) -> bool:
     return position < HEADERS_BAND_LINES or position >= max(0, total - HEADERS_BAND_LINES)
 
 
-def align_headers_best(llm_headers: Sequence[Header], lines_input: Sequence[Line], tracer: HeaderTracer | None = None) -> List[Dict[str, object]]:
+def align_headers_best(
+    llm_headers: Sequence[Header],
+    lines_input: Sequence[Line],
+    tracer: HeaderTracer | None = None,
+) -> List[Dict[str, object]]:
+    if tracer:
+        tracer.log_call(f"{__name__}.align_headers_best")
+
     lines = _two_line_appendix_fuse(list(lines_input))
     sizes = [float(line.get("font_size") or 0.0) for line in lines if line.get("font_size") is not None]
     median_size = sorted(sizes)[len(sizes) // 2] if sizes else 0.0

--- a/backend/services/header_locate_vector.py
+++ b/backend/services/header_locate_vector.py
@@ -58,6 +58,9 @@ def locate_headers_with_vectors(
 ) -> list[dict[str, object]]:
     """Return located headers using the vector locator."""
 
+    if tracer is not None:
+        tracer.log_call(f"{__name__}.locate_headers_with_vectors")
+
     canonical = _canonical_headers(simple_headers)
     if not canonical:
         return []

--- a/backend/services/header_locator.py
+++ b/backend/services/header_locator.py
@@ -35,6 +35,8 @@ def _locate_headers_legacy(
     tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
     excluded = set(excluded_pages)
+    if tracer:
+        tracer.log_call(f"{__name__}._locate_headers_legacy")
     usable: list[dict] = []
     for line in lines:
         if line.get("page") in excluded:
@@ -194,6 +196,9 @@ def locate_headers_in_lines(
     similarity_threshold: float = 0.88,
     tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
+    if tracer:
+        tracer.log_call(f"{__name__}.locate_headers_in_lines")
+
     strategy = os.getenv("HEADERS_ALIGN_STRATEGY", HEADERS_ALIGN_STRATEGY).strip().lower()
 
     index_buckets: dict[tuple[str, str], list[int]] = {}

--- a/backend/services/headers_llm_strict.py
+++ b/backend/services/headers_llm_strict.py
@@ -174,6 +174,9 @@ def align_headers_llm_strict(
 ) -> List[Dict[str, Any]]:
     """Align LLM-provided headers to body lines using strict heuristics."""
 
+    if tracer is not None:
+        tracer.log_call(f"{__name__}.align_headers_llm_strict")
+
     lines_list = list(lines_input)
     raw_lines = fuse_two_line_appendix_candidates(lines_list)
 
@@ -490,6 +493,9 @@ def _align_headers_to_sections(
     *,
     fenced_text: str | None,
 ) -> Dict[str, Any]:
+    if tracer is not None:
+        tracer.log_call(f"{__name__}._align_headers_to_sections")
+
     resolved = align_headers_llm_strict(llm_headers, lines_list, tracer=tracer)
 
     located: List[Dict[str, Any]] = []
@@ -583,6 +589,9 @@ def extract_headers_and_sections_strict(
 ) -> Dict[str, Any]:
     """Locate headers and construct contiguous section ranges."""
 
+    if tracer is not None:
+        tracer.log_call(f"{__name__}.extract_headers_and_sections_strict")
+
     lines_list = list(lines)
     full_text = "\n".join(str(line.get("text", "")) for line in lines_list)
 
@@ -658,6 +667,9 @@ def run_strict_headers_pipeline(
             file_id=file_id,
             metadata={"provider": provider, "model": model},
         )
+
+    if tracer is not None:
+        tracer.log_call(f"{__name__}.run_strict_headers_pipeline")
 
     outline_loader = getattr(llm_module, "get_outline_for_headers", None)
     if callable(outline_loader):

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -69,6 +69,8 @@ async def extract_headers_and_chunks(
 
     trace_requested = want_trace or app_config.HEADERS_TRACE
     tracer: HeaderTracer | None = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
+    if tracer:
+        tracer.log_call(f"{__name__}.extract_headers_and_chunks")
 
     start_time = time.perf_counter()
     if tracer:
@@ -96,6 +98,10 @@ async def extract_headers_and_chunks(
                 count=len(native_headers),
             )
 
+    if tracer:
+        tracer.log_call(
+            f"{collect_line_metrics.__module__}.{collect_line_metrics.__qualname__}"
+        )
     lines, excluded_pages, doc_hash = collect_line_metrics(
         document_bytes,
         metadata,
@@ -203,6 +209,10 @@ async def extract_headers_and_chunks(
             vector_attempted = False
             if settings.headers_llm_strict and llm_headers:
                 strict_attempted = True
+                if tracer:
+                    tracer.log_call(
+                        f"{align_headers_llm_strict.__module__}.{align_headers_llm_strict.__qualname__}"
+                    )
                 strict_resolved = align_headers_llm_strict(
                     llm_headers,
                     lines,
@@ -227,6 +237,10 @@ async def extract_headers_and_chunks(
             if not located_headers and settings.header_locate_use_embeddings:
                 try:
                     vector_attempted = True
+                    if tracer:
+                        tracer.log_call(
+                            f"{locate_headers_with_vectors.__module__}.{locate_headers_with_vectors.__qualname__}"
+                        )
                     located_headers = locate_headers_with_vectors(
                         session=session,
                         document_id=doc_id or 0,
@@ -253,6 +267,10 @@ async def extract_headers_and_chunks(
                     located_headers = []
 
             if not located_headers:
+                if tracer:
+                    tracer.log_call(
+                        f"{locate_headers_in_lines.__module__}.{locate_headers_in_lines.__qualname__}"
+                    )
                 located_headers = locate_headers_in_lines(
                     llm_headers,
                     lines,
@@ -329,6 +347,10 @@ async def extract_headers_and_chunks(
             )
             tracer.ev("llm_outline_received", count=0, headers=[])
 
+    if tracer:
+        tracer.log_call(
+            f"{_enforce_header_sequence.__module__}.{_enforce_header_sequence.__qualname__}"
+        )
     located_headers, sections = _enforce_header_sequence(
         located_headers, lines, tracer=tracer
     )
@@ -403,6 +425,9 @@ def _enforce_header_sequence(
     tracer: HeaderTracer | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """Ensure located headers follow sequential numbering when possible."""
+
+    if tracer:
+        tracer.log_call(f"{__name__}._enforce_header_sequence")
 
     if not headers:
         return [], []

--- a/backend/services/headers_sequential.py
+++ b/backend/services/headers_sequential.py
@@ -394,6 +394,9 @@ def build_top_level_windows(
     toc_pages: set[int],
     tracer: HeaderTracer | None = None,
 ) -> Dict[str, Tuple[int, int, int]]:
+    if tracer:
+        tracer.log_call(f"{__name__}.build_top_level_windows")
+
     anchors: Dict[str, int] = {}
     cursor_idx = -1
     pos_map = page_positions(lines)
@@ -504,6 +507,9 @@ def find_in_window(
     pos_map: Optional[Dict[int, Dict[int, int]]] = None,
     cursor_idx: Optional[int] = None,
 ) -> Optional[int]:
+    if tracer:
+        tracer.log_call(f"{__name__}.find_in_window")
+
     re_num = compile_number_regex(target.num)
     want = normalize(f"{target.num} {target.title}", confusables=confusables)
     best: Optional[Tuple[int, int]] = None
@@ -882,6 +888,9 @@ def align_headers_sequential(
     tracer: HeaderTracer | None = None,
 ) -> List[Dict]:
     """Return aligned headers with positional metadata using sequential search."""
+
+    if tracer:
+        tracer.log_call(f"{__name__}.align_headers_sequential")
 
     lines: List[Line] = []
     for raw in lines_input:

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -111,6 +111,9 @@ async def get_headers_llm_full(
 ) -> LLMFullHeadersResult:
     """Return LLM extracted headers for a document."""
 
+    if tracer is not None:
+        tracer.log_call(f"{__name__}.get_headers_llm_full")
+
     cache_file = _cache_path(settings.headers_llm_cache_dir, doc_hash)
     if cache_file.exists():
         cached = json.loads(cache_file.read_text(encoding="utf-8"))

--- a/backend/services/pdf_native.py
+++ b/backend/services/pdf_native.py
@@ -513,6 +513,9 @@ def collect_line_metrics(
 ) -> tuple[list[dict], set[int], str]:
     """Return flattened line metrics for the provided PDF bytes."""
 
+    if tracer:
+        tracer.log_call(f"{__name__}.collect_line_metrics")
+
     doc_hash = hashlib.sha256(document_bytes).hexdigest()
     excluded_pages: set[int] = set()
     header_counter: Counter[str] = Counter()

--- a/backend/tests/test_header_trace.py
+++ b/backend/tests/test_header_trace.py
@@ -27,6 +27,7 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
 
     def _fake_collect(document_bytes, *_args, tracer=None, **_kwargs):  # noqa: ANN001
         if tracer is not None:
+            tracer.log_call("backend.services.pdf_native.collect_line_metrics")
             tracer.ev(
                 "pre_normalize_sample",
                 page=0,
@@ -38,6 +39,7 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
         tracer = _kwargs.get("tracer")
         if tracer is not None:
+            tracer.log_call("backend.services.pdf_headers_llm_full.get_headers_llm_full")
             tracer.ev(
                 "llm_request",
                 part=1,
@@ -109,6 +111,25 @@ def test_header_trace_enabled(monkeypatch, tmp_path) -> None:
         "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
     ]
     assert summary["final_outline"]["headers"]
+    call_names = [entry["name"] for entry in summary["function_calls"]]
+    assert call_names[0] == "backend.services.headers_orchestrator.extract_headers_and_chunks"
+    assert (
+        call_names.index("backend.services.pdf_native.collect_line_metrics")
+        > call_names.index("backend.services.headers_orchestrator.extract_headers_and_chunks")
+    )
+    assert (
+        call_names.index("backend.services.pdf_headers_llm_full.get_headers_llm_full")
+        > call_names.index("backend.services.pdf_native.collect_line_metrics")
+    )
+    assert (
+        call_names.index("backend.services.header_locator.locate_headers_in_lines")
+        > call_names.index("backend.services.pdf_headers_llm_full.get_headers_llm_full")
+    )
+    assert "backend.services.headers_sequential.align_headers_sequential" in call_names
+    assert (
+        call_names.index("backend.services.headers_orchestrator._enforce_header_sequence")
+        > call_names.index("backend.services.header_locator.locate_headers_in_lines")
+    )
 
 
 def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
@@ -128,6 +149,7 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
 
     def _fake_collect(document_bytes, *_args, tracer=None, **_kwargs):  # noqa: ANN001
         if tracer is not None:
+            tracer.log_call("backend.services.pdf_native.collect_line_metrics")
             tracer.ev(
                 "pre_normalize_sample",
                 page=0,
@@ -139,6 +161,7 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
     async def _fake_llm(*_args, **_kwargs):  # noqa: ANN001
         tracer = _kwargs.get("tracer")
         if tracer is not None:
+            tracer.log_call("backend.services.pdf_headers_llm_full.get_headers_llm_full")
             tracer.ev(
                 "llm_request",
                 part=1,
@@ -186,6 +209,9 @@ def test_header_trace_summary_created_by_default(monkeypatch, tmp_path) -> None:
         "-----BEGIN SIMPLEHEADERS JSON-----\n{\"headers\": []}\n-----END SIMPLEHEADERS JSON-----"
     ]
     assert summary["final_outline"]["headers"][0]["text"] == "Intro"
+    call_names = [entry["name"] for entry in summary["function_calls"]]
+    assert call_names[0] == "backend.services.headers_orchestrator.extract_headers_and_chunks"
+    assert "backend.services.header_locator.locate_headers_in_lines" in call_names
     assert payload["headers"]
 
 

--- a/backend/utils/trace.py
+++ b/backend/utils/trace.py
@@ -36,6 +36,11 @@ class HeaderTracer:
     def ev(self, event_type: str, **data: Any) -> None:
         self.events.append(TraceEvent(t=time.time(), type=event_type, data=data))
 
+    def log_call(self, name: str, **context: Any) -> None:
+        """Record an invocation of *name* preserving call order."""
+
+        self.ev("function_call", name=name, **context)
+
     def flush_jsonl(self) -> str:
         with open(self._path, "w", encoding="utf-8") as handle:
             for event in self.events:
@@ -69,6 +74,7 @@ class HeaderTracer:
         final_outline: Dict[str, Any] = {}
         decisions: List[Dict[str, Any]] = []
         elapsed: float | None = None
+        function_calls: List[Dict[str, Any]] = []
 
         decision_types = {
             "candidate_found",
@@ -128,6 +134,19 @@ class HeaderTracer:
                 if elapsed is None:
                     elapsed = event.get("elapsed_s")
                 final_outline.setdefault("mode", event.get("mode"))
+            elif event_type == "function_call":
+                call_entry: Dict[str, Any] = {
+                    "order": len(function_calls) + 1,
+                    "name": str(event.get("name", "")),
+                }
+                context = {
+                    key: value
+                    for key, value in event.items()
+                    if key not in {"t", "type", "name"}
+                }
+                if context:
+                    call_entry["context"] = context
+                function_calls.append(call_entry)
 
             if event_type in decision_types:
                 decisions.append(event)
@@ -142,6 +161,7 @@ class HeaderTracer:
             "decisions": decisions,
             "final_outline": final_outline,
             "elapsed_s": elapsed,
+            "function_calls": function_calls,
         }
 
 


### PR DESCRIPTION
## Summary
- add a HeaderTracer.log_call helper and expose ordered function call data in header search summaries
- instrument the header orchestration pipeline and related helpers to record call events during header searches
- extend header trace tests to cover the new call logging and ordering expectations

## Testing
- pytest backend/tests/test_header_trace.py

------
https://chatgpt.com/codex/tasks/task_e_6908cb0b661083248eb732d04a3008bb