### PR TITLE
Add spec run tracing and expose trace reports

### DIFF
--- a/backend/routers/specs_buckets.py
+++ b/backend/routers/specs_buckets.py
@@ -33,6 +33,7 @@ try:
         BUCKET_ARTIFACT_KEY,
         SPEC_BUCKET_ARTIFACT_TYPE,
     )
+    from backend.utils.spec_trace import SpecTracer
     from backend.services.documents import get_document_or_404  # if present
 except Exception:
     # minimal fallbacks to keep this file importable even if some modules moved
@@ -48,6 +49,7 @@ except Exception:
         store_spec_buckets_result,
         wipe_spec_buckets_for_document,
     )
+    from backend.utils.spec_trace import SpecTracer  # type: ignore
 
     def get_document_or_404(session: Session, document_id: int) -> Document:  # type: ignore
         from backend.models import Document  # type: ignore
@@ -143,78 +145,162 @@ async def run_again(
     Wipes cached bucket results (best-effort) then re-runs all bucket prompts concurrently.
     Returns a JSON object: {"ok": true, "buckets": {...}, "messages": [...]}.
     """
+    tracer = SpecTracer(metadata={"trigger": "run_again", "document_id": document_id})
+    tracer.function_call("run_again", document_id=document_id)
     logger.debug("[specs_buckets] run_again invoked", {"document_id": document_id})
-    # Purge cache first (no-op if unavailable)
-    try:
-        logger.debug("[specs_buckets] run_again calling delete_buckets_cache", {"document_id": document_id})
-        delete_buckets_cache(document_id, session=session, settings=settings)  # type: ignore[arg-type]
-    except Exception:
-        logger.exception("[specs_buckets] run_again delete_buckets_cache raised", exc_info=True)
-        pass
 
-    # Resolve document and run the worker
-    doc = get_document_or_404(session, document_id)
-    logger.debug(
-        "[specs_buckets] run_again resolved document",
-        {
-            "document_id": document_id,
-            "doc_hash": getattr(doc, "doc_hash", None) or getattr(doc, "hash", None),
-            "filename": getattr(doc, "filename", None),
-        },
-    )
-
-    # Ensure any previous spec payload is cleared so the new run stores a fresh draft.
-    try:
-        logger.debug("[specs_buckets] run_again wiping spec record", {"document_id": document_id})
-        wipe_spec_buckets_for_document(session, document_id=document_id)
-    except Exception:
-        logger.exception("[specs_buckets] run_again wipe_spec_buckets_for_document raised", exc_info=True)
-        pass
-    # Expect PDFs to already be parsed/available on disk; we only need the text content.
-    # The worker will fetch the parsed text (via artifact store) or re-parse if necessary.
-    result = await run_all_buckets_concurrently(
-        session=session,
-        document=doc,
-        settings=settings,
-    )
-    logger.debug(
-        "[specs_buckets] run_again worker result",
-        {
-            "document_id": document_id,
-            "result_keys": list(result.keys()),
-            "messages": result.get("messages"),
-        },
-    )
-
-    # Persist a single artifact blob with all bucket outputs for this doc.
-    try:
-        logger.debug("[specs_buckets] run_again storing artifact", {"document_id": document_id})
-        store_artifact(
-            session=session,
-            document_id=doc.id,
-            artifact_type=SPEC_BUCKET_ARTIFACT_TYPE,
-            key=BUCKET_ARTIFACT_KEY,
-            inputs=_artifact_inputs(result.get("doc_hash")),
-            body=result,
-        )
-    except Exception:
-        # Do not fail the request just because caching failed.
-        logger.exception("[specs_buckets] run_again store_artifact raised", exc_info=True)
-        pass
-
+    trace_path: str | None = None
+    result: Dict[str, Any] | None = None
     stored_record = None
+    artifact_stored = False
+
     try:
-        logger.debug("[specs_buckets] run_again storing spec record", {"document_id": document_id})
-        stored_record = store_spec_buckets_result(
-            session,
-            document_id=document_id,
-            payload=result,
+        # Purge cache first (no-op if unavailable)
+        try:
+            logger.debug("[specs_buckets] run_again calling delete_buckets_cache", {"document_id": document_id})
+            delete_buckets_cache(document_id, session=session, settings=settings)  # type: ignore[arg-type]
+            tracer.decision("delete_buckets_cache", status="ok", document_id=document_id)
+        except Exception as exc:
+            logger.exception("[specs_buckets] run_again delete_buckets_cache raised", exc_info=True)
+            tracer.decision(
+                "delete_buckets_cache",
+                status="error",
+                document_id=document_id,
+                error=str(exc),
+            )
+
+        # Resolve document and run the worker
+        doc = get_document_or_404(session, document_id)
+        doc_hash = getattr(doc, "doc_hash", None) or getattr(doc, "hash", None)
+        filename = getattr(doc, "filename", None)
+        tracer.metadata(document_hash=doc_hash, document_filename=filename)
+        logger.debug(
+            "[specs_buckets] run_again resolved document",
+            {
+                "document_id": document_id,
+                "doc_hash": doc_hash,
+                "filename": filename,
+            },
         )
+
+        # Ensure any previous spec payload is cleared so the new run stores a fresh draft.
+        try:
+            logger.debug("[specs_buckets] run_again wiping spec record", {"document_id": document_id})
+            wipe_spec_buckets_for_document(session, document_id=document_id)
+            tracer.decision("wipe_spec_record", status="ok", document_id=document_id)
+        except Exception as exc:
+            logger.exception("[specs_buckets] run_again wipe_spec_buckets_for_document raised", exc_info=True)
+            tracer.decision(
+                "wipe_spec_record",
+                status="error",
+                document_id=document_id,
+                error=str(exc),
+            )
+
+        # Expect PDFs to already be parsed/available on disk; we only need the text content.
+        # The worker will fetch the parsed text (via artifact store) or re-parse if necessary.
+        try:
+            result = await run_all_buckets_concurrently(
+                session=session,
+                document=doc,
+                settings=settings,
+                tracer=tracer,
+            )
+        except Exception as exc:
+            tracer.outcome(
+                "run_again_worker",
+                document_id=document_id,
+                ok=False,
+                error=str(exc),
+            )
+            raise
+
+        tracer.decision(
+            "worker_result",
+            document_id=document_id,
+            bucket_count=len(result.get("buckets", {})),
+            message_count=len(result.get("messages", [])),
+            doc_hash=result.get("doc_hash"),
+        )
+        logger.debug(
+            "[specs_buckets] run_again worker result",
+            {
+                "document_id": document_id,
+                "result_keys": list(result.keys()),
+                "messages": result.get("messages"),
+            },
+        )
+
+        # Persist a single artifact blob with all bucket outputs for this doc.
+        try:
+            logger.debug("[specs_buckets] run_again storing artifact", {"document_id": document_id})
+            store_artifact(
+                session=session,
+                document_id=doc.id,
+                artifact_type=SPEC_BUCKET_ARTIFACT_TYPE,
+                key=BUCKET_ARTIFACT_KEY,
+                inputs=_artifact_inputs(result.get("doc_hash")),
+                body=result,
+            )
+            tracer.decision("store_artifact", status="ok", document_id=document_id)
+            artifact_stored = True
+        except Exception as exc:
+            # Do not fail the request just because caching failed.
+            logger.exception("[specs_buckets] run_again store_artifact raised", exc_info=True)
+            tracer.decision(
+                "store_artifact",
+                status="error",
+                document_id=document_id,
+                error=str(exc),
+            )
+
+        try:
+            logger.debug("[specs_buckets] run_again storing spec record", {"document_id": document_id})
+            stored_record = store_spec_buckets_result(
+                session,
+                document_id=document_id,
+                payload=result,
+            )
+            tracer.decision(
+                "store_spec_record",
+                status="ok",
+                document_id=document_id,
+                record_id=getattr(stored_record, "id", None),
+            )
+        except Exception as exc:
+            logger.exception("[specs_buckets] run_again store_spec_buckets_result raised", exc_info=True)
+            tracer.decision(
+                "store_spec_record",
+                status="error",
+                document_id=document_id,
+                error=str(exc),
+            )
+
+        tracer.outcome(
+            "run_again",
+            document_id=document_id,
+            ok=True,
+            artifact_stored=artifact_stored,
+            record_stored=stored_record is not None,
+        )
+
     except Exception:
-        logger.exception("[specs_buckets] run_again store_spec_buckets_result raised", exc_info=True)
-        pass
+        tracer.outcome("run_again", document_id=document_id, ok=False)
+        trace_path = tracer.flush()
+        raise
+    finally:
+        if trace_path is None:
+            trace_path = tracer.flush()
+
+    assert result is not None  # for mypy/static tools
+    result["trace_path"] = trace_path
 
     response: Dict[str, Any] = {"ok": True, **result, "persisted": stored_record is not None}
+    metadata = response.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        response["metadata"] = metadata
+    metadata["trace_path"] = trace_path
     logger.debug(
         "[specs_buckets] run_again response summary",
         {

--- a/backend/services/specs_worker.py
+++ b/backend/services/specs_worker.py
@@ -26,6 +26,7 @@ from backend.services.artifact_store import (
     get_cached_artifact,
     store_artifact,
 )  # type: ignore
+from backend.utils.spec_trace import SpecTracer
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +226,12 @@ VALIDATION
 ]
 
 # ---------- Utilities ----------------------------------------------------------
-async def _openrouter_chat(prompt: str) -> str:
+async def _openrouter_chat(
+    prompt: str,
+    *,
+    tracer: SpecTracer | None = None,
+    bucket: str | None = None,
+) -> str:
     """
     Minimal OpenRouter client using the unofficial fetch via httpx for a single-turn chat.
     We keep it inline to avoid adding dependencies elsewhere in the repo.
@@ -254,6 +260,9 @@ async def _openrouter_chat(prompt: str) -> str:
     }
 
     timeout = httpx.Timeout(SPECS_LLM_TIMEOUT_S)
