### PR TITLE
Restrict spec extraction to mechanical agent

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -64,6 +64,22 @@ def _parse_weights(raw: str | None) -> tuple[float, ...]:
             continue
     return tuple(parts) if parts else (0.55, 0.30, 0.10, 0.05)
 
+
+def _parse_csv(raw: str | None) -> tuple[str, ...]:
+    """Return a tuple of non-empty strings parsed from ``raw``."""
+
+    if raw is None:
+        return ()
+    items = [part.strip() for part in raw.split(",") if part.strip()]
+    return tuple(items)
+
+
+def _default_spec_agents() -> tuple[str, ...]:
+    """Return the configured spec agents or a Mechanical-only default."""
+
+    parsed = _parse_csv(os.getenv("SPECS_ENABLED_AGENTS", "Mechanical"))
+    return parsed or ("Mechanical",)
+
 HEADERS_ALIGN_STRATEGY: str = os.getenv("HEADERS_ALIGN_STRATEGY", "sequential")
 HEADERS_SUPPRESS_TOC: bool = os.getenv("HEADERS_SUPPRESS_TOC", "1") in (
     "1",
@@ -506,6 +522,12 @@ class Settings(BaseModel):
     )
     specs_backoff_s: float = Field(
         default_factory=lambda: float(os.getenv("SPECS_BACKOFF_S", "1.5"))
+    )
+    specs_max_headers: int = Field(
+        default_factory=lambda: int(os.getenv("SPECS_MAX_HEADERS", "10"))
+    )
+    specs_enabled_agents: Tuple[str, ...] = Field(
+        default_factory=_default_spec_agents
     )
 
     @field_validator("upload_dir", mode="after")

--- a/backend/spec_extraction/__init__.py
+++ b/backend/spec_extraction/__init__.py
@@ -12,6 +12,14 @@ from backend.config import PROJECT_ROOT, get_settings
 
 from .models import Agent
 
+_AGENT_DESCRIPTIONS: dict[str, str] = {
+    "Mechanical": "Mechanical discipline specialist",
+    "Electrical": "Electrical discipline specialist",
+    "Controls": "Controls and automation specialist",
+    "Software": "Software and firmware specialist",
+    "ProjectManagement": "Project management specialist",
+}
+
 _ENGINE = None
 
 
@@ -63,22 +71,17 @@ def init_db() -> None:
 
 
 def _seed_agents(session: Session) -> None:
-    """Ensure the five built-in agent descriptors exist."""
+    """Ensure configured agent descriptors exist in the database."""
 
     existing = set(session.exec(select(Agent.code)))
-    required = {
-        "Mechanical": "Mechanical discipline specialist",
-        "Electrical": "Electrical discipline specialist",
-        "Controls": "Controls and automation specialist",
-        "Software": "Software and firmware specialist",
-        "ProjectManagement": "Project management specialist",
-    }
-    missing = required.keys() - existing
-    if not missing:
-        return
+    settings = get_settings()
+    enabled = tuple(settings.specs_enabled_agents) or ("Mechanical",)
+    allowed = [code for code in enabled if code in _AGENT_DESCRIPTIONS]
+    missing = set(allowed) - existing
     for code in missing:
-        session.add(Agent(code=code, description=required[code]))
-    session.commit()
+        session.add(Agent(code=code, description=_AGENT_DESCRIPTIONS[code]))
+    if missing:
+        session.commit()
 
 
 def reset_engine() -> None:

--- a/backend/spec_extraction/jobs.py
+++ b/backend/spec_extraction/jobs.py
@@ -11,6 +11,7 @@ from typing import Iterable, Iterator, Sequence
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
+from backend.config import get_settings
 from backend.services.simpleheaders_state import SimpleHeadersState
 
 from . import get_engine, init_db
@@ -64,8 +65,25 @@ class _AgentSnapshot:
     code: str
 
 
+def _section_sort_key(section: Section) -> tuple:
+    """Return a deterministic ordering key for sections."""
+
+    return (
+        section.start_global_idx is None,
+        section.start_global_idx or 0,
+        section.page_start is None,
+        section.page_start or 0,
+        section.created_at,
+        section.id,
+    )
+
+
 async def enqueue_jobs_for_document(document_id: str) -> tuple[int, int]:
     """Create queued jobs for every section/agent combination."""
+
+    settings = get_settings()
+    enabled_agents = tuple(settings.specs_enabled_agents) or ("Mechanical",)
+    max_headers = settings.specs_max_headers
 
     with _session_scope() as session:
         document = session.get(Document, document_id)
@@ -77,9 +95,16 @@ async def enqueue_jobs_for_document(document_id: str) -> tuple[int, int]:
         if not sections:
             return 0, 0
 
-        agents = session.exec(select(Agent)).all()
+        sections = sorted(sections, key=_section_sort_key)
+        if max_headers and max_headers > 0:
+            sections = sections[:max_headers]
+
+        agent_query = select(Agent)
+        if enabled_agents:
+            agent_query = agent_query.where(Agent.code.in_(enabled_agents))
+        agents = session.exec(agent_query).all()
         if not agents:
