### PR TITLE
Prevent header LLM requests from blocking the event loop

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -107,7 +107,7 @@ async def extract_headers_and_chunks(
     )
     if use_simple_llm:
         try:
-            llm_obj = get_headers_llm_json(document_id, session, settings)
+            llm_obj = await get_headers_llm_json(document_id, session, settings)
         except InvalidLLMJSONError:
             return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/services/headers_llm_simple.py
+++ b/backend/services/headers_llm_simple.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
+import anyio
+
 from fastapi import HTTPException
 
 from ..config import Settings
@@ -90,7 +92,7 @@ def _strip_fences(payload: str) -> str:
     return text.strip()
 
 
-def get_headers_llm_json(
+async def get_headers_llm_json(
     document_id: int,
     session,
     settings: Settings,
@@ -110,11 +112,13 @@ def get_headers_llm_json(
         messages.append({"role": "user", "content": prefix + chunk})
 
     try:
-        response_text = openrouter_client.chat(
-            messages,
-            model=settings.headers_llm_model,
-            temperature=0.0,
-            timeout_read=settings.headers_llm_timeout_s,
+        response_text = await anyio.to_thread.run_sync(
+            lambda: openrouter_client.chat(
+                messages,
+                model=settings.headers_llm_model,
+                temperature=0.0,
+                timeout_read=settings.headers_llm_timeout_s,
+            ),
         )
     except openrouter_client.OpenRouterError as exc:  # pragma: no cover - network failure
         raise HTTPException(


### PR DESCRIPTION
## Summary
- make the simple headers LLM helper asynchronous and execute the OpenRouter chat call in a worker thread
- await the asynchronous helper from the headers API so the FastAPI event loop is not blocked during long LLM calls

## Testing
- pytest tests/test_headers_llm_simple.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e991292dc8333a8e71ba74811214d)