+    if tracer:
+        tracer.llm_request(bucket=bucket, request_headers=headers, request_body=body)
+
     async with httpx.AsyncClient(timeout=timeout) as client:
         logger.debug(
             "[specs_worker] _openrouter_chat sending request",
@@ -264,10 +273,22 @@ async def _openrouter_chat(prompt: str) -> str:
             "[specs_worker] _openrouter_chat received response",
             {"status_code": r.status_code, "headers": dict(r.headers)},
         )
-        r.raise_for_status()
-        data = r.json()
         try:
-            content = data["choices"][0]["message"]["content"]
+            payload = r.json()
+        except ValueError:
+            payload = {"raw": r.text}
+
+        if tracer:
+            tracer.llm_response(
+                bucket=bucket,
+                status_code=r.status_code,
+                response_headers=dict(r.headers),
+                response_body=payload,
+            )
+
+        r.raise_for_status()
+        try:
+            content = payload["choices"][0]["message"]["content"]  # type: ignore[index]
             logger.debug(
                 "[specs_worker] _openrouter_chat parsed content",
                 {"content_preview": content[:200], "content_length": len(content)},
@@ -275,11 +296,15 @@ async def _openrouter_chat(prompt: str) -> str:
             return content
         except Exception:
             logger.exception("[specs_worker] _openrouter_chat unexpected response structure", exc_info=True)
-            return json.dumps({"error": "Unexpected response", "raw": data})
+            return json.dumps({"error": "Unexpected response", "raw": payload})
 
 
 def _best_doc_text_from_cache(
-    session: Session, document: Document, *, settings: Any | None = None
+    session: Session,
+    document: Document,
+    *,
+    settings: Any | None = None,
+    tracer: SpecTracer | None = None,
 ) -> Tuple[str, Optional[str]]:
     """
     Try to obtain the best available "full text" for the document from the artifact store.
@@ -289,12 +314,16 @@ def _best_doc_text_from_cache(
         "[specs_worker] _best_doc_text_from_cache invoked",
         {"document_id": document.id},
     )
+    if tracer:
+        tracer.function_call("_best_doc_text_from_cache", document_id=document.id)
     # Prefer a dedicated PARSED_TEXT artifact if your repo writes one.
     for key in ("parsed_text", "fulltext", "plain_text"):
         logger.debug(
             "[specs_worker] _best_doc_text_from_cache attempting cache lookup",
             {"document_id": document.id, "key": key},
         )
+        if tracer:
+            tracer.decision("doc_text_cache_lookup", key=key)
         cached = get_cached_artifact(
             session=session,
             document_id=document.id,
@@ -315,7 +344,16 @@ def _best_doc_text_from_cache(
                         "doc_hash": doc_hash,
                     },
                 )
+                if tracer:
+                    tracer.decision(
+                        "doc_text_cache_hit",
+                        key=key,
+                        text_length=len(text),
+                        doc_hash=doc_hash,
+                    )
                 return text, doc_hash
+        if tracer:
+            tracer.decision("doc_text_cache_miss", key=key)
 
     # Fall back to reading the PDF and extracting on the fly (basic PyMuPDF approach).
     # We avoid adding new heavy deps; SimpleSpecs likely already uses PyMuPDF elsewhere.
@@ -330,6 +368,12 @@ def _best_doc_text_from_cache(
                 "settings_upload_dir": getattr(settings, "upload_dir", None),
             },
         )
+        if tracer:
+            tracer.decision(
+                "doc_text_fallback_pymupdf",
+                filename=document.filename,
+                upload_dir=getattr(settings, "upload_dir", None),
+            )
         import fitz  # PyMuPDF
 
         candidate_dirs: List[Path] = []
@@ -370,6 +414,12 @@ def _best_doc_text_from_cache(
                         "pdf_path": str(pdf_path),
                     },
                 )
+                if tracer:
+                    tracer.decision(
+                        "doc_text_pymupdf_success",
+                        pdf_path=str(pdf_path),
+                        text_length=len(joined),
+                    )
                 return joined, None
 
         logger.error(
@@ -380,6 +430,12 @@ def _best_doc_text_from_cache(
                 "checked_paths": checked_paths,
             },
         )
+        if tracer:
+            tracer.decision(
+                "doc_text_pdf_not_found",
+                filename=document.filename,
+                checked_paths=checked_paths,
+            )
         logger.debug(
             "[specs_worker] _best_doc_text_from_cache falling back to PyMuPDF",
             {"document_id": document.id, "filename": document.filename},
@@ -398,10 +454,37 @@ def _best_doc_text_from_cache(
             "[specs_worker] _best_doc_text_from_cache extracted via PyMuPDF",
             {"document_id": document.id, "text_length": len(joined)},
         )
+        if tracer:
+            tracer.decision(
+                "doc_text_pymupdf_success",
+                pdf_path=str(pdf_path),
+                text_length=len(joined),
+            )
         return joined, None
+    except Exception as exc:
+        logger.exception(
+            "[specs_worker] _best_doc_text_from_cache fallback failed",
+            {
+                "document_id": document.id,
+                "filename": getattr(document, "filename", None),
+            },
+            exc_info=True,
+        )
+        if tracer:
+            tracer.decision(
+                "doc_text_fallback_error",
+                error=str(exc),
+                filename=getattr(document, "filename", None),
+            )
+        return "", None
    
 
-async def _run_single_bucket(bucket: Dict[str, str], doc_text: str) -> Dict[str, Any]:
+async def _run_single_bucket(
+    bucket: Dict[str, str],
+    doc_text: str,
+    *,
+    tracer: SpecTracer | None = None,
+) -> Dict[str, Any]:
     name = bucket["name"]
     prompt = bucket["prompt"] + doc_text
     try:
@@ -409,7 +492,9 @@ async def _run_single_bucket(bucket: Dict[str, str], doc_text: str) -> Dict[str,
             "[specs_worker] _run_single_bucket starting",
             {"bucket": name, "prompt_length": len(prompt)},
         )
-        raw = await _openrouter_chat(prompt)
+        if tracer:
+            tracer.function_call("_run_single_bucket", bucket=name, prompt_length=len(prompt))
+        raw = await _openrouter_chat(prompt, tracer=tracer, bucket=name)
         # Try to coerce to JSON when possible
         try:
             data = json.loads(raw)
@@ -423,6 +508,18 @@ async def _run_single_bucket(bucket: Dict[str, str], doc_text: str) -> Dict[str,
                 "parsed_keys": list(data.keys()) if isinstance(data, dict) else None,
             },
         )
+        if tracer:
+            tracer.decision(
+                "bucket_parse",
+                bucket=name,
+                parsed_keys=list(data.keys()) if isinstance(data, dict) else None,
+            )
+            tracer.outcome(
+                "bucket",
+                bucket=name,
+                ok=True,
+                response_preview=raw[:200],
+            )
         return {"name": name, "ok": True, "data": data}
     except Exception as exc:
         logger.exception(
@@ -430,11 +527,17 @@ async def _run_single_bucket(bucket: Dict[str, str], doc_text: str) -> Dict[str,
             name,
             exc_info=True,
         )
+        if tracer:
+            tracer.outcome("bucket", bucket=name, ok=False, error=str(exc))
         return {"name": name, "ok": False, "error": str(exc)}
 
 
 async def run_all_buckets_concurrently(
-    *, session: Session, document: Document, settings: Any = None
+    *,
+    session: Session,
+    document: Document,
+    settings: Any = None,
+    tracer: SpecTracer | None = None,
 ) -> Dict[str, Any]:
     """
     Orchestrates a single concurrent run of all BUCKETS for one document.
@@ -447,8 +550,20 @@ async def run_all_buckets_concurrently(
             "bucket_names": [bucket["name"] for bucket in BUCKETS],
         },
     )
