### PR TITLE
Add detailed spec search reporting

### DIFF
--- a/backend/spec_search/__init__.py
+++ b/backend/spec_search/__init__.py
@@ -1,5 +1,6 @@
 """Spec search package wiring for SimpleSpecs."""
 
 from .extractor import extract_buckets
+from .reporting import SpecSearchReporter
 
-__all__ = ["extract_buckets"]
+__all__ = ["extract_buckets", "SpecSearchReporter"]

--- a/backend/spec_search/extractor.py
+++ b/backend/spec_search/extractor.py
@@ -19,6 +19,7 @@ from .models import (
 )
 from .normalize import detect_normative_terms, next_requirement_id
 from .prompt import SYSTEM_PROMPT, build_user_prompt
+from .reporting import SpecSearchReporter
 from .validators import AbortSignal, ValidationError, dedupe_requirements, validate_schema
 
 DEFAULT_BUCKETS = ["mechanical", "electrical", "software", "controls"]
@@ -67,8 +68,12 @@ async def extract_buckets(
     text: str,
     buckets: Sequence[str] | None = None,
     llm_client: Optional[LLMClient] = None,
+    reporter: Optional[SpecSearchReporter] = None,
 ) -> SpecSearchResponse:
     """Run the extraction retry ladder and return a stable response."""
+
+    reporter = reporter or SpecSearchReporter.disabled()
+    reporter.log("pipeline.start", text_length=len(text))
 
     if buckets is None:
         buckets = DEFAULT_BUCKETS
