### PR TITLE
Refine header extraction API flow

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -11,6 +12,7 @@ from sqlmodel import Session, select
 from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import Document, DocumentSection
+from ..services.artifact_store import get_or_create_parse_result
 from ..services.header_match import find_header_occurrences
 from ..services.headers import (
     HeadersLLMClient,
@@ -22,10 +24,11 @@ from ..services.headers_llm_simple import (
     InvalidLLMJSONError,
     get_headers_llm_json,
 )
-from ..services.headers_orchestrator import extract_headers_and_chunks
-from ..services.artifact_store import get_or_create_parse_result
+from ..services.headers_orchestrator import (
+    extract_headers_and_chunks as orchestrate_headers_and_chunks,
+)
 from ..services.pdf_native import parse_pdf
-from ..services.sections import build_and_store_sections
+from ..services.sections import build_and_store_sections, delete_sections_for_document
 from ..services.simpleheaders_state import SimpleHeadersState
 
 router = APIRouter(prefix="/api", tags=["headers"])
@@ -36,10 +39,33 @@ async def compute_headers(
     document_id: int,
     *,
     trace: bool = Query(False, description="Return inline trace events when available"),
+    force: bool = Query(
+        False,
+        description="Force new LLM headers; purge prior headers/sections and bypass caches.",
+    ),
     session: Session = Depends(get_session),
     settings: Settings = Depends(get_settings),
 ):
     """Return LLM-provided headers and alignment matches for ``document_id``."""
+
+    return await extract_headers_and_chunks(
+        document_id=document_id,
+        settings=settings,
+        session=session,
+        force=force,
+        trace=trace,
+    )
+
+
+async def extract_headers_and_chunks(
+    *,
+    document_id: int,
+    settings: Settings,
+    session: Session,
+    force: bool = False,
+    trace: bool = False,
+) -> Dict[str, Any] | JSONResponse:
+    """Core header extraction workflow shared by routers and tests."""
 
     document = session.get(Document, document_id)
     if document is None:
@@ -53,6 +79,16 @@ async def compute_headers(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Document is missing a primary key",
         )
+
+    doc_id = int(document.id)
+
+    if force:
+        try:
+            delete_sections_for_document(session=session, document_id=doc_id)
+        except Exception:
+            # Deletion failures should not block a re-run.
+            pass
+        SimpleHeadersState.clear(doc_id)
 
     use_simple_llm = (
         settings.headers_mode.lower() == "llm_simple"
@@ -72,7 +108,6 @@ async def compute_headers(
         )
         return {"llm_headers": llm_obj.get("headers", []), "matches": matches}
 
-    doc_id = int(document.id)
     document_path = settings.upload_dir / str(doc_id) / document.filename
     if not document_path.exists():
         raise HTTPException(
@@ -108,13 +143,13 @@ async def compute_headers(
     native_headers = flatten_outline(header_result.outline)
 
     document_bytes = document_path.read_bytes()
-    orchestrator_impl = extract_headers_and_chunks
+    orchestrator_impl = orchestrate_headers_and_chunks
     if headers_router is not None:
         orchestrator_impl = getattr(
-            headers_router, "extract_headers_and_chunks", extract_headers_and_chunks
+            headers_router, "extract_headers_and_chunks", orchestrate_headers_and_chunks
         )
 
-    orchestrator_kwargs = {
+    orchestrator_kwargs: Dict[str, Any] = {
         "settings": settings,
         "native_headers": native_headers,
         "metadata": {
@@ -124,6 +159,7 @@ async def compute_headers(
         "session": session,
         "document": document,
         "want_trace": trace,
+        "force": force,
     }
     accepted_params = set(inspect.signature(orchestrator_impl).parameters)
     for key in list(orchestrator_kwargs.keys()):
@@ -347,4 +383,4 @@ def section_text(
     return PlainTextResponse("\n".join(text_lines))
 
 
-__all__ = ["router"]
+__all__ = ["router", "extract_headers_and_chunks"]

--- a/backend/routers/headers.py
+++ b/backend/routers/headers.py
@@ -1,43 +1,77 @@
-"""Headers router that adds `force` semantics to Start Header Search.
-
-This module replaces the previous compat shim by defining the /api/headers/{document_id}
-route itself and threading a `force` flag into the underlying implementation.
-On force:
-  - previously stored sections/state for the document are purged
-  - any on-disk LLM cache (if a helper is available) is purged
-  - the orchestrator is invoked with cache-bypass semantics
-"""
+"""Compatibility router that delegates to :mod:`backend.api.headers`."""
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel import Session
 
-# The existing implementation lives under backend/api/headers.py
 from ..api import headers as headers_api
+from ..config import Settings, get_settings
 from ..database import get_session
-
-# Optional purge helpers — if these modules/functions don't exist yet,
-# the no-op fallbacks keep this router backward compatible.
-try:
-    from ..services.sections import delete_sections_for_document  # type: ignore
-except Exception:  # pragma: no cover
-    def delete_sections_for_document(session: Session, document_id: int) -> None:  # type: ignore
-        return None
-
-try:
-    from ..services.state import reset_simple_headers_state  # type: ignore
-except Exception:  # pragma: no cover
-    def reset_simple_headers_state(session: Session, document_id: int) -> None:  # type: ignore
-        return None
+from ..services.headers import HeadersLLMClient as HeadersLLMClientImpl
+from ..services.headers_orchestrator import (
+    extract_headers_and_chunks as orchestrator_extract_headers_and_chunks,
+)
+from ..services.pdf_native import parse_pdf as parse_pdf_impl
 
 router = APIRouter(prefix="/api", tags=["headers"])
 
 
+async def _call_extract_headers_and_chunks(
+    *,
+    document_id: int,
+    session: Session,
+    settings: Settings,
+    force: bool,
+) -> Any:
+    """Call into ``backend.api.headers.extract_headers_and_chunks`` safely."""
+
+    func = getattr(headers_api, "extract_headers_and_chunks", None)
+    if not callable(func):
+        raise HTTPException(status_code=500, detail="Header extraction unavailable")
+
+    signature = inspect.signature(func)
+    params = signature.parameters
+
+    kwargs: Dict[str, Any] = {}
+
+    if "document_id" in params:
+        kwargs["document_id"] = document_id
+    elif "doc_id" in params:
+        kwargs["doc_id"] = document_id
+    elif "id" in params:
+        kwargs["id"] = document_id
+
+    if "settings" in params:
+        kwargs["settings"] = settings
+    if "session" in params:
+        kwargs["session"] = session
+    if "force" in params:
+        kwargs["force"] = force
+
+    # Trace support is optional; only pass when accepted.
+    if "trace" in params:
+        kwargs.setdefault("trace", False)
+
+    try:
+        if not any(name in params for name in ("document_id", "doc_id", "id")):
+            result = func(document_id, **kwargs)  # type: ignore[misc]
+        else:
+            result = func(**kwargs)
+    except TypeError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=f"Header extraction failed: {exc}") from exc
+
+    if inspect.isawaitable(result):
+        result = await result
+
+    return result
+
+
 @router.post("/headers/{document_id}")
-def compute_headers(
+async def compute_headers(
     document_id: int,
     *,
     force: bool = Query(
@@ -45,57 +79,31 @@ def compute_headers(
         description="Force new LLM headers; purge prior headers/sections and bypass caches.",
     ),
     session: Session = Depends(get_session),
-) -> Dict[str, Any]:
-    """Compute headers for a document.
+    settings: Settings = Depends(get_settings),
+):
+    """Forward the request to :func:`backend.api.headers.extract_headers_and_chunks`."""
 
-    If `force` is true, this will wipe prior header storage for the document
-    and force a fresh LLM header extraction (skipping any caches).
-    """
     if force:
-        # 1) Purge previously persisted artifacts for this document.
-        # These are safe to call even if there were no prior runs.
-        try:
-            delete_sections_for_document(session=session, document_id=document_id)
-        except Exception:
-            # Purge errors shouldn't block a new run.
-            pass
-
-        try:
-            reset_simple_headers_state(session=session, document_id=document_id)
-        except Exception:
-            pass
-
-        # 2) Optionally purge on-disk LLM cache if the api module exposes a helper.
-        # This is best-effort and will silently continue on failure.
-        try:
-            purge_cache = getattr(headers_api, "purge_llm_cache_for_document", None)
-            if callable(purge_cache):
+        purge_cache = getattr(headers_api, "purge_llm_cache_for_document", None)
+        if callable(purge_cache):
+            try:
                 purge_cache(document_id)
-        except Exception:
-            pass
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
 
-        # 3) Delegate to the existing API function: it takes (document_id[, force])
-    try:
-        # Newer implementations may support a 'force' kwarg; pass it when available.
-        result = headers_api.extract_headers_and_chunks(document_id, force=force)  # type: ignore[call-arg]
-    except TypeError:
-        # Older signature without 'force'
-        result = headers_api.extract_headers_and_chunks(document_id)  # type: ignore[misc]
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Header extraction failed: {exc}") from exc
+    result = await _call_extract_headers_and_chunks(
+        document_id=document_id,
+        session=session,
+        settings=settings,
+        force=force,
+    )
 
-
-    if not result:
-        raise HTTPException(status_code=500, detail="Header extraction returned no result")
     return result
 
 
-# ---- Test patch points / public API compatibility --------------------------
-
-# Keep these available for tests and external imports
-parse_pdf = headers_api.parse_pdf
-extract_headers_and_chunks = headers_api.extract_headers_and_chunks
-HeadersLLMClient = headers_api.HeadersLLMClient
+parse_pdf = parse_pdf_impl
+extract_headers_and_chunks = orchestrator_extract_headers_and_chunks
+HeadersLLMClient = HeadersLLMClientImpl
 
 __all__ = [
     "router",
@@ -104,3 +112,4 @@ __all__ = [
     "extract_headers_and_chunks",
     "HeadersLLMClient",
 ]
+

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -228,6 +228,7 @@ async def extract_headers_and_chunks(
                 settings=settings,
                 excluded_pages=excluded_pages,
                 tracer=tracer,
+                force=force,
             )
             llm_headers = llm_result.headers or []
             llm_raw_responses = list(llm_result.raw_responses)

--- a/backend/services/simpleheaders_state.py
+++ b/backend/services/simpleheaders_state.py
@@ -28,4 +28,15 @@ class SimpleHeadersState:
         return value
 
 
+    @classmethod
+    def clear(cls, document_id: int | None = None) -> None:
+        """Remove cached state for ``document_id`` or clear all entries."""
+
+        if document_id is None:
+            cls._store.clear()
+            return
+
+        cls._store.pop(document_id, None)
+
+
 __all__ = ["SimpleHeadersState"]

--- a/backend/tests/test_headers_api_process.py
+++ b/backend/tests/test_headers_api_process.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+import types
+
+from sqlmodel import Session
+
+from backend.api import headers as headers_api
+from backend.config import get_settings, reset_settings_cache
+from backend.database import get_engine, init_db, reset_database_state
+from backend.models.document import Document
+from backend.services.headers import HeaderExtractionResult, HeaderNode
+from backend.services.simpleheaders_state import SimpleHeadersState
+
+
+def test_extract_headers_and_chunks_force_refresh(monkeypatch, tmp_path):
+    """The API helper should honour the end-to-end header extraction process."""
+
+    monkeypatch.setenv("HEADERS_MODE", "llm_full")
+    db_path = tmp_path / "test.db"
+    upload_dir = tmp_path / "uploads"
+    export_dir = tmp_path / "exports"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("EXPORT_DIR", str(export_dir))
+    monkeypatch.setenv("EXPORT_RETENTION_DAYS", "1")
+    monkeypatch.setenv("MAX_UPLOAD_SIZE", "1024")
+    reset_settings_cache()
+    reset_database_state()
+
+    settings = get_settings()
+    init_db()
+
+    engine = get_engine()
+    with Session(engine) as setup_session:
+        document = Document(filename="doc.pdf", checksum="abc123")
+        setup_session.add(document)
+        setup_session.commit()
+        setup_session.refresh(document)
+        document_id = int(document.id or 0)
+
+    document_dir = settings.upload_dir / str(document_id)
+    document_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = document_dir / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%EOF")
+
+    SimpleHeadersState.set(document_id, "stale-hash", [{"global_idx": 999}])
+
+    delete_called: list[int] = []
+
+    def _fake_delete_sections(session, document_id: int) -> None:  # noqa: ANN001
+        delete_called.append(document_id)
+
+    monkeypatch.setattr(
+        "backend.api.headers.delete_sections_for_document",
+        _fake_delete_sections,
+    )
+
+    parse_result = object()
+    monkeypatch.setattr(
+        "backend.api.headers.get_or_create_parse_result",
+        lambda **kwargs: (parse_result, False),
+    )
+
+    header_outline = [HeaderNode(title="Intro", numbering="1", page=0)]
+    header_result = HeaderExtractionResult(
+        outline=header_outline,
+        fenced_text="#headers#\n#/headers#",
+        source="openrouter",
+        messages=["outline message"],
+    )
+
+    monkeypatch.setattr(
+        "backend.api.headers.extract_headers",
+        lambda *args, **kwargs: header_result,
+    )
+
+    section_stub = types.SimpleNamespace(
+        section_key="sec-1",
+        title="Intro",
+        number="1",
+        level=1,
+        start_global_idx=0,
+        end_global_idx=2,
+        start_page=0,
+        end_page=0,
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_build_and_store_sections(
+        *,
+        session,
+        document_id: int,
+        simpleheaders,
+        lines,
+    ):  # noqa: ANN001
+        captured["simpleheaders"] = list(simpleheaders)
+        captured["lines"] = list(lines)
+        return [section_stub]
+
+    monkeypatch.setattr(
+        "backend.api.headers.build_and_store_sections",
+        _fake_build_and_store_sections,
+    )
+
+    class DummyTracer:
+        path = "trace.jsonl"
+        summary_path = "trace.summary.json"
+
+        def as_list(self):  # noqa: ANN201
+            return []
+
+        def log_call(self, *args, **kwargs):  # noqa: ANN201
+            return None
+
+        def ev(self, *args, **kwargs):  # noqa: ANN201
+            return None
+
+    async def _fake_orchestrator(
+        document_bytes: bytes,
+        *,
+        settings,
+        native_headers,
+        metadata,
+        session,
+        document,
+        want_trace=False,
+        force=False,
+    ):  # noqa: ANN001
+        captured["force"] = force
+        captured["metadata"] = metadata
+        return (
+            {
+                "headers": [
+                    {
+                        "text": "Intro",
+                        "number": "1",
+                        "level": 1,
+                        "page": 0,
+                        "line_idx": 0,
+                        "global_idx": 0,
+                    }
+                ],
+                "sections": [
+                    {
+                        "header_text": "Intro",
+                        "header_number": "1",
+                        "level": 1,
+                        "start_global_idx": 0,
+                        "end_global_idx": 2,
+                        "start_page": 0,
+                        "end_page": 0,
+                    }
+                ],
+                "mode": "llm_full",
+                "messages": ["orchestrator message"],
+                "fenced_text": "#headers#\n#/headers#",
+                "doc_hash": "fresh-hash",
+                "excluded_pages": [],
+                "llm_headers": [
+                    {"text": "Intro", "number": "1", "level": 1, "page": 0}
+                ],
+                "llm_raw_responses": ["raw-response"],
+                "llm_fenced_blocks": ["block"],
+                "lines": [
+                    {"text": "Intro", "page": 0, "line_idx": 0, "global_idx": 0},
+                    {"text": "Body", "page": 0, "line_idx": 1, "global_idx": 1},
+                ],
+            },
+            DummyTracer(),
+        )
+
+    monkeypatch.setattr(
+        "backend.api.headers.orchestrate_headers_and_chunks",
+        _fake_orchestrator,
+    )
+    monkeypatch.setattr(
+        "backend.routers.headers.extract_headers_and_chunks",
+        _fake_orchestrator,
+    )
+
+    async def _run() -> dict:
+        with Session(engine) as session:
+            return await headers_api.extract_headers_and_chunks(
+                document_id=document_id,
+                settings=settings,
+                session=session,
+                force=True,
+                trace=False,
+            )
+
+    response = asyncio.run(_run())
+
+    assert delete_called == [document_id]
+    assert captured["force"] is True
+    assert captured["metadata"] == {"filename": "doc.pdf", "document_id": document_id}
+
+    cached = SimpleHeadersState.get(document_id)
+    assert cached is not None
+    cache_hash, cache_lines = cached
+    assert cache_hash == "fresh-hash"
+    assert len(cache_lines) == 2
+
+    assert response["llm_raw_responses"] == ["raw-response"]
+    assert response["simpleheaders"][0]["page"] == 0
+    assert response["sections"][0]["header_text"] == "Intro"
+    assert response["doc_hash"] == "fresh-hash"
+    assert "outline message" in response["messages"]
+    assert "orchestrator message" in response["messages"]
+


### PR DESCRIPTION
## Summary
- centralize the `/api/headers/{document_id}` logic in `backend.api.headers.extract_headers_and_chunks`, wiring `force` support, cache resets, and orchestrator delegation
- update the headers router to dynamically adapt to the API helper signature while re-exporting the orchestrator/parsing hooks for tests
- ensure the orchestrator propagates the `force` flag to the full LLM extractor, extend the in-memory state helper, and add coverage for the new flow

## Testing
- pytest backend/tests/test_headers_api_process.py backend/tests/test_headers_orchestrator.py tests/test_headers_llm_simple.py -q

------
https://chatgpt.com/codex/tasks/task_e_6908e4f0bed08324bf8bb9dd305d4fe7