### PR TITLE
Fix rerun specs button API base handling

### DIFF
--- a/frontend/static/js/specs_patch.js
+++ b/frontend/static/js/specs_patch.js
@@ -1,103 +1,89 @@
 // Updated Specs Patch for re-running specs from scratch
-// This script attaches to the "Rerun specs" button in the Specification buckets
-// panel.  It wipes any previously cached/extracted specification buckets on the
-// server and then re-invokes the LLM-driven extraction workflow.  When
+// This module attaches to the "Rerun specs" button in the Specification buckets
+// panel. It wipes any previously cached/extracted specification buckets on the
+// server and then re-invokes the LLM-driven extraction workflow. When
 // completed, it fires a `specs:buckets:updated` event so that the main app
 // (app.js) can re-render the view.
 
-;(function () {
-  /**
-   * Perform a fetch request against the API.  Prepends the API base URL from
-   * the page meta tag or window.API_BASE if set.  JSON bodies are stringified
-   * and appropriate headers are applied.
-   *
-   * @param {string} url The API path (e.g. `/api/specs/1/buckets`)
-   * @param {Object} opts Options passed to fetch (method, headers, body)
-   * @returns {Promise<any>} Parsed JSON result
-   */
-  async function apiRequest(url, opts = {}) {
-    const base = (window.API_BASE) ||
-      (document.querySelector('meta[name="api-base"]')?.getAttribute('content')) || '';
-    const res = await fetch(base + url, {
-      method: opts.method || 'GET',
-      headers: { 'Content-Type': 'application/json', ...(opts.headers || {}) },
-      body: opts.body ? JSON.stringify(opts.body) : undefined,
-    });
-    const text = await res.text().catch(() => '');
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}: ${text}`.trim());
-    }
-    if (!text) return null;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
+import { deleteSpecsBuckets, runSpecsBucketsAgain } from './api.js';
+
+function findRerunButton() {
+  return document.getElementById('run-again-buckets')
+    || document.getElementById('rerun-specs');
+}
+
+function coerceDocumentId(docId) {
+  if (docId == null || docId === '') {
+    return null;
   }
 
-  /**
-   * Delete existing specification buckets and re-run extraction for the given document.
-   * Disables the triggering button and updates its text while in progress.  When
-   * finished, re-enables the button and dispatches a `specs:buckets:updated`
-   * event containing the updated bucket payload.
-   *
-   * @param {number|string} docId The ID of the document whose specs to re-run
-   */
-  async function runAgainBuckets(docId) {
-    const btn = document.getElementById('run-again-buckets')
-      || document.getElementById('rerun-specs');
-    if (!docId) {
-      alert('No document selected.');
-      return;
-    }
-    if (btn) {
-      btn.disabled = true;
-      btn.dataset.loading = 'true';
-      btn.textContent = 'Re-running…';
-      btn.setAttribute('aria-busy', 'true');
-    }
-    try {
-      // First, wipe any stored bucket results for this document
-      await apiRequest(`/api/specs/${docId}/buckets`, { method: 'DELETE' });
-      // Next, re-run the extraction from scratch
-      const json = await apiRequest(`/api/specs/${docId}/buckets/run-again`, { method: 'POST' });
-      console.debug('[Specs] Buckets wipe + re-run result:', json);
-      // Fire an event so the main app can re-render the buckets
-      window.dispatchEvent(new CustomEvent('specs:buckets:updated', { detail: json }));
-      alert('Buckets wiped and re-extracted.  Check the Specs panel for updates.');
-    } catch (err) {
-      console.error('[Specs] Specs rerun failed:', err);
-      alert('Rerunning specs failed: ' + (err && err.message || err));
-    } finally {
-      if (btn) {
-        btn.disabled = false;
-        btn.dataset.loading = '';
-        btn.removeAttribute('aria-busy');
-        btn.textContent = 'Rerun specs';
-      }
-    }
+  const numeric = Number(docId);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric;
   }
 
-  // Expose the function globally so app.js or other scripts can call it
-  window.SpecsPatch = { runAgainBuckets };
+  return null;
+}
 
-  // Auto-wire the button on DOMContentLoaded.  If the button has a data-doc-id
-  // attribute at page load, this will run once; otherwise app.js may call
-  // SpecsPatch.runAgainBuckets(docId) directly.
+/**
+ * Delete existing specification buckets and re-run extraction for the given document.
+ * Disables the triggering button and updates its text while in progress. When
+ * finished, re-enables the button and dispatches a `specs:buckets:updated`
+ * event containing the updated bucket payload.
+ *
+ * @param {number|string} docId The ID of the document whose specs to re-run
+ */
+export async function runAgainBuckets(docId) {
+  const button = findRerunButton();
+  const normalisedId = coerceDocumentId(docId);
+
+  if (!normalisedId) {
+    alert('No document selected.');
+    return;
+  }
+
+  if (button) {
+    button.disabled = true;
+    button.dataset.loading = 'true';
+    button.textContent = 'Re-running…';
+    button.setAttribute('aria-busy', 'true');
+  }
+
+  try {
+    await deleteSpecsBuckets(normalisedId);
+    const json = await runSpecsBucketsAgain(normalisedId);
+    console.debug('[Specs] Buckets wipe + re-run result:', json);
+    window.dispatchEvent(new CustomEvent('specs:buckets:updated', { detail: json }));
+    alert('Buckets wiped and re-extracted. Check the Specs panel for updates.');
+  } catch (err) {
+    console.error('[Specs] Specs rerun failed:', err);
+    const message = err && err.message ? err.message : String(err);
+    alert('Rerunning specs failed: ' + message);
+  } finally {
+    if (button) {
+      button.disabled = false;
+      button.dataset.loading = '';
+      button.removeAttribute('aria-busy');
+      button.textContent = 'Rerun specs';
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.SpecsPatch = { ...(window.SpecsPatch ?? {}), runAgainBuckets };
+
   window.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('run-again-buckets')
-      || document.getElementById('rerun-specs');
-    const docIdAttr = btn?.dataset?.docId;
-    if (btn && docIdAttr) {
-      btn.addEventListener('click', (event) => {
+    const button = findRerunButton();
+    if (button) {
+      button.addEventListener('click', (event) => {
         event.preventDefault();
-        const id = Number(docIdAttr);
-        if (Number.isFinite(id)) {
-          runAgainBuckets(id);
-        } else {
+        const currentId = coerceDocumentId(button.dataset?.docId ?? null);
+        if (!currentId) {
           alert('Invalid document id');
+          return;
         }
+        void runAgainBuckets(currentId);
       });
     }
   });
-})();
+}


### PR DESCRIPTION
## Summary
- import the shared API helpers in `specs_patch.js` so the rerun button uses the normalised API base
- normalise document ids before hitting the wipe and rerun endpoints and guard click wiring accordingly
- keep the global `window.SpecsPatch` helper available for existing callers

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_690ab73794388333b2df1343d4443b3f