### PR TITLE
Fix header artifact retrieval error

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -6,8 +6,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy import desc, select
-from sqlmodel import Session
+from sqlalchemy import desc
+from sqlmodel import Session, select
 
 from ..database import get_session
 from ..models import (
@@ -193,7 +193,7 @@ async def get_cached_headers(
             status_code=status.HTTP_404_NOT_FOUND, detail="No cached headers"
         )
 
-    payload = dict(artifact.body)
+    payload = dict(artifact.body or {})
     return StoredHeadersResponse(
         headers=list(payload.get("headers", [])),
         sections=list(payload.get("sections", [])),


### PR DESCRIPTION
## Summary
- use the SQLModel `select` helper when fetching cached header artifacts
- default the artifact payload to an empty mapping when the stored body is missing

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_690ab2c224148333810a922d4cda8a02