### PR TITLE
Add verbose diagnostics to Specs rerun workflow

### DIFF
--- a/backend/routers/specs_buckets.py
+++ b/backend/routers/specs_buckets.py
@@ -9,6 +9,7 @@ Drop-in router that you can include from your FastAPI app.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -56,6 +57,8 @@ except Exception:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
         return doc
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/specs", tags=["specs"])
 
 
@@ -64,6 +67,10 @@ def _artifact_inputs(doc_hash: str | None = None) -> Dict[str, Any]:
     inputs = {"kind": "spec_buckets"}
     if doc_hash:
         inputs["doc_hash"] = doc_hash
+    logger.debug(
+        "[specs_buckets] _artifact_inputs",
+        {"doc_hash": doc_hash, "inputs": inputs},
+    )
     return inputs
 
 
@@ -77,21 +84,37 @@ def delete_buckets_cache(
     Best-effort purge of cached Spec Bucket artifacts for the given document.
     Safe to call even if cache is empty or the delete helper isn't present.
     """
+    logger.debug("[specs_buckets] delete_buckets_cache invoked", {"document_id": document_id})
     doc = get_document_or_404(session, document_id)
+    logger.debug(
+        "[specs_buckets] delete_buckets_cache resolved document",
+        {
+            "document_id": document_id,
+            "doc_hash": getattr(doc, "doc_hash", None) or getattr(doc, "hash", None),
+            "filename": getattr(doc, "filename", None),
+        },
+    )
 
     # Clear any persisted spec record payload before wiping cached artifacts.
     try:
+        logger.debug("[specs_buckets] delete_buckets_cache wiping spec record", {"document_id": document_id})
         wipe_spec_buckets_for_document(session, document_id=document_id)
     except Exception:
+        logger.exception("[specs_buckets] delete_buckets_cache wipe failed", exc_info=True)
         pass
 
     # Fetch a doc_hash if you store it on Document; otherwise skip (inputs filter remains generic).
     doc_hash = getattr(doc, "doc_hash", None) or getattr(doc, "hash", None)
+    logger.debug(
+        "[specs_buckets] delete_buckets_cache using doc_hash",
+        {"document_id": document_id, "doc_hash": doc_hash},
+    )
 
     # Try targeted delete if helper is available
     try:
         _ = _delete_artifact  # type: ignore[name-defined]
     except Exception:
+        logger.debug("[specs_buckets] delete_buckets_cache delete helper unavailable")
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     try:
@@ -104,7 +127,9 @@ def delete_buckets_cache(
         )
     except Exception:
         # swallow; we only want to make "Run again" never crash
+        logger.exception("[specs_buckets] delete_buckets_cache delete_artifact raised", exc_info=True)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
+    logger.debug("[specs_buckets] delete_buckets_cache completed", {"document_id": document_id})
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -118,19 +143,32 @@ async def run_again(
     Wipes cached bucket results (best-effort) then re-runs all bucket prompts concurrently.
     Returns a JSON object: {"ok": true, "buckets": {...}, "messages": [...]}.
     """
+    logger.debug("[specs_buckets] run_again invoked", {"document_id": document_id})
     # Purge cache first (no-op if unavailable)
     try:
+        logger.debug("[specs_buckets] run_again calling delete_buckets_cache", {"document_id": document_id})
         delete_buckets_cache(document_id, session=session, settings=settings)  # type: ignore[arg-type]
     except Exception:
+        logger.exception("[specs_buckets] run_again delete_buckets_cache raised", exc_info=True)
         pass
 
     # Resolve document and run the worker
     doc = get_document_or_404(session, document_id)
+    logger.debug(
+        "[specs_buckets] run_again resolved document",
+        {
+            "document_id": document_id,
+            "doc_hash": getattr(doc, "doc_hash", None) or getattr(doc, "hash", None),
+            "filename": getattr(doc, "filename", None),
+        },
+    )
 
     # Ensure any previous spec payload is cleared so the new run stores a fresh draft.
     try:
+        logger.debug("[specs_buckets] run_again wiping spec record", {"document_id": document_id})
         wipe_spec_buckets_for_document(session, document_id=document_id)
     except Exception:
+        logger.exception("[specs_buckets] run_again wipe_spec_buckets_for_document raised", exc_info=True)
         pass
     # Expect PDFs to already be parsed/available on disk; we only need the text content.
     # The worker will fetch the parsed text (via artifact store) or re-parse if necessary.
@@ -139,9 +177,18 @@ async def run_again(
         document=doc,
         settings=settings,
     )
+    logger.debug(
+        "[specs_buckets] run_again worker result",
+        {
+            "document_id": document_id,
+            "result_keys": list(result.keys()),
+            "messages": result.get("messages"),
+        },
+    )
 
     # Persist a single artifact blob with all bucket outputs for this doc.
     try:
+        logger.debug("[specs_buckets] run_again storing artifact", {"document_id": document_id})
         store_artifact(
             session=session,
             document_id=doc.id,
@@ -152,19 +199,30 @@ async def run_again(
         )
     except Exception:
         # Do not fail the request just because caching failed.
+        logger.exception("[specs_buckets] run_again store_artifact raised", exc_info=True)
         pass
 
     stored_record = None
     try:
+        logger.debug("[specs_buckets] run_again storing spec record", {"document_id": document_id})
         stored_record = store_spec_buckets_result(
             session,
             document_id=document_id,
             payload=result,
         )
     except Exception:
+        logger.exception("[specs_buckets] run_again store_spec_buckets_result raised", exc_info=True)
         pass
 
     response: Dict[str, Any] = {"ok": True, **result, "persisted": stored_record is not None}
+    logger.debug(
+        "[specs_buckets] run_again response summary",
+        {
+            "document_id": document_id,
+            "persisted": stored_record is not None,
+            "response_keys": list(response.keys()),
+        },
+    )
     if stored_record is not None:
         response["record"] = {
             "id": stored_record.id,
@@ -173,5 +231,13 @@ async def run_again(
             if stored_record.updated_at
             else None,
         }
+        logger.debug(
+            "[specs_buckets] run_again stored record",
+            {
+                "document_id": document_id,
+                "record_id": stored_record.id,
+                "state": stored_record.state,
+            },
+        )
 
     return response

--- a/backend/services/spec_records.py
+++ b/backend/services/spec_records.py
@@ -6,6 +6,7 @@ import csv
 import hashlib
 import io
 import json
+import logging
 import zipfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -18,6 +19,8 @@ from sqlmodel import Session, select
 from ..config import Settings
 from ..middleware import get_request_id
 from ..models import Document, SpecAuditEntry, SpecRecord
+
+logger = logging.getLogger(__name__)
 # If you have an artifact store for buckets, import its delete helper:
 # from .artifact_store import delete_artifact, DocumentArtifactType
 
@@ -29,9 +32,15 @@ class SpecRecordError(RuntimeError):
 def ensure_document(session: Session, document_id: int) -> Document:
     """Return the document for the given id or raise an error."""
 
+    logger.debug("[spec_records] ensure_document invoked", {"document_id": document_id})
     document = session.get(Document, document_id)
     if document is None:
+        logger.debug("[spec_records] ensure_document missing document", {"document_id": document_id})
         raise SpecRecordError(f"Document {document_id} not found")
+    logger.debug(
+        "[spec_records] ensure_document resolved document",
+        {"document_id": document_id, "filename": getattr(document, "filename", None)},
+    )
     return document
 
 
@@ -327,14 +336,20 @@ __all__ = [
 def wipe_spec_buckets_for_document(session, *, document_id: int) -> None:
     """Reset any persisted specification payload for ``document_id`` to a clean draft."""
 
+    logger.debug("[spec_records] wipe_spec_buckets_for_document invoked", {"document_id": document_id})
     rec = session.exec(
         select(SpecRecord).where(SpecRecord.document_id == document_id)
     ).first()
 
     if rec is None:
+        logger.debug("[spec_records] wipe_spec_buckets_for_document no record", {"document_id": document_id})
         return
 
     now = datetime.now(UTC)
+    logger.debug(
+        "[spec_records] wipe_spec_buckets_for_document resetting record",
+        {"document_id": document_id, "record_id": rec.id},
+    )
     rec.state = "draft"
     rec.reviewer = None
     rec.content_hash = None
@@ -344,6 +359,7 @@ def wipe_spec_buckets_for_document(session, *, document_id: int) -> None:
     rec.updated_at = now
     session.add(rec)
     session.commit()
+    logger.debug("[spec_records] wipe_spec_buckets_for_document completed", {"document_id": document_id, "record_id": rec.id})
 
 
 def store_spec_buckets_result(
@@ -351,6 +367,10 @@ def store_spec_buckets_result(
 ) -> SpecRecord:
     """Persist the latest specification buckets payload for a document as a draft."""
 
+    logger.debug(
+        "[spec_records] store_spec_buckets_result invoked",
+        {"document_id": document_id, "payload_type": type(payload).__name__},
+    )
     document = ensure_document(session, document_id)
     data = _serialise_payload(payload)
     now = datetime.now(UTC)
@@ -360,6 +380,10 @@ def store_spec_buckets_result(
     ).first()
 
     if rec is None:
+        logger.debug(
+            "[spec_records] store_spec_buckets_result creating record",
+            {"document_id": document_id},
+        )
         rec = SpecRecord(
             document_id=document.id,
             state="draft",
@@ -373,6 +397,10 @@ def store_spec_buckets_result(
         )
         session.add(rec)
     else:
+        logger.debug(
+            "[spec_records] store_spec_buckets_result updating record",
+            {"document_id": document_id, "record_id": rec.id},
+        )
         rec.state = "draft"
         rec.reviewer = None
         rec.approved_at = None
@@ -384,4 +412,8 @@ def store_spec_buckets_result(
 
     session.commit()
     session.refresh(rec)
+    logger.debug(
+        "[spec_records] store_spec_buckets_result completed",
+        {"document_id": document_id, "record_id": rec.id},
+    )
     return rec

--- a/backend/services/specs_worker.py
+++ b/backend/services/specs_worker.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -25,6 +26,8 @@ from backend.services.artifact_store import (
     get_cached_artifact,
     store_artifact,
 )  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 # ---------- Configuration (env-driven so we don't edit config module) ----------
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -229,6 +232,11 @@ async def _openrouter_chat(prompt: str) -> str:
     """
     import httpx  # SimpleSpecs already depends on httpx via other paths
 
+    logger.debug(
+        "[specs_worker] _openrouter_chat invoked",
+        {"prompt_preview": prompt[:200], "prompt_length": len(prompt)},
+    )
+
     headers = {
         "Authorization": f"Bearer {OPENROUTER_API_KEY}",
         "HTTP-Referer": "https://github.com/hambonesoftware/SimpleSpecs",
@@ -247,12 +255,26 @@ async def _openrouter_chat(prompt: str) -> str:
 
     timeout = httpx.Timeout(SPECS_LLM_TIMEOUT_S)
     async with httpx.AsyncClient(timeout=timeout) as client:
+        logger.debug(
+            "[specs_worker] _openrouter_chat sending request",
+            {"model": SPECS_LLM_MODEL, "temperature": body["temperature"]},
+        )
         r = await client.post("https://openrouter.ai/api/v1/chat/completions", headers=headers, json=body)
+        logger.debug(
+            "[specs_worker] _openrouter_chat received response",
+            {"status_code": r.status_code, "headers": dict(r.headers)},
+        )
         r.raise_for_status()
         data = r.json()
         try:
-            return data["choices"][0]["message"]["content"]
+            content = data["choices"][0]["message"]["content"]
+            logger.debug(
+                "[specs_worker] _openrouter_chat parsed content",
+                {"content_preview": content[:200], "content_length": len(content)},
+            )
+            return content
         except Exception:
+            logger.exception("[specs_worker] _openrouter_chat unexpected response structure", exc_info=True)
             return json.dumps({"error": "Unexpected response", "raw": data})
 
 
@@ -261,8 +283,16 @@ def _best_doc_text_from_cache(session: Session, document: Document) -> Tuple[str
     Try to obtain the best available "full text" for the document from the artifact store.
     Returns (text, doc_hash?|None).
     """
+    logger.debug(
+        "[specs_worker] _best_doc_text_from_cache invoked",
+        {"document_id": document.id},
+    )
     # Prefer a dedicated PARSED_TEXT artifact if your repo writes one.
     for key in ("parsed_text", "fulltext", "plain_text"):
+        logger.debug(
+            "[specs_worker] _best_doc_text_from_cache attempting cache lookup",
+            {"document_id": document.id, "key": key},
+        )
         cached = get_cached_artifact(
             session=session,
             document_id=document.id,
@@ -273,11 +303,25 @@ def _best_doc_text_from_cache(session: Session, document: Document) -> Tuple[str
         if cached and isinstance(cached.body, dict):
             text = cached.body.get("text") or cached.body.get("content") or ""
             if text:
-                return text, cached.body.get("doc_hash")
+                doc_hash = cached.body.get("doc_hash")
+                logger.debug(
+                    "[specs_worker] _best_doc_text_from_cache cache hit",
+                    {
+                        "document_id": document.id,
+                        "key": key,
+                        "text_length": len(text),
+                        "doc_hash": doc_hash,
+                    },
+                )
+                return text, doc_hash
 
     # Fall back to reading the PDF and extracting on the fly (basic PyMuPDF approach).
     # We avoid adding new heavy deps; SimpleSpecs likely already uses PyMuPDF elsewhere.
     try:
+        logger.debug(
+            "[specs_worker] _best_doc_text_from_cache falling back to PyMuPDF",
+            {"document_id": document.id, "filename": document.filename},
+        )
         import fitz  # PyMuPDF
         # Document is typically saved in uploads/ by filename; try that.
         from backend.paths import UPLOAD_DIR  # type: ignore
@@ -287,8 +331,18 @@ def _best_doc_text_from_cache(session: Session, document: Document) -> Tuple[str
         with fitz.open(pdf_path) as doc:
             for page in doc:
                 text_parts.append(page.get_text("text"))
-        return "\n".join(text_parts), None
+        joined = "\n".join(text_parts)
+        logger.debug(
+            "[specs_worker] _best_doc_text_from_cache extracted via PyMuPDF",
+            {"document_id": document.id, "text_length": len(joined)},
+        )
+        return joined, None
     except Exception:
+        logger.exception(
+            "[specs_worker] _best_doc_text_from_cache fallback failed (document_id=%s)",
+            document.id,
+            exc_info=True,
+        )
         return "", None
 
 
@@ -296,14 +350,31 @@ async def _run_single_bucket(bucket: Dict[str, str], doc_text: str) -> Dict[str,
     name = bucket["name"]
     prompt = bucket["prompt"] + doc_text
     try:
+        logger.debug(
+            "[specs_worker] _run_single_bucket starting",
+            {"bucket": name, "prompt_length": len(prompt)},
+        )
         raw = await _openrouter_chat(prompt)
         # Try to coerce to JSON when possible
         try:
             data = json.loads(raw)
         except Exception:
             data = {"raw": raw}
+        logger.debug(
+            "[specs_worker] _run_single_bucket success",
+            {
+                "bucket": name,
+                "response_preview": raw[:200],
+                "parsed_keys": list(data.keys()) if isinstance(data, dict) else None,
+            },
+        )
         return {"name": name, "ok": True, "data": data}
     except Exception as exc:
+        logger.exception(
+            "[specs_worker] _run_single_bucket failed (bucket=%s)",
+            name,
+            exc_info=True,
+        )
         return {"name": name, "ok": False, "error": str(exc)}
 
 
@@ -314,9 +385,29 @@ async def run_all_buckets_concurrently(
     Orchestrates a single concurrent run of all BUCKETS for one document.
     Returns a dictionary with "buckets" (mapping) and light run metadata.
     """
+    logger.debug(
+        "[specs_worker] run_all_buckets_concurrently invoked",
+        {
+            "document_id": document.id,
+            "bucket_names": [bucket["name"] for bucket in BUCKETS],
+        },
+    )
     doc_text, doc_hash = _best_doc_text_from_cache(session, document)
+    logger.debug(
+        "[specs_worker] run_all_buckets_concurrently document text status",
+        {
+            "document_id": document.id,
+            "doc_hash": doc_hash,
+            "text_available": bool(doc_text),
+            "text_length": len(doc_text or ""),
+        },
+    )
     if not doc_text:
         # We don't fail hard; return an informative structure
+        logger.debug(
+            "[specs_worker] run_all_buckets_concurrently no doc text",
+            {"document_id": document.id},
+        )
         return {
             "doc_id": document.id,
             "doc_hash": doc_hash,
@@ -325,12 +416,26 @@ async def run_all_buckets_concurrently(
         }
 
     sem = asyncio.Semaphore(SPECS_MAX_CONCURRENCY)
+    logger.debug(
+        "[specs_worker] run_all_buckets_concurrently semaphore created",
+        {"max_concurrency": SPECS_MAX_CONCURRENCY},
+    )
 
     async def guarded(bucket):
         async with sem:
+            logger.debug("[specs_worker] run_all_buckets_concurrently entering bucket", {"bucket": bucket["name"]})
             return await _run_single_bucket(bucket, doc_text)
 
     results = await asyncio.gather(*(guarded(b) for b in BUCKETS))
+    logger.debug(
+        "[specs_worker] run_all_buckets_concurrently gathered results",
+        {
+            "document_id": document.id,
+            "result_count": len(results),
+            "ok_buckets": [r["name"] for r in results if r.get("ok")],
+            "error_buckets": [r["name"] for r in results if not r.get("ok")],
+        },
+    )
 
     buckets_out: Dict[str, Any] = {}
     messages: List[str] = []
@@ -342,6 +447,14 @@ async def run_all_buckets_concurrently(
             buckets_out[name] = {"error": item.get("error", "unknown")}
             messages.append(f"Bucket {name} failed: {item.get('error')}")
 
+    logger.debug(
+        "[specs_worker] run_all_buckets_concurrently assembled output",
+        {
+            "document_id": document.id,
+            "bucket_keys": list(buckets_out.keys()),
+            "messages": messages,
+        },
+    )
     return {
         "doc_id": document.id,
         "doc_hash": doc_hash,

--- a/frontend/static/js/api.js
+++ b/frontend/static/js/api.js
@@ -1,13 +1,24 @@
 const SAME_ORIGIN_KEYS = new Set(["", "/", ".", "auto", "same-origin"]);
 
+function apiDebug(message, payload) {
+  if (payload !== undefined) {
+    console.debug(`[API] ${message}`, payload);
+  } else {
+    console.debug(`[API] ${message}`);
+  }
+}
+
 function normaliseBase(value) {
+  apiDebug('normaliseBase invoked', { value });
   if (typeof value !== "string") {
+    apiDebug('normaliseBase returning null (non-string input)', { value });
     return null;
   }
 
   const trimmed = value.trim();
   const lower = trimmed.toLowerCase();
   if (SAME_ORIGIN_KEYS.has(lower)) {
+    apiDebug('normaliseBase resolved same-origin', { trimmed });
     return "";
   }
 
@@ -32,28 +43,42 @@ function normaliseBase(value) {
 
       const needsBrackets = host.includes(":") && !(host.startsWith("[") && host.endsWith("]"));
       const safeHost = needsBrackets ? `[${host}]` : host;
-      return `${protocol}//${safeHost}${trimmed}`.replace(/\/+$/, "");
+      const computed = `${protocol}//${safeHost}${trimmed}`.replace(/\/+$/, "");
+      apiDebug('normaliseBase port-only override with window', { computed, host: safeHost });
+      return computed;
     }
-    return trimmed.replace(/\/+$/, "");
+    const fallback = trimmed.replace(/\/+$/, "");
+    apiDebug('normaliseBase port-only override without window', { fallback });
+    return fallback;
   }
 
   if (trimmed.startsWith("//")) {
-    return `${window.location.protocol}${trimmed}`.replace(/\/+$/, "");
+    const computed = `${window.location.protocol}${trimmed}`.replace(/\/+$/, "");
+    apiDebug('normaliseBase protocol-relative URL', { computed });
+    return computed;
   }
 
   if (/^https?:\/\//i.test(trimmed)) {
-    return trimmed.replace(/\/+$/, "");
+    const cleaned = trimmed.replace(/\/+$/, "");
+    apiDebug('normaliseBase absolute URL', { cleaned });
+    return cleaned;
   }
 
   if (trimmed.startsWith("/")) {
-    return `${window.location.origin}${trimmed}`.replace(/\/+$/, "");
+    const combined = `${window.location.origin}${trimmed}`.replace(/\/+$/, "");
+    apiDebug('normaliseBase origin-relative URL', { combined });
+    return combined;
   }
 
-  return trimmed.replace(/\/+$/, "");
+  const cleaned = trimmed.replace(/\/+$/, "");
+  apiDebug('normaliseBase fallback URL', { cleaned });
+  return cleaned;
 }
 
 function resolveApiBase() {
+  apiDebug('resolveApiBase invoked');
   if (typeof window === "undefined") {
+    apiDebug('resolveApiBase returning empty (no window)');
     return "";
   }
 
@@ -65,36 +90,49 @@ function resolveApiBase() {
   for (const candidate of candidates) {
     const normalised = normaliseBase(candidate);
     if (typeof normalised === "string") {
+      apiDebug('resolveApiBase selected candidate', { candidate, normalised });
       return normalised;
     }
   }
 
+  apiDebug('resolveApiBase using empty default');
   return "";
 }
 
 export const API_BASE = resolveApiBase();
 
 function buildUrl(path) {
+  apiDebug('buildUrl invoked', { path, API_BASE });
   if (/^https?:\/\//i.test(path)) {
+    apiDebug('buildUrl returning absolute path', { path });
     return path;
   }
 
   const normalisedPath = path.startsWith("/") ? path : `/${path}`;
+  apiDebug('buildUrl normalised path', { normalisedPath });
 
   if (!API_BASE) {
+    apiDebug('buildUrl using normalised path without base', { normalisedPath });
     return normalisedPath;
   }
 
   const base = API_BASE.replace(/\/+$/, "");
+  apiDebug('buildUrl computed base', { base });
 
   if (/^https?:\/\//i.test(base)) {
     if (normalisedPath.startsWith("/api/") && base.endsWith("/api")) {
-      return `${base}${normalisedPath.slice(4)}`;
+      const combined = `${base}${normalisedPath.slice(4)}`;
+      apiDebug('buildUrl combining with base ending in /api', { combined });
+      return combined;
     }
-    return `${base}${normalisedPath}`;
+    const combined = `${base}${normalisedPath}`;
+    apiDebug('buildUrl combining with absolute base', { combined });
+    return combined;
   }
 
-  return `${base}${normalisedPath}`;
+  const combined = `${base}${normalisedPath}`;
+  apiDebug('buildUrl combining with relative base', { combined });
+  return combined;
 }
 
 function serialiseQuery(params = {}) {
@@ -119,28 +157,46 @@ async function request(path, options = {}) {
     ...options,
   };
 
+  apiDebug('request starting', { path, url, config });
   const response = await fetch(url, config);
+  apiDebug('request response received', {
+    url,
+    status: response.status,
+    statusText: response.statusText,
+  });
   const text = await response.text();
+  apiDebug('request response text snippet', { url, snippet: text.slice(0, 200) });
 
   if (!response.ok) {
     const snippet = text.slice(0, 500);
+    apiDebug('request throwing due to non-ok response', {
+      url,
+      status: response.status,
+      statusText: response.statusText,
+      snippet,
+    });
     throw new Error(`${response.status} ${response.statusText}: ${snippet}`.trim());
   }
 
   if (response.status === 204 || text.length === 0) {
+    apiDebug('request returning null payload', { url, status: response.status });
     return null;
   }
 
   const contentType = response.headers.get("content-type") ?? "";
+  apiDebug('request evaluating content type', { url, contentType });
   if (contentType.includes("application/json")) {
     try {
-      return JSON.parse(text);
+      const parsed = JSON.parse(text);
+      apiDebug('request returning parsed JSON', { url, keys: Object.keys(parsed ?? {}) });
+      return parsed;
     } catch (error) {
       console.warn("[API] Failed to parse JSON response", { url, text, error });
       return text;
     }
   }
 
+  apiDebug('request returning raw text', { url, length: text.length });
   return text;
 }
 
@@ -237,19 +293,31 @@ export async function fetchCachedHeaders(documentId) {
 }
 // Wipe all stored/spec-cached buckets for a document on the server
 export async function deleteSpecsBuckets(documentId) {
+  apiDebug('deleteSpecsBuckets invoked', { documentId });
   if (!Number.isFinite(Number(documentId))) {
+    apiDebug('deleteSpecsBuckets invalid document id', { documentId });
     throw new Error('deleteSpecsBuckets: invalid documentId');
   }
-  return request(`/api/specs/${documentId}/buckets`, { method: 'DELETE' });
+  const result = await request(`/api/specs/${documentId}/buckets`, { method: 'DELETE' });
+  apiDebug('deleteSpecsBuckets completed', { documentId, result });
+  return result;
 }
 
 // Re-run extraction fresh (bypass caches) and return new buckets payload
 export async function runSpecsBucketsAgain(documentId) {
+  apiDebug('runSpecsBucketsAgain invoked', { documentId });
   if (!Number.isFinite(Number(documentId))) {
+    apiDebug('runSpecsBucketsAgain invalid document id', { documentId });
     throw new Error('runSpecsBucketsAgain: invalid documentId');
   }
   // This endpoint should trigger a full re-extract on the server
-  return request(`/api/specs/${documentId}/buckets/run-again`, { method: 'POST' });
+  const result = await request(`/api/specs/${documentId}/buckets/run-again`, { method: 'POST' });
+  apiDebug('runSpecsBucketsAgain completed', {
+    documentId,
+    resultType: result == null ? 'null' : typeof result,
+    resultKeys: result && typeof result === 'object' ? Object.keys(result) : null,
+  });
+  return result;
 }
 
 

--- a/frontend/static/js/specs_patch.js
+++ b/frontend/static/js/specs_patch.js
@@ -7,21 +7,38 @@
 
 import { deleteSpecsBuckets, runSpecsBucketsAgain } from './api.js';
 
+function debugLog(message, payload) {
+  if (payload !== undefined) {
+    console.debug(`[SpecsPatch] ${message}`, payload);
+  } else {
+    console.debug(`[SpecsPatch] ${message}`);
+  }
+}
+
 function findRerunButton() {
-  return document.getElementById('run-again-buckets')
+  const button = document.getElementById('run-again-buckets')
     || document.getElementById('rerun-specs');
+  debugLog('findRerunButton invoked', {
+    found: Boolean(button),
+    id: button?.id ?? null,
+  });
+  return button;
 }
 
 function coerceDocumentId(docId) {
+  debugLog('coerceDocumentId invoked', { raw: docId });
   if (docId == null || docId === '') {
+    debugLog('coerceDocumentId returning null (empty input)');
     return null;
   }
 
   const numeric = Number(docId);
   if (Number.isFinite(numeric) && numeric > 0) {
+    debugLog('coerceDocumentId returning numeric value', { numeric });
     return numeric;
   }
 
+  debugLog('coerceDocumentId returning null (non-numeric input)', { coerced: numeric });
   return null;
 }
 
@@ -34,15 +51,19 @@ function coerceDocumentId(docId) {
  * @param {number|string} docId The ID of the document whose specs to re-run
  */
 export async function runAgainBuckets(docId) {
+  debugLog('runAgainBuckets invoked', { docId, typeofDocId: typeof docId });
   const button = findRerunButton();
   const normalisedId = coerceDocumentId(docId);
+  debugLog('runAgainBuckets normalised document id', { normalisedId });
 
   if (!normalisedId) {
+    debugLog('runAgainBuckets aborting due to missing/invalid id');
     alert('No document selected.');
     return;
   }
 
   if (button) {
+    debugLog('runAgainBuckets disabling rerun button', { buttonId: button.id });
     button.disabled = true;
     button.dataset.loading = 'true';
     button.textContent = 'Re-running…';
@@ -50,17 +71,22 @@ export async function runAgainBuckets(docId) {
   }
 
   try {
+    debugLog('runAgainBuckets initiating deleteSpecsBuckets call');
     await deleteSpecsBuckets(normalisedId);
+    debugLog('runAgainBuckets deleteSpecsBuckets resolved');
     const json = await runSpecsBucketsAgain(normalisedId);
-    console.debug('[Specs] Buckets wipe + re-run result:', json);
+    debugLog('runAgainBuckets runSpecsBucketsAgain resolved', json);
     window.dispatchEvent(new CustomEvent('specs:buckets:updated', { detail: json }));
+    debugLog('runAgainBuckets dispatched specs:buckets:updated event', { detailKeys: Object.keys(json ?? {}) });
     alert('Buckets wiped and re-extracted. Check the Specs panel for updates.');
   } catch (err) {
-    console.error('[Specs] Specs rerun failed:', err);
+    console.error('[SpecsPatch] Specs rerun failed:', err);
     const message = err && err.message ? err.message : String(err);
+    debugLog('runAgainBuckets encountered error', { message });
     alert('Rerunning specs failed: ' + message);
   } finally {
     if (button) {
+      debugLog('runAgainBuckets restoring button to idle state', { buttonId: button.id });
       button.disabled = false;
       button.dataset.loading = '';
       button.removeAttribute('aria-busy');
@@ -73,17 +99,32 @@ if (typeof window !== 'undefined') {
   window.SpecsPatch = { ...(window.SpecsPatch ?? {}), runAgainBuckets };
 
   window.addEventListener('DOMContentLoaded', () => {
+    debugLog('DOMContentLoaded handler for SpecsPatch executing');
     const button = findRerunButton();
     if (button) {
+      debugLog('Attaching click listener to rerun button', {
+        buttonId: button.id,
+        dataset: { ...button.dataset },
+      });
       button.addEventListener('click', (event) => {
+        debugLog('Rerun button click handler invoked', {
+          buttonId: button.id,
+          dataset: { ...button.dataset },
+        });
         event.preventDefault();
         const currentId = coerceDocumentId(button.dataset?.docId ?? null);
         if (!currentId) {
+          debugLog('Click handler aborting due to invalid coerceDocumentId result', {
+            raw: button.dataset?.docId ?? null,
+          });
           alert('Invalid document id');
           return;
         }
+        debugLog('Click handler calling runAgainBuckets', { currentId });
         void runAgainBuckets(currentId);
       });
+    } else {
+      debugLog('DOMContentLoaded handler did not find rerun button');
     }
   });
 }


### PR DESCRIPTION
## Summary
- add verbose console logging to the rerun specs front-end helpers and API wrapper
- instrument the FastAPI buckets endpoints and worker pipeline with detailed debug statements
- log spec record persistence helpers so rerun executions can be traced end-to-end

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b8ff8b2a48333ae68a2c1221ef847