+    bucket_names = [bucket["name"] for bucket in BUCKETS]
+    if tracer:
+        tracer.function_call(
+            "run_all_buckets_concurrently",
+            document_id=document.id,
+            bucket_names=bucket_names,
+        )
+        tracer.metadata(
+            document_id=document.id,
+            document_filename=getattr(document, "filename", None),
+            bucket_names=bucket_names,
+        )
     doc_text, doc_hash = _best_doc_text_from_cache(
-        session, document, settings=settings
+        session, document, settings=settings, tracer=tracer
     )
     logger.debug(
         "[specs_worker] run_all_buckets_concurrently document text status",
@@ -459,12 +574,27 @@ async def run_all_buckets_concurrently(
             "text_length": len(doc_text or ""),
         },
     )
+    if tracer:
+        tracer.decision(
+            "doc_text_status",
+            document_id=document.id,
+            doc_hash=doc_hash,
+            text_available=bool(doc_text),
+            text_length=len(doc_text or ""),
+        )
     if not doc_text:
         # We don't fail hard; return an informative structure
         logger.debug(
             "[specs_worker] run_all_buckets_concurrently no doc text",
             {"document_id": document.id},
         )
+        if tracer:
+            tracer.outcome(
+                "run",
+                document_id=document.id,
+                ok=False,
+                reason="no_parsed_text",
+            )
         return {
             "doc_id": document.id,
             "doc_hash": doc_hash,
@@ -481,7 +611,7 @@ async def run_all_buckets_concurrently(
     async def guarded(bucket):
         async with sem:
             logger.debug("[specs_worker] run_all_buckets_concurrently entering bucket", {"bucket": bucket["name"]})
-            return await _run_single_bucket(bucket, doc_text)
+            return await _run_single_bucket(bucket, doc_text, tracer=tracer)
 
     results = await asyncio.gather(*(guarded(b) for b in BUCKETS))
     logger.debug(
@@ -503,6 +633,13 @@ async def run_all_buckets_concurrently(
         else:
             buckets_out[name] = {"error": item.get("error", "unknown")}
             messages.append(f"Bucket {name} failed: {item.get('error')}")
+        if tracer:
+            tracer.outcome(
+                "bucket_result",
+                bucket=name,
+                ok=bool(item.get("ok")),
+                error=item.get("error"),
+            )
 
     logger.debug(
         "[specs_worker] run_all_buckets_concurrently assembled output",
@@ -512,6 +649,13 @@ async def run_all_buckets_concurrently(
             "messages": messages,
         },
     )
+    if tracer:
+        tracer.outcome(
+            "run",
+            document_id=document.id,
+            ok=True,
+            message_count=len(messages),
+        )
     return {
         "doc_id": document.id,
         "doc_hash": doc_hash,

--- a/backend/utils/spec_trace.py
+++ b/backend/utils/spec_trace.py
@@ -1,0 +1,148 @@
+"""Structured tracing utilities for specification bucket runs."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SpecTracer:
+    """Collect structured events for specification bucket executions."""
+
+    def __init__(
+        self,
+        *,
+        run_id: str | None = None,
+        out_dir: str = "backend/logs/specs",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.run_id = run_id or str(uuid.uuid4())
+        self.out_dir = Path(out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self._path = self.out_dir / f"{self.run_id}.json"
+        self._closed = False
+        self._metadata: MutableMapping[str, Any] = dict(metadata or {})
+        self._events: list[dict[str, Any]] = []
+        self._started_at = time.time()
+        LOGGER.debug("[specs] SpecTracer created", {"run_id": self.run_id, "path": str(self._path)})
+
+    # ------------------------------------------------------------------
+    def metadata(self, **fields: Any) -> None:
+        """Attach metadata to the trace and emit a metadata event."""
+
+        if not fields:
+            return
+        self._metadata.update({k: v for k, v in fields.items() if v is not None})
+        self._record("metadata", **fields)
+
+    def function_call(self, name: str, **context: Any) -> None:
+        self._record("function_call", name=name, **context)
+
+    def llm_request(self, *, bucket: str | None, request_headers: Mapping[str, Any], request_body: Mapping[str, Any]) -> None:
+        self._record(
+            "llm_request",
+            bucket=bucket,
+            headers=dict(request_headers),
+            body=json.loads(json.dumps(request_body)),
+        )
+
+    def llm_response(
+        self,
+        *,
+        bucket: str | None,
+        status_code: int,
+        response_headers: Mapping[str, Any],
+        response_body: Mapping[str, Any] | list[Any] | str,
+    ) -> None:
+        try:
+            serialisable_body = json.loads(json.dumps(response_body))
+        except Exception:
+            serialisable_body = response_body
+        self._record(
+            "llm_response",
+            bucket=bucket,
+            status_code=status_code,
+            headers=dict(response_headers),
+            body=serialisable_body,
+        )
+
+    def decision(self, name: str, **data: Any) -> None:
+        self._record("decision", name=name, **data)
+
+    def outcome(self, name: str, **data: Any) -> None:
+        self._record("outcome", name=name, **data)
+
+    def message(self, text: str, **data: Any) -> None:
+        self._record("message", text=text, **data)
+
+    # ------------------------------------------------------------------
+    def flush(self) -> str:
+        """Persist the trace to disk and return the path."""
+
+        if self._closed:
+            return str(self._path)
+
+        finished_at = time.time()
+        summary = self._build_summary(finished_at)
+        with self._path.open("w", encoding="utf-8") as handle:
+            json.dump(summary, handle, ensure_ascii=False, indent=2)
+        os.chmod(self._path, 0o600)
+        self._closed = True
+        LOGGER.info("[specs] Spec trace saved", {"run_id": self.run_id, "path": str(self._path)})
+        return str(self._path)
+
+    @property
+    def path(self) -> str:
+        return str(self._path)
+
+    # ------------------------------------------------------------------
+    def _record(self, event_type: str, **data: Any) -> None:
+        payload = {"type": event_type, "ts": time.time(), **data}
+        self._events.append(payload)
+
+    def _build_summary(self, finished_at: float) -> Dict[str, Any]:
+        started_dt = datetime.fromtimestamp(self._started_at, tz=timezone.utc)
+        finished_dt = datetime.fromtimestamp(finished_at, tz=timezone.utc)
+        events = [self._normalise_event(event) for event in self._events]
+
+        summary: Dict[str, Any] = {
+            "run_id": self.run_id,
+            "metadata": dict(self._metadata),
+            "started_at": started_dt.isoformat(),
+            "finished_at": finished_dt.isoformat(),
+            "duration_seconds": round(finished_at - self._started_at, 3),
+            "function_calls": [self._strip_type(event) for event in events if event["type"] == "function_call"],
+            "llm_requests": [self._strip_type(event) for event in events if event["type"] == "llm_request"],
+            "llm_responses": [self._strip_type(event) for event in events if event["type"] == "llm_response"],
+            "decisions": [self._strip_type(event) for event in events if event["type"] == "decision"],
+            "outcomes": [self._strip_type(event) for event in events if event["type"] == "outcome"],
+            "messages": [self._strip_type(event) for event in events if event["type"] == "message"],
+            "events": events,
+        }
+        return summary
+
+    @staticmethod
+    def _normalise_event(event: Mapping[str, Any]) -> Dict[str, Any]:
+        payload = dict(event)
+        ts = payload.pop("ts", None)
+        if ts is not None:
+            payload["timestamp"] = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+        return payload
+
+    @staticmethod
+    def _strip_type(event: Mapping[str, Any]) -> Dict[str, Any]:
+        payload = dict(event)
+        payload.pop("type", None)
+        return payload
+
+
+__all__ = ["SpecTracer"]


### PR DESCRIPTION
## Summary
- add a reusable `SpecTracer` utility that captures spec run metadata and writes structured logs under `backend/logs/specs`
- instrument the specs worker to record function calls, cache decisions, and LLM traffic into the new tracer
- update the specs rerun endpoint to drive the tracer, log persistence decisions, and surface the trace path in API responses

## Testing
- pytest backend/tests -k specs

------
https://chatgpt.com/codex/tasks/task_e_690bae597fc483338a8479b129ff2a11