### PR TITLE
Ensure cached headers hydrate section cache

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc
 from sqlmodel import Session, select
 
+from ..config import Settings, get_settings
 from ..database import get_session
 from ..models import (
     Document,
@@ -17,6 +18,8 @@ from ..models import (
     DocumentPage,
     DocumentTable,
 )
+from ..services.pdf_native import collect_line_metrics
+from ..services.simpleheaders_state import SimpleHeadersState
 
 router = APIRouter(prefix="/api", tags=["documents"])
 
@@ -163,6 +166,50 @@ async def get_document_tables(
     return payload
 
 
+def _ensure_section_cache(
+    *,
+    document: Document,
+    doc_hash: str,
+    settings: Settings,
+) -> None:
+    """Populate :class:`SimpleHeadersState` when missing for ``document``."""
+
+    if document.id is None:
+        return
+
+    cached = SimpleHeadersState.get(document.id)
+    if cached is not None:
+        cached_hash, cached_lines = cached
+        if cached_lines and (not doc_hash or cached_hash == doc_hash):
+            return
+
+    document_path = settings.upload_dir / str(document.id) / document.filename
+    if not document_path.exists():
+        return
+
+    try:
+        document_bytes = document_path.read_bytes()
+    except OSError:
+        return
+
+    try:
+        lines, _, computed_hash = collect_line_metrics(
+            document_bytes,
+            {"document_id": document.id, "filename": document.filename},
+            suppress_toc=settings.headers_suppress_toc,
+            suppress_running=settings.headers_suppress_running,
+            tracer=None,
+        )
+    except Exception:
+        return
+
+    if not lines:
+        return
+
+    cache_hash = doc_hash or computed_hash
+    SimpleHeadersState.set(document.id, cache_hash, lines)
+
+
 @router.get(
     "/documents/{document_id}/headers", response_model=StoredHeadersResponse
 )
@@ -170,6 +217,7 @@ async def get_cached_headers(
     document_id: int,
     *,
     session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ) -> StoredHeadersResponse:
     """Return the most recent cached header tree for a document."""
 
@@ -194,6 +242,8 @@ async def get_cached_headers(
         )
 
     payload = dict(artifact.body or {})
+    doc_hash = str(payload.get("doc_hash", "") or "")
+    _ensure_section_cache(document=document, doc_hash=doc_hash, settings=settings)
     return StoredHeadersResponse(
         headers=list(payload.get("headers", [])),
         sections=list(payload.get("sections", [])),

--- a/backend/tests/test_documents_cached_headers.py
+++ b/backend/tests/test_documents_cached_headers.py
@@ -1,0 +1,129 @@
+"""Tests for document header cache hydration behaviour."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from backend.config import get_settings, reset_settings_cache
+from backend.database import get_engine, init_db, reset_database_state
+from backend.main import app
+from backend.models import (
+    Document,
+    DocumentArtifact,
+    DocumentArtifactType,
+    DocumentSection,
+)
+from backend.services.simpleheaders_state import SimpleHeadersState
+
+
+def test_cached_headers_hydrates_section_state(monkeypatch, tmp_path) -> None:
+    """Fetching cached headers should hydrate the section text cache."""
+
+    db_path = tmp_path / "test.db"
+    upload_dir = tmp_path / "uploads"
+    export_dir = tmp_path / "exports"
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setenv("EXPORT_DIR", str(export_dir))
+    monkeypatch.setenv("EXPORT_RETENTION_DAYS", "1")
+    monkeypatch.setenv("MAX_UPLOAD_SIZE", "1024")
+
+    reset_settings_cache()
+    reset_database_state()
+    settings = get_settings()
+    init_db()
+
+    engine = get_engine()
+    SimpleHeadersState.clear()
+
+    with Session(engine) as session:
+        document = Document(filename="doc.pdf", checksum="abc123")
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+        document_id = int(document.id or 0)
+
+        section = DocumentSection(
+            document_id=document_id,
+            section_key="intro",
+            title="Intro",
+            number="1",
+            level=1,
+            start_global_idx=2,
+            end_global_idx=4,
+            start_page=0,
+            end_page=0,
+        )
+        session.add(section)
+
+        artifact = DocumentArtifact(
+            document_id=document_id,
+            artifact_type=DocumentArtifactType.HEADER_TREE,
+            artifact_key="llm_full",
+            sha_inputs="inputs",
+            body={
+                "headers": [
+                    {"text": "Intro", "number": "1", "level": 1, "global_idx": 2}
+                ],
+                "sections": [
+                    {
+                        "section_key": "intro",
+                        "title": "Intro",
+                        "number": "1",
+                        "level": 1,
+                        "start_global_idx": 2,
+                        "end_global_idx": 4,
+                        "start_page": 0,
+                        "end_page": 0,
+                    }
+                ],
+                "doc_hash": "artifact-hash",
+            },
+        )
+        session.add(artifact)
+        session.commit()
+
+    doc_dir = settings.upload_dir / str(document_id)
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    (doc_dir / "doc.pdf").write_bytes(b"%PDF-1.4\n%EOF")
+
+    lines = [
+        {"global_idx": 2, "text": "Intro heading"},
+        {"global_idx": 3, "text": "Body text"},
+    ]
+
+    def _fake_collect_line_metrics(
+        document_bytes: bytes,
+        metadata: dict | None,
+        *,
+        suppress_toc: bool,
+        suppress_running: bool,
+        tracer,
+    ):
+        return lines, set(), "artifact-hash"
+
+    monkeypatch.setattr(
+        "backend.routers.documents.collect_line_metrics",
+        _fake_collect_line_metrics,
+    )
+
+    with TestClient(app) as client:
+        response = client.get(f"/api/documents/{document_id}/headers")
+        assert response.status_code == 200
+        cached = SimpleHeadersState.get(document_id)
+        assert cached is not None
+        cached_hash, cached_lines = cached
+        assert cached_hash == "artifact-hash"
+        assert cached_lines == lines
+
+        section_response = client.get(
+            f"/api/headers/{document_id}/section-text",
+            params={"start": 2, "end": 3},
+        )
+
+    SimpleHeadersState.clear(document_id)
+
+    assert section_response.status_code == 200
+    assert section_response.text == "Intro heading\nBody text"


### PR DESCRIPTION
## Summary
- hydrate the in-memory section text cache when serving stored headers so section text lookups work after selecting a header
- add a regression test to confirm cached headers prime the cache and allow section text retrieval

## Testing
- pytest backend/tests/test_documents_cached_headers.py
- pytest backend/tests/test_headers_section_text.py

------
https://chatgpt.com/codex/tasks/task_e_690ab56b3d94833386bae8aa9806ec90