### PR TITLE
Persist rerun specs and load cached document data

### DIFF
--- a/backend/routers/specs.py
+++ b/backend/routers/specs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlmodel import Session
@@ -292,7 +292,7 @@ async def export_spec_record_endpoint(
 # ---- RERUN SPECS SUPPORT ----------------------------------------------------
 
 
-@router.delete("/specs/{document_id}/buckets", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/specs/{document_id}/buckets", response_class=Response)
 async def delete_spec_buckets(
     document_id: int,
     *,
@@ -309,7 +309,7 @@ async def delete_spec_buckets(
         )
 
     wipe_spec_buckets_for_document(session, document_id=document_id)
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 __all__ = ["router"]

--- a/backend/routers/specs_buckets.py
+++ b/backend/routers/specs_buckets.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlmodel import Session
 
 try:
@@ -23,6 +23,10 @@ try:
         get_cached_artifact, store_artifact
     )
     from backend.services.artifact_store import delete_artifact as _delete_artifact  # optional in older revs
+    from backend.services.spec_records import (
+        store_spec_buckets_result,
+        wipe_spec_buckets_for_document,
+    )
     from backend.services.specs_worker import (
         run_all_buckets_concurrently,
         BUCKET_ARTIFACT_KEY,
@@ -39,6 +43,10 @@ except Exception:
         BUCKET_ARTIFACT_KEY,
         SPEC_BUCKET_ARTIFACT_TYPE,
     )  # type: ignore
+    from backend.services.spec_records import (  # type: ignore
+        store_spec_buckets_result,
+        wipe_spec_buckets_for_document,
+    )
 
     def get_document_or_404(session: Session, document_id: int) -> Document:  # type: ignore
         from backend.models import Document  # type: ignore
@@ -59,7 +67,7 @@ def _artifact_inputs(doc_hash: str | None = None) -> Dict[str, Any]:
     return inputs
 
 
-@router.delete("/{document_id}/buckets", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{document_id}/buckets", response_class=Response)
 def delete_buckets_cache(
     document_id: int,
     session: Session = Depends(get_session),
@@ -71,6 +79,12 @@ def delete_buckets_cache(
     """
     doc = get_document_or_404(session, document_id)
 
+    # Clear any persisted spec record payload before wiping cached artifacts.
+    try:
+        wipe_spec_buckets_for_document(session, document_id=document_id)
+    except Exception:
+        pass
+
     # Fetch a doc_hash if you store it on Document; otherwise skip (inputs filter remains generic).
     doc_hash = getattr(doc, "doc_hash", None) or getattr(doc, "hash", None)
 
@@ -78,7 +92,7 @@ def delete_buckets_cache(
     try:
         _ = _delete_artifact  # type: ignore[name-defined]
     except Exception:
-        return  # older artifact store without delete; nothing to do
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     try:
         _delete_artifact(
@@ -90,7 +104,8 @@ def delete_buckets_cache(
         )
     except Exception:
         # swallow; we only want to make "Run again" never crash
-        return
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post("/{document_id}/buckets/run-again")
@@ -111,6 +126,12 @@ async def run_again(
 
     # Resolve document and run the worker
     doc = get_document_or_404(session, document_id)
+
+    # Ensure any previous spec payload is cleared so the new run stores a fresh draft.
+    try:
+        wipe_spec_buckets_for_document(session, document_id=document_id)
+    except Exception:
+        pass
     # Expect PDFs to already be parsed/available on disk; we only need the text content.
     # The worker will fetch the parsed text (via artifact store) or re-parse if necessary.
     result = await run_all_buckets_concurrently(
@@ -133,4 +154,24 @@ async def run_again(
         # Do not fail the request just because caching failed.
         pass
 
-    return {"ok": True, **result}
+    stored_record = None
+    try:
+        stored_record = store_spec_buckets_result(
+            session,
+            document_id=document_id,
+            payload=result,
+        )
+    except Exception:
+        pass
+
+    response: Dict[str, Any] = {"ok": True, **result, "persisted": stored_record is not None}
+    if stored_record is not None:
+        response["record"] = {
+            "id": stored_record.id,
+            "state": stored_record.state,
+            "updated_at": stored_record.updated_at.isoformat()
+            if stored_record.updated_at
+            else None,
+        }
+
+    return response

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from typing import Iterable, Mapping, Sequence
@@ -55,6 +56,27 @@ def _format_llm_failure(exc: Exception) -> str:
     return "LLM header extraction unavailable."
 
 
+def _run_section_chunking(headers, lines, *, tracer):
+    """Call :func:`single_chunks_from_headers` tolerating older signatures."""
+
+    try:
+        return single_chunks_from_headers(headers, lines, tracer=tracer)
+    except TypeError:
+        return single_chunks_from_headers(headers, lines)
+
+
+def _persist_trace(tracer: HeaderTracer, *, write_trace_json: bool) -> str | None:
+    """Persist tracer outputs and return the trace path when written."""
+
+    if write_trace_json:
+        return tracer.flush_jsonl()
+
+    summary_payload = tracer._build_summary()  # noqa: SLF001 - internal helper
+    with open(tracer.summary_path, "w", encoding="utf-8") as handle:
+        json.dump(summary_payload, handle, ensure_ascii=False, indent=2)
+    return None
+
+
 async def extract_headers_and_chunks(
     document_bytes: bytes,
     *,
@@ -76,10 +98,10 @@ async def extract_headers_and_chunks(
     LLM extraction/alignment is performed.
     """
 
-    trace_requested = want_trace or settings.headers_trace or app_config.HEADERS_TRACE
+    write_trace_json = bool(want_trace or settings.headers_trace or app_config.HEADERS_TRACE)
     align_strategy = (align or settings.headers_align_strategy).strip().lower()
     sequential_config = SequentialAlignmentConfig.from_settings(settings)
-    tracer: HeaderTracer | None = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR) if trace_requested else None
+    tracer: HeaderTracer | None = HeaderTracer(out_dir=app_config.HEADERS_TRACE_DIR)
     if tracer:
         tracer.log_call(f"{__name__}.extract_headers_and_chunks")
 
@@ -205,8 +227,9 @@ async def extract_headers_and_chunks(
                         mode="cache",
                         doc_hash=doc_hash,
                     )
-                    tracer.flush_jsonl()
-                    LOGGER.info("[headers] Trace written: %s", tracer.path)
+                    trace_path = _persist_trace(tracer, write_trace_json=write_trace_json)
+                    if trace_path:
+                        LOGGER.info("[headers] Trace written: %s", trace_path)
                     LOGGER.info("[headers] Summary written: %s", tracer.summary_path)
 
                 trace_payload = _trace_payload(tracer)
@@ -285,7 +308,7 @@ async def extract_headers_and_chunks(
                         excluded_pages=excluded_pages,
                         tracer=tracer,
                         doc_hash=doc_hash,
-                        write_trace_json=trace_requested,
+                        write_trace_json=write_trace_json,
                     )
                     if located_headers:
                         mode_used = "llm_vector"
@@ -419,8 +442,9 @@ async def extract_headers_and_chunks(
             mode=mode_used,
             doc_hash=doc_hash,
         )
-        trace_path = tracer.flush_jsonl()
-        LOGGER.info("[headers] Trace written: %s", trace_path)
+        trace_path = _persist_trace(tracer, write_trace_json=write_trace_json)
+        if trace_path:
+            LOGGER.info("[headers] Trace written: %s", trace_path)
         LOGGER.info("[headers] Summary written: %s", tracer.summary_path)
 
     trace_payload = _trace_payload(tracer)
@@ -511,7 +535,7 @@ def _enforce_header_sequence(
     working_headers.sort(key=_order_key)
 
     # Build the initial sections (trace will include 'chunking_start'/'chunk_built' events).
-    sections = single_chunks_from_headers(working_headers, lines, tracer=tracer)
+    sections = _run_section_chunking(working_headers, lines, tracer=tracer)
 
     # -------- Gap fill using numbering (does not change global ordering rule) --------
     iteration = 0
@@ -572,7 +596,7 @@ def _enforce_header_sequence(
             working_headers.insert(insert_position, candidate)
 
             # Recompute sections with the updated list (trace emits chunk events again).
-            sections = single_chunks_from_headers(working_headers, lines, tracer=tracer)
+            sections = _run_section_chunking(working_headers, lines, tracer=tracer)
             inserted = True
 
             if tracer:
@@ -594,7 +618,7 @@ def _enforce_header_sequence(
 
         # Important: re-apply ONLY the LLM-first ordering, never number-based.
         working_headers.sort(key=_order_key)
-        sections = single_chunks_from_headers(working_headers, lines, tracer=tracer)
+        sections = _run_section_chunking(working_headers, lines, tracer=tracer)
     # -------------------------------------------------------------------------------
 
     # Final ordering and cleanup.

--- a/backend/services/spec_records.py
+++ b/backend/services/spec_records.py
@@ -18,8 +18,6 @@ from sqlmodel import Session, select
 from ..config import Settings
 from ..middleware import get_request_id
 from ..models import Document, SpecAuditEntry, SpecRecord
-from sqlmodel import select
-from ..models import SpecRecord
 # If you have an artifact store for buckets, import its delete helper:
 # from .artifact_store import delete_artifact, DocumentArtifactType
 
@@ -321,43 +319,69 @@ __all__ = [
     "ensure_document",
     "export_spec_record",
     "fetch_spec_record",
+    "store_spec_buckets_result",
+    "wipe_spec_buckets_for_document",
 ]
 
-def wipe_spec_buckets_for_document(session, *, document_id: int) -> None:
-    """
-    Clear any persisted specification state for a document so a fresh
-    LLM extraction will run on the next request.
 
-    - Resets (or creates) a SpecRecord to a clean draft with empty payload.
-    - Optionally deletes any cached bucket artifacts (uncomment if you use them).
-    """
+def wipe_spec_buckets_for_document(session, *, document_id: int) -> None:
+    """Reset any persisted specification payload for ``document_id`` to a clean draft."""
+
     rec = session.exec(
         select(SpecRecord).where(SpecRecord.document_id == document_id)
     ).first()
 
     if rec is None:
-        # If your app expects a record to exist, you could create one here.
-        # Otherwise just no-op.
         return
 
+    now = datetime.now(UTC)
     rec.state = "draft"
     rec.reviewer = None
     rec.content_hash = None
-    rec.payload = {}  # wipe frozen/spec payload
+    rec.payload = {}
     rec.approved_at = None
     rec.frozen_at = None
+    rec.updated_at = now
     session.add(rec)
+    session.commit()
 
-    # If you persist bucket artifacts separately, delete them here.
-    # try:
-    #     delete_artifact(
-    #         session,
-    #         document_id=document_id,
-    #         artifact_type=DocumentArtifactType.SPEC_BUCKETS,
-    #         key="buckets",
-    #     )
-    # except Exception:
-    #     # Don't fail the wipe on artifact deletion issues.
-    #     pass
+
+def store_spec_buckets_result(
+    session: Session, *, document_id: int, payload: Any
+) -> SpecRecord:
+    """Persist the latest specification buckets payload for a document as a draft."""
+
+    document = ensure_document(session, document_id)
+    data = _serialise_payload(payload)
+    now = datetime.now(UTC)
+
+    rec = session.exec(
+        select(SpecRecord).where(SpecRecord.document_id == document.id)
+    ).first()
+
+    if rec is None:
+        rec = SpecRecord(
+            document_id=document.id,
+            state="draft",
+            reviewer=None,
+            created_at=now,
+            updated_at=now,
+            approved_at=None,
+            frozen_at=None,
+            content_hash=None,
+            payload=data,
+        )
+        session.add(rec)
+    else:
+        rec.state = "draft"
+        rec.reviewer = None
+        rec.approved_at = None
+        rec.frozen_at = None
+        rec.content_hash = None
+        rec.payload = data
+        rec.updated_at = now
+        session.add(rec)
 
     session.commit()
+    session.refresh(rec)
+    return rec

--- a/frontend/static/js/api.js
+++ b/frontend/static/js/api.js
@@ -231,6 +231,10 @@ export async function fetchSpecifications(documentId) {
 export async function compareSpecifications(documentId) {
   return request(`/api/specs/compare/${documentId}`, { method: "POST" });
 }
+
+export async function fetchCachedHeaders(documentId) {
+  return request(`/api/documents/${documentId}/headers`);
+}
 // Wipe all stored/spec-cached buckets for a document on the server
 export async function deleteSpecsBuckets(documentId) {
   if (!Number.isFinite(Number(documentId))) {

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -10,6 +10,7 @@ import {
   uploadDocument,
   parseDocument,
   fetchHeaders,
+  fetchCachedHeaders,
   fetchSectionText,
   fetchSpecifications,
   compareSpecifications,
@@ -100,6 +101,16 @@ function deriveHeaderMatches(payload) {
       };
     })
     .filter((entry) => entry.text);
+}
+
+function normaliseHeadersForUi(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+  if (!Array.isArray(payload.simpleheaders) && Array.isArray(payload.headers)) {
+    return { ...payload, simpleheaders: payload.headers };
+  }
+  return payload;
 }
 
 // Helper: update the header mode tag based on a mode string
@@ -231,13 +242,33 @@ elements.approveSpecs?.addEventListener('click', () => {
 // Listen for custom event from specs_patch.js to update the UI when buckets are re-run.
 window.addEventListener('specs:buckets:updated', (event) => {
   // Reset approval state and update specs
+  const detail = event.detail ?? {};
   state.approvedLines.clear();
   state.specRecord = null;
-  state.specs = event.detail;
+  state.specs = detail;
+  state.specsSearchAttempted = true;
   state.approvalLoading = false;
   renderSpecsView();
   updateApprovalUI();
   showToast('Specification buckets reloaded from scratch.');
+  setSpecsSearchBusy(false);
+  if (state.selectedId) {
+    void (async () => {
+      try {
+        const refreshedRecord = await fetchSpecRecord(state.selectedId);
+        state.specRecord = refreshedRecord;
+        const refreshedPayload = refreshedRecord?.record?.payload ?? null;
+        if (refreshedPayload && typeof refreshedPayload === 'object') {
+          state.specs = refreshedPayload;
+          renderSpecsView();
+        }
+      } catch (error) {
+        console.error('[Specs] Unable to refresh spec record after rerun:', error);
+      } finally {
+        updateApprovalUI();
+      }
+    })();
+  }
 });
 
 // Busy state helpers for header search & specs search
@@ -394,10 +425,16 @@ async function selectDocument(documentId) {
   setApprovalStatus('Loading approval status…', 'muted');
   updateApprovalUI({ busy: true });
   try {
-    const [parseResult, riskResult, recordResult] = await Promise.allSettled([
+    const [
+      parseResult,
+      riskResult,
+      recordResult,
+      cachedHeadersResult,
+    ] = await Promise.allSettled([
       parseDocument(documentId),
       compareSpecifications(documentId),
       fetchSpecRecord(documentId),
+      fetchCachedHeaders(documentId),
     ]);
     if (parseResult.status === 'fulfilled') {
       state.parse = parseResult.value;
@@ -413,17 +450,48 @@ async function selectDocument(documentId) {
       state.risk = null;
       setPanelError(elements.riskContent, riskResult.reason?.message ?? 'Unable to compute risk score.');
     }
+    if (cachedHeadersResult.status === 'fulfilled') {
+      state.headers = cachedHeadersResult.value;
+      state.headerMatches = deriveHeaderMatches(state.headers);
+      const uiPayload = normaliseHeadersForUi(state.headers);
+      renderHeaderRawResponse(elements.headersRawContent, uiPayload);
+      renderHeaderOutline(elements.headersContent, uiPayload, {
+        documentId,
+        fetchSection: fetchSectionText,
+      });
+      updateHeaderModeTag(state.headers?.mode ?? null);
+      state.headerSearchAttempted = true;
+      setHeaderRefreshBusy(false);
+    } else if (cachedHeadersResult.status === 'rejected') {
+      const message = cachedHeadersResult.reason?.message ?? '';
+      const isNotFound = typeof message === 'string' && /^404\b/.test(message);
+      if (!isNotFound && message) {
+        setPanelError(elements.headersRawContent, message);
+        setPanelError(elements.headersContent, message);
+      }
+    }
+    if (cachedHeadersResult.status !== 'fulfilled') {
+      setHeaderRefreshBusy(false);
+    }
     if (recordResult.status === 'fulfilled') {
       state.specRecord = recordResult.value;
+      const payload = recordResult.value?.record?.payload ?? null;
+      if (payload && typeof payload === 'object') {
+        state.specs = payload;
+        state.specsSearchAttempted = true;
+        renderSpecsView();
+      } else {
+        state.specs = null;
+      }
       state.approvalLoading = false;
       updateApprovalUI();
-      renderSpecsView();
     } else {
       state.specRecord = null;
       state.approvalLoading = false;
       setApprovalStatus('Unable to load approval status.', 'error');
       updateApprovalUI({ preserveStatus: true });
     }
+    setSpecsSearchBusy(false);
   } finally {
     if (elements.workspaceSubtitle) {
       elements.workspaceSubtitle.textContent = `Document ${documentId} ready.`;
@@ -449,11 +517,7 @@ async function refreshHeaders() {
     state.headerMatches = deriveHeaderMatches(state.headers);
     // The UI expects `simpleheaders` + `sections` fields.  If present, pass through;
     // otherwise, alias `headers` as `simpleheaders`.
-    const uiPayload = (!headersResult || typeof headersResult !== 'object')
-      ? headersResult
-      : (!Array.isArray(headersResult.simpleheaders) && Array.isArray(headersResult.headers))
-        ? { ...headersResult, simpleheaders: headersResult.headers }
-        : headersResult;
+    const uiPayload = normaliseHeadersForUi(headersResult);
     renderHeaderRawResponse(elements.headersRawContent, uiPayload);
     renderHeaderOutline(elements.headersContent, uiPayload, {
       documentId,
@@ -472,11 +536,7 @@ async function refreshHeaders() {
     if (previousHeaders) {
       state.headers = previousHeaders;
       state.headerMatches = deriveHeaderMatches(previousHeaders);
-      const uiPayload = (!previousHeaders || typeof previousHeaders !== 'object')
-        ? previousHeaders
-        : (!Array.isArray(previousHeaders.simpleheaders) && Array.isArray(previousHeaders.headers))
-          ? { ...previousHeaders, simpleheaders: previousHeaders.headers }
-          : previousHeaders;
+      const uiPayload = normaliseHeadersForUi(previousHeaders);
       renderHeaderRawResponse(elements.headersRawContent, uiPayload);
       renderHeaderOutline(elements.headersContent, uiPayload, {
         documentId,


### PR DESCRIPTION
## Summary
- ensure rerunning specs clears saved record state and stores fresh bucket payloads
- refresh cached header and spec data when selecting a document in the UI
- always emit header trace summaries while tolerating legacy chunking hooks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690aaf1c7d4c833383ca057ef02f7b62