@@ -76,7 +81,6 @@ async def extract_buckets(
     client = llm_client or create_default_client()
     meta = SpecSearchMeta()
     normative_hits = detect_normative_terms(text)
-
     success_payload: Optional[Dict[str, BucketResult]] = None
     rung_plan = [
         "try-1",
@@ -85,15 +89,37 @@ async def extract_buckets(
         "fallback-model",
         "legacy",
     ]
+    reporter.log(
+        "pipeline.configured",
+        buckets=bucket_list,
+        normative_hits=normative_hits,
+        rung_plan=rung_plan,
+    )
 
     async def record_and_wait(attempt: AttemptTelemetry, attempt_index: int) -> None:
         meta.attempts.append(attempt)
+        reporter.log(
+            "attempt.recorded",
+            rung=attempt.rung,
+            model=attempt.model,
+            parsed=attempt.parsed,
+            reason=attempt.reason.value,
+            response_bytes=attempt.response_bytes,
+            input_tokens=attempt.input_tokens_est,
+            attempt_index=attempt_index,
+        )
         if attempt.rung != "legacy" and attempt.reason != AttemptReason.OK:
             await _sleep_backoff(attempt_index)
 
     for attempt_index, rung in enumerate(rung_plan):
+        reporter.log("attempt.start", rung=rung, attempt_index=attempt_index)
         if rung == "try-1":
             prompt = build_user_prompt(text, bucket_list)
+            reporter.log(
+                "attempt.prompt_prepared",
+                rung=rung,
+                prompt_tokens=approximate_tokens(prompt),
+            )
             try:
                 raw = await _call_model(
                     client,
@@ -102,7 +128,14 @@ async def extract_buckets(
                     spec_search_settings.MAX_TOKENS,
                     spec_search_settings.TIMEOUT_S,
                 )
+                reporter.log(
+                    "attempt.model_completed",
+                    rung=rung,
+                    model=spec_search_settings.PRIMARY_MODEL,
+                    bytes=len(raw.encode("utf-8")),
+                )
                 validated = validate_schema(raw, bucket_list)
+                reporter.log("attempt.schema_valid", rung=rung)
                 dedupe_requirements(validated)
                 validated = _assign_ids(validated)
                 total_requirements = sum(len(b.requirements) for b in validated.values())
@@ -124,6 +157,7 @@ async def extract_buckets(
                     break
                 continue
             except AbortSignal:
+                reporter.log("attempt.abort_signal", rung=rung)
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -140,6 +174,11 @@ async def extract_buckets(
                     mapped = AttemptReason.BAD_LABEL
                 elif exc.reason == "invalid_json":
                     mapped = AttemptReason.INVALID_JSON
+                reporter.log(
+                    "attempt.validation_error",
+                    rung=rung,
+                    reason=exc.reason,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -150,7 +189,13 @@ async def extract_buckets(
                 )
                 await record_and_wait(attempt, attempt_index)
                 continue
-            except Exception:
+            except Exception as exc:
+                reporter.log(
+                    "attempt.exception",
+                    rung=rung,
+                    error=str(exc),
+                    error_type=exc.__class__.__name__,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -163,6 +208,11 @@ async def extract_buckets(
                 continue
         elif rung == "try-2":
             prompt = build_user_prompt(text, bucket_list) + "\nFormat reminder: respond only with the SIMPLEBUCKETS fence."
+            reporter.log(
+                "attempt.prompt_prepared",
+                rung=rung,
+                prompt_tokens=approximate_tokens(prompt),
+            )
             try:
                 raw = await _call_model(
                     client,
@@ -171,7 +221,14 @@ async def extract_buckets(
                     max(spec_search_settings.MAX_TOKENS // 2, 4096),
                     spec_search_settings.TIMEOUT_S,
                 )
+                reporter.log(
+                    "attempt.model_completed",
+                    rung=rung,
+                    model=spec_search_settings.PRIMARY_MODEL,
+                    bytes=len(raw.encode("utf-8")),
+                )
                 validated = validate_schema(raw, bucket_list)
+                reporter.log("attempt.schema_valid", rung=rung)
                 dedupe_requirements(validated)
                 validated = _assign_ids(validated)
                 total_requirements = sum(len(b.requirements) for b in validated.values())
@@ -192,6 +249,7 @@ async def extract_buckets(
                     break
                 continue
             except AbortSignal:
+                reporter.log("attempt.abort_signal", rung=rung)
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -208,6 +266,11 @@ async def extract_buckets(
                     mapped = AttemptReason.BAD_LABEL
                 elif exc.reason == "invalid_json":
                     mapped = AttemptReason.INVALID_JSON
+                reporter.log(
+                    "attempt.validation_error",
+                    rung=rung,
+                    reason=exc.reason,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -218,7 +281,13 @@ async def extract_buckets(
                 )
                 await record_and_wait(attempt, attempt_index)
                 continue
-            except Exception:
+            except Exception as exc:
+                reporter.log(
+                    "attempt.exception",
+                    rung=rung,
+                    error=str(exc),
+                    error_type=exc.__class__.__name__,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -236,6 +305,12 @@ async def extract_buckets(
             failure_reason: AttemptReason | None = None
             for chunk_index, chunk in enumerate(chunks, start=1):
                 prompt = build_user_prompt(chunk, bucket_list) + f"\n(Chunk {chunk_index}/{len(chunks)})"
+                reporter.log(
+                    "chunk.start",
+                    rung=rung,
+                    chunk_index=chunk_index,
+                    prompt_tokens=approximate_tokens(prompt),
+                )
                 try:
                     raw = await _call_model(
                         client,
@@ -245,10 +320,26 @@ async def extract_buckets(
                         spec_search_settings.TIMEOUT_S,
                     )
                     total_bytes += len(raw.encode("utf-8"))
+                    reporter.log(
+                        "chunk.model_completed",
+                        rung=rung,
+                        chunk_index=chunk_index,
+                        bytes=len(raw.encode("utf-8")),
+                    )
                     validated = validate_schema(raw, bucket_list)
+                    reporter.log(
+                        "chunk.schema_valid",
+                        rung=rung,
+                        chunk_index=chunk_index,
+                    )
                     dedupe_requirements(validated)
                     chunk_payloads.append(validated)
                 except AbortSignal:
+                    reporter.log(
+                        "chunk.abort_signal",
+                        rung=rung,
+                        chunk_index=chunk_index,
+                    )
                     failure_reason = AttemptReason.ABORT_TOKEN
                     break
                 except ValidationError as exc:
@@ -258,8 +349,21 @@ async def extract_buckets(
                         failure_reason = AttemptReason.INVALID_JSON
                     else:
                         failure_reason = AttemptReason.MISSING_FENCE
+                    reporter.log(
+                        "chunk.validation_error",
+                        rung=rung,
+                        chunk_index=chunk_index,
+                        reason=exc.reason,
+                    )
                     break
-                except Exception:
+                except Exception as exc:
+                    reporter.log(
+                        "chunk.exception",
+                        rung=rung,
+                        chunk_index=chunk_index,
+                        error=str(exc),
+                        error_type=exc.__class__.__name__,
+                    )
                     failure_reason = AttemptReason.OTHER
                     break
             token_estimate = sum(
@@ -272,6 +376,11 @@ async def extract_buckets(
                 reason = AttemptReason.OK
                 if normative_hits > 0 and total_requirements == 0:
                     reason = AttemptReason.EMPTY
+                reporter.log(
+                    "chunked.success",
+                    chunk_count=len(chunks),
+                    total_requirements=total_requirements,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -285,6 +394,11 @@ async def extract_buckets(
                     success_payload = stitched
                     break
             else:
+                reporter.log(
+                    "chunked.failed",
+                    chunk_count=len(chunks),
+                    failure_reason=failure_reason.value,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.PRIMARY_MODEL,
@@ -297,6 +411,11 @@ async def extract_buckets(
             continue
         elif rung == "fallback-model":
             prompt = build_user_prompt(text, bucket_list)
+            reporter.log(
+                "attempt.prompt_prepared",
+                rung=rung,
+                prompt_tokens=approximate_tokens(prompt),
+            )
             try:
                 raw = await _call_model(
                     client,
@@ -305,7 +424,14 @@ async def extract_buckets(
                     spec_search_settings.MAX_TOKENS,
                     spec_search_settings.TIMEOUT_S,
                 )
+                reporter.log(
+                    "attempt.model_completed",
+                    rung=rung,
+                    model=spec_search_settings.FALLBACK_MODEL,
+                    bytes=len(raw.encode("utf-8")),
+                )
                 validated = validate_schema(raw, bucket_list)
+                reporter.log("attempt.schema_valid", rung=rung)
                 dedupe_requirements(validated)
                 validated = _assign_ids(validated)
                 total_requirements = sum(len(b.requirements) for b in validated.values())
@@ -326,6 +452,7 @@ async def extract_buckets(
                     break
                 continue
             except AbortSignal:
+                reporter.log("attempt.abort_signal", rung=rung)
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.FALLBACK_MODEL,
@@ -342,6 +469,11 @@ async def extract_buckets(
                     mapped = AttemptReason.BAD_LABEL
                 elif exc.reason == "invalid_json":
                     mapped = AttemptReason.INVALID_JSON
+                reporter.log(
+                    "attempt.validation_error",
+                    rung=rung,
+                    reason=exc.reason,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.FALLBACK_MODEL,
@@ -352,7 +484,13 @@ async def extract_buckets(
                 )
                 await record_and_wait(attempt, attempt_index)
                 continue
-            except Exception:
+            except Exception as exc:
+                reporter.log(
+                    "attempt.exception",
+                    rung=rung,
+                    error=str(exc),
+                    error_type=exc.__class__.__name__,
+                )
                 attempt = _build_attempt(
                     rung,
                     spec_search_settings.FALLBACK_MODEL,
@@ -371,6 +509,11 @@ async def extract_buckets(
             if normative_hits > 0 and total_requirements == 0:
                 reason = AttemptReason.EMPTY
                 meta.warnings.append("normative_tripwire_triggered_empty_result")
+            reporter.log(
+                "legacy.executed",
+                total_requirements=total_requirements,
+                warnings=list(meta.warnings),
+            )
             attempt = _build_attempt(
                 rung,
                 "legacy",
@@ -383,13 +526,27 @@ async def extract_buckets(
             success_payload = legacy_payload
             break
 
-    if success_payload is not None:
-        response = SpecSearchResponse(ok=True, data=SpecSearchData(success_payload), meta=meta)
+    status = "failure"
+    try:
+        if success_payload is not None:
+            status = "success"
+            response = SpecSearchResponse(ok=True, data=SpecSearchData(success_payload), meta=meta)
+        else:
+            response = SpecSearchResponse(
+                ok=False,
+                error="Failed to extract requirements",
+                data=SpecSearchData.empty(bucket_list),
+                meta=meta,
+            )
         return response
-
-    return SpecSearchResponse(
-        ok=False,
-        error="Failed to extract requirements",
-        data=SpecSearchData.empty(bucket_list),
-        meta=meta,
-    )
+    except Exception as exc:
+        reporter.log("pipeline.exception", error=str(exc), error_type=exc.__class__.__name__)
+        raise
+    finally:
+        if reporter.enabled:
+            reporter.finalize(
+                status=status,
+                attempts=len(meta.attempts),
+                warnings=list(meta.warnings),
+            )
+            meta.log_path = reporter.log_path

--- a/backend/spec_search/models.py
+++ b/backend/spec_search/models.py
@@ -69,6 +69,7 @@ class SpecSearchMeta(BaseModel):
 
     attempts: List[AttemptTelemetry] = Field(default_factory=list)
     warnings: List[str] = Field(default_factory=list)
+    log_path: Optional[str] = None
 
 
 class SpecSearchData(RootModel):

--- a/backend/spec_search/reporting.py
+++ b/backend/spec_search/reporting.py
@@ -1,0 +1,97 @@
+"""Reporting utilities for the spec-search pipeline."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from backend.config import PROJECT_ROOT
+
+
+def _utcnow() -> str:
+    """Return an ISO8601 timestamp in UTC."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+class SpecSearchReporter:
+    """Persist a step-by-step report for spec-search runs."""
+
+    def __init__(
+        self,
+        *,
+        base_dir: Path | str | None = None,
+        request_id: Optional[str] = None,
+        enabled: bool = True,
+    ) -> None:
+        self.enabled = enabled
+        self._path: Optional[Path]
+        self._public_path: Optional[str]
+        if not enabled:
+            self._path = None
+            self._public_path = None
+            return
+
+        directory = Path(base_dir) if base_dir is not None else Path("backend/logs/spec_search")
+        if not directory.is_absolute():
+            directory = PROJECT_ROOT / directory
+        directory.mkdir(parents=True, exist_ok=True)
+
+        self._path = directory / f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}_{request_id or uuid4().hex}.jsonl"
+        try:
+            public_path = str(self._path.relative_to(PROJECT_ROOT))
+        except ValueError:
+            public_path = str(self._path)
+
+        self._public_path = public_path
+
+    @classmethod
+    def disabled(cls) -> "SpecSearchReporter":
+        """Return a reporter instance that drops all events."""
+
+        return cls(enabled=False)
+
+    @property
+    def log_path(self) -> Optional[str]:
+        if not self.enabled or self._public_path is None:
+            return None
+        return self._public_path
+
+    def _append(self, payload: Dict[str, Any]) -> None:
+        if not self.enabled or self._path is None:
+            return
+        entry = json.dumps(payload, ensure_ascii=False)
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(entry)
+            handle.write("\n")
+
+    def log(self, event: str, **details: Any) -> None:
+        """Record an intermediate event."""
+
+        if not self.enabled or self._path is None:
+            return
+        payload: Dict[str, Any] = {
+            "timestamp": _utcnow(),
+            "event": event,
+        }
+        if details:
+            payload["details"] = details
+        self._append(payload)
+
+    def finalize(self, status: str, **details: Any) -> Optional[str]:
+        """Record the terminal state and return the public log path."""
+
+        if not self.enabled or self._path is None:
+            return None
+        payload: Dict[str, Any] = {
+            "timestamp": _utcnow(),
+            "event": "pipeline.complete",
+            "details": {"status": status, **details},
+        }
+        self._append(payload)
+        return self._public_path
+
+
+__all__ = ["SpecSearchReporter"]

--- a/backend/spec_search/router.py
+++ b/backend/spec_search/router.py
@@ -7,6 +7,7 @@ from backend.llm_client import create_default_client
 
 from .extractor import extract_buckets
 from .models import SpecSearchData, SpecSearchMeta, SpecSearchRequest, SpecSearchResponse
+from .reporting import SpecSearchReporter
 
 router = APIRouter()
 
@@ -16,17 +17,20 @@ async def run_spec_search(payload: SpecSearchRequest) -> SpecSearchResponse:
     """Execute the extraction pipeline and return the normalized response."""
 
     client = create_default_client()
+    reporter = SpecSearchReporter()
     try:
         response = await extract_buckets(
             text=payload.text,
             buckets=payload.buckets,
             llm_client=client,
+            reporter=reporter,
         )
         return response
     except Exception as exc:  # pragma: no cover - defensive
+        meta = SpecSearchMeta(log_path=reporter.log_path)
         return SpecSearchResponse(
             ok=False,
             error=str(exc),
             data=SpecSearchData.empty(payload.buckets),
-            meta=SpecSearchMeta(),
+            meta=meta,
         )

--- a/tests/test_integration_success.py
+++ b/tests/test_integration_success.py
@@ -1,21 +1,27 @@
 """Integration-style tests with mocked LLM responses."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from backend.spec_search.extractor import extract_buckets
 from backend.spec_search.models import AttemptReason
+from backend.spec_search.reporting import SpecSearchReporter
 
 VALID_CHUNK = """```SIMPLEBUCKETS\n{\n  \"mechanical\": {\"requirements\": [{\"text\": \"The enclosure shall be stainless steel.\", \"level\": \"MUST\", \"page_hint\": null}]},\n  \"electrical\": {\"requirements\": []},\n  \"software\": {\"requirements\": []},\n  \"controls\": {\"requirements\": []}\n}\n```"""
 
 
 @pytest.mark.asyncio
-async def test_retry_ladder_eventual_success(mock_llm, sample_text_simple) -> None:
+async def test_retry_ladder_eventual_success(mock_llm, sample_text_simple, tmp_path) -> None:
     mock_llm.enqueue("json []")
     mock_llm.enqueue("ABORT")
     mock_llm.enqueue(VALID_CHUNK)
 
-    response = await extract_buckets(sample_text_simple, llm_client=mock_llm)
+    log_dir = tmp_path / "spec_logs"
+    reporter = SpecSearchReporter(base_dir=log_dir, request_id="integration-success")
+
+    response = await extract_buckets(sample_text_simple, llm_client=mock_llm, reporter=reporter)
 
     assert response.ok is True
     assert response.data is not None
@@ -27,3 +33,9 @@ async def test_retry_ladder_eventual_success(mock_llm, sample_text_simple) -> No
     mech = response.data.buckets["mechanical"].requirements
     assert mech and mech[0].text.startswith("The enclosure shall")
     assert mech[0].id.startswith("m-")
+    assert response.meta.log_path is not None
+    log_path = Path(response.meta.log_path)
+    if not log_path.is_absolute():
+        log_path = Path.cwd() / log_path
+    assert log_path.exists()
+    assert log_path.stat().st_size > 0

--- a/tests/test_tripwire_and_fallback.py
+++ b/tests/test_tripwire_and_fallback.py
@@ -1,10 +1,13 @@
 """Tests for normative tripwire and retry ladder."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from backend.spec_search.extractor import extract_buckets
 from backend.spec_search.models import AttemptReason
+from backend.spec_search.reporting import SpecSearchReporter
 
 
 EMPTY_PAYLOAD = """```SIMPLEBUCKETS\n{\n  \"mechanical\": {\"requirements\": []},\n  \"electrical\": {\"requirements\": []},\n  \"software\": {\"requirements\": []},\n  \"controls\": {\"requirements\": []}\n}\n```"""
@@ -13,13 +16,18 @@ VALID_FALLBACK = """```SIMPLEBUCKETS\n{\n  \"mechanical\": {\"requirements\": [{
 
 
 @pytest.mark.asyncio
-async def test_normative_tripwire_escalates_and_uses_fallback(mock_llm, sample_text_normative) -> None:
+async def test_normative_tripwire_escalates_and_uses_fallback(
+    mock_llm, sample_text_normative, tmp_path
+) -> None:
     mock_llm.enqueue(EMPTY_PAYLOAD)
     mock_llm.enqueue("ABORT")
     mock_llm.enqueue(EMPTY_PAYLOAD)
     mock_llm.enqueue(VALID_FALLBACK)
 
-    response = await extract_buckets(sample_text_normative, llm_client=mock_llm)
+    log_dir = tmp_path / "spec_logs_normative"
+    reporter = SpecSearchReporter(base_dir=log_dir, request_id="normative-test")
+
+    response = await extract_buckets(sample_text_normative, llm_client=mock_llm, reporter=reporter)
 
     assert response.ok is True
     assert response.data is not None
@@ -33,3 +41,9 @@ async def test_normative_tripwire_escalates_and_uses_fallback(mock_llm, sample_t
     assert mechanical and mechanical[0].level.value == "MUST"
     models = [attempt.model for attempt in attempts]
     assert models[-1] != models[0]
+    assert response.meta.log_path is not None
+    log_path = Path(response.meta.log_path)
+    if not log_path.is_absolute():
+        log_path = Path.cwd() / log_path
+    assert log_path.exists()
+    assert log_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add a dedicated `SpecSearchReporter` that writes JSONL traces for spec-search runs under `backend/logs/spec_search`
- instrument the spec-search retry ladder to emit detailed attempt, chunk, and completion events while surfacing the log path in the API metadata
- wire the reporter into the FastAPI route and extend integration tests to assert that logs are generated

## Testing
- pytest tests/test_integration_success.py tests/test_tripwire_and_fallback.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2d1438b08333a6dcdcdcda418012)