-            return 0, 0
+            return len(sections), 0
 
         sections_count = len(sections)
         jobs_created = 0

--- a/backend/spec_extraction/router.py
+++ b/backend/spec_extraction/router.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 from sqlmodel import Session, select
 
+from backend.config import get_settings
+
 from . import get_engine
 from .jobs import enqueue_jobs_for_document, list_job_ids, run_job
 from .models import Agent, Document, Section, SpecRecord
@@ -58,7 +60,12 @@ async def list_specs(documentId: str = Query(...)) -> Any:
         sections = session.exec(
             select(Section).where(Section.document_id == document_id)
         ).all()
-        agents = session.exec(select(Agent)).all()
+        settings = get_settings()
+        enabled_agents = tuple(settings.specs_enabled_agents) or ("Mechanical",)
+        agent_stmt = select(Agent)
+        if enabled_agents:
+            agent_stmt = agent_stmt.where(Agent.code.in_(enabled_agents))
+        agents = session.exec(agent_stmt).all()
         section_ids = [section.id for section in sections]
         records = (
             session.exec(
@@ -113,7 +120,12 @@ async def get_section_specs(section_id: UUID) -> Any:
         document = session.get(Document, section.document_id)
         if document is None:
             raise HTTPException(status_code=404, detail="Document not indexed for specs")
-        agents = session.exec(select(Agent)).all()
+        settings = get_settings()
+        enabled_agents = tuple(settings.specs_enabled_agents) or ("Mechanical",)
+        agent_stmt = select(Agent)
+        if enabled_agents:
+            agent_stmt = agent_stmt.where(Agent.code.in_(enabled_agents))
+        agents = session.exec(agent_stmt).all()
         records = session.exec(
             select(SpecRecord).where(SpecRecord.section_id == section_key)
         ).all()

--- a/tests/spec_extraction/test_dispatch_enqueues_jobs.py
+++ b/tests/spec_extraction/test_dispatch_enqueues_jobs.py
@@ -8,7 +8,7 @@ from backend.spec_extraction.models import AgentJob, Section
 
 
 def test_dispatch_enqueues_jobs(client, monkeypatch) -> None:
-    """Dispatching should queue five jobs per section without running them."""
+    """Dispatching should queue one Mechanical job per section without running it."""
 
     persist_sections(
         document_id="1",
@@ -45,16 +45,64 @@ def test_dispatch_enqueues_jobs(client, monkeypatch) -> None:
         "ok": True,
         "documentId": "1",
         "sectionsEnqueued": 2,
-        "jobsCreated": 10,
+        "jobsCreated": 2,
     }
 
     with Session(get_engine()) as session:
         jobs = session.exec(select(AgentJob)).all()
-        assert len(jobs) == 10
+        assert len(jobs) == 2
         assert {job.state for job in jobs} == {"queued"}
         sections = session.exec(select(Section)).all()
         assert len(sections) == 2
         assert {section.status for section in sections} == {"running"}
 
     # Background tasks should receive every job identifier once.
+    assert len(captured) == 2
+
+
+def test_dispatch_respects_header_limit(client, monkeypatch) -> None:
+    """Only the first configured number of sections should be enqueued."""
+
+    sections = []
+    for idx in range(12):
+        sections.append(
+            {
+                "header_text": f"Section {idx+1}",
+                "start_page": idx + 1,
+                "end_page": idx + 1,
+                "start_global_idx": idx * 5,
+                "end_global_idx": idx * 5 + 4,
+            }
+        )
+
+    persist_sections(document_id="9", filename="limit.pdf", sections=sections)
+
+    captured: list[str] = []
+
+    async def _noop(job_id: str) -> None:
+        captured.append(job_id)
+
+    monkeypatch.setattr("backend.spec_extraction.router.run_job", _noop)
+
+    response = client.post("/api/specs/dispatch", json={"documentId": "9"})
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload == {
+        "ok": True,
+        "documentId": "9",
+        "sectionsEnqueued": 10,
+        "jobsCreated": 10,
+    }
+
+    with Session(get_engine()) as session:
+        all_sections = session.exec(select(Section).where(Section.document_id == "9")).all()
+        running = [section for section in all_sections if section.status == "running"]
+        pending = [section for section in all_sections if section.status == "pending"]
+        assert len(running) == 10
+        assert len(pending) == 2
+        jobs = session.exec(
+            select(AgentJob).where(AgentJob.section_id.in_([section.id for section in all_sections]))
+        ).all()
+        assert len(jobs) == 10
+
     assert len(captured) == 10

--- a/tests/spec_extraction/test_get_specs.py
+++ b/tests/spec_extraction/test_get_specs.py
@@ -59,7 +59,7 @@ def test_get_specs_endpoints(client) -> None:
     assert section_payload["sectionId"] == section_id
     assert section_payload["specs"]["Mechanical"]["result"]["requirements"][0]["text"] == "Install guard rails."
     assert section_payload["specs"]["Mechanical"]["confidence"] == "0.820"
-    assert section_payload["specs"]["Electrical"] is None
+    assert list(section_payload["specs"].keys()) == ["Mechanical"]
 
     single = client.get(f"/api/specs/{section_id}")
     assert single.status_code == 200

--- a/tests/spec_extraction/test_models_and_seed.py
+++ b/tests/spec_extraction/test_models_and_seed.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from backend.spec_extraction import get_engine, init_db
 from backend.spec_extraction.models import Agent, Document, Section
@@ -9,15 +9,14 @@ from backend.spec_extraction.models import Agent, Document, Section
 def test_agent_seed_and_models(monkeypatch) -> None:
     init_db()
     with Session(get_engine()) as session:
+        session.exec(delete(Agent))
+        session.commit()
+
+    init_db()
+    with Session(get_engine()) as session:
         agents = session.exec(select(Agent)).all()
         codes = {agent.code for agent in agents}
-        assert codes == {
-            "Mechanical",
-            "Electrical",
-            "Controls",
-            "Software",
-            "ProjectManagement",
-        }
+        assert codes == {"Mechanical"}
 
         document = Document(id="doc-1", filename="sample.pdf")
         session.add(document)

--- a/tests/spec_extraction/test_normative_tripwire.py
+++ b/tests/spec_extraction/test_normative_tripwire.py
@@ -60,7 +60,7 @@ def test_normative_tripwire_triggers_fallback() -> None:
         filename="doc.pdf",
         sections=[
             {
-                "header_text": "Electrical",
+                "header_text": "Mechanical",
                 "start_page": 6,
                 "end_page": 7,
                 "start_global_idx": 20,
@@ -73,8 +73,8 @@ def test_normative_tripwire_triggers_fallback() -> None:
         1,
         "hash",
         [
-            {"global_idx": 20, "text": "The subsystem shall provide uninterrupted power."},
-            {"global_idx": 21, "text": "Backup supply must start within 5 seconds."},
+            {"global_idx": 20, "text": "The assembly shall resist 5 g vibration."},
+            {"global_idx": 21, "text": "Fasteners must be torqued to 45 N·m."},
         ],
     )
 
@@ -85,7 +85,7 @@ def test_normative_tripwire_triggers_fallback() -> None:
 
     with Session(get_engine()) as session:
         section = session.exec(select(Section)).one()
-        agent = session.exec(select(Agent).where(Agent.code == "Electrical")).one()
+        agent = session.exec(select(Agent).where(Agent.code == "Mechanical")).one()
         job = session.exec(
             select(AgentJob)
             .where(AgentJob.section_id == section.id)

--- a/tests/spec_extraction/test_run_job_retry_and_error.py
+++ b/tests/spec_extraction/test_run_job_retry_and_error.py
@@ -24,7 +24,7 @@ def test_run_job_retry_and_error() -> None:
         filename="doc.pdf",
         sections=[
             {
-                "header_text": "Controls",
+                "header_text": "Mechanical",
                 "start_page": 4,
                 "end_page": 5,
                 "start_global_idx": 10,
@@ -37,8 +37,8 @@ def test_run_job_retry_and_error() -> None:
         1,
         "hash",
         [
-            {"global_idx": 10, "text": "Control panel should provide redundancy."},
-            {"global_idx": 11, "text": "Add alarm logic."},
+            {"global_idx": 10, "text": "Support frame should provide redundancy."},
+            {"global_idx": 11, "text": "Add guard rail."},
         ],
     )
 
@@ -46,14 +46,14 @@ def test_run_job_retry_and_error() -> None:
 
     failing = MockLLMClient(
         responses={
-            ("Controls", "primary"): ["missing fence", "ABORT"],
+            ("Mechanical", "primary"): ["missing fence", "ABORT"],
         }
     )
     set_llm_client(failing)
 
     with Session(get_engine()) as session:
         section = session.exec(select(Section)).one()
-        agent = session.exec(select(Agent).where(Agent.code == "Controls")).one()
+        agent = session.exec(select(Agent).where(Agent.code == "Mechanical")).one()
         job = session.exec(
             select(AgentJob)
             .where(AgentJob.section_id == section.id)

--- a/tests/spec_extraction/test_run_job_success.py
+++ b/tests/spec_extraction/test_run_job_success.py
@@ -86,4 +86,4 @@ def test_run_job_success() -> None:
 
         section = session.get(Section, section_id)
         assert section is not None
-        assert section.status == "running"
+        assert section.status == "complete"


### PR DESCRIPTION
## Summary
- add configuration knobs to cap spec extraction to the first 10 headers and enable only the Mechanical agent by default
- filter seeded agents, job queueing, and spec APIs to honour the configured agent list and section limit
- update and extend spec extraction tests for the Mechanical-only workflow and the section cap

## Testing
- `pytest tests/spec_extraction -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f282ba0c883339fd8654c7d9ff0fb)