### PR TITLE
Persist extracted headers and log spec LLM requests

### DIFF
--- a/backend/api/headers.py
+++ b/backend/api/headers.py
@@ -223,6 +223,7 @@ async def extract_headers_and_chunks(
             document_id=str(doc_id),
             filename=document.filename,
             sections=sections_payload,
+            headers=simpleheaders_payload,
         )
     except Exception:  # pragma: no cover - persistence should not block response
         pass

--- a/backend/spec_extraction/jobs.py
+++ b/backend/spec_extraction/jobs.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
+from bisect import bisect_right
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Iterable, Iterator, Sequence
 
+from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
@@ -16,11 +19,13 @@ from backend.services.simpleheaders_state import SimpleHeadersState
 
 from . import get_engine, init_db
 from .llm_client import ExtractionResult, LLMClient
-from .models import Agent, AgentJob, Document, Section, SpecRecord
+from .models import Agent, AgentJob, Document, Header, Section, SpecRecord
 
 init_db()
 
 _LLM_CLIENT: LLMClient | None = None
+
+LOGGER = logging.getLogger(__name__)
 
 
 def set_llm_client(client: LLMClient) -> None:
@@ -167,6 +172,15 @@ async def run_job(job_id: str) -> None:
         _record_job_error(job_id, "Section text unavailable")
         return
 
+    LOGGER.info(
+        "[specs] dispatching LLM request document=%s section=%s agent=%s pages=%s-%s",
+        section_snapshot.document_id,
+        section_snapshot.title,
+        agent_snapshot.code,
+        section_snapshot.page_start,
+        section_snapshot.page_end,
+    )
+
     payload = json.dumps(
         {
             "title": section_snapshot.title,
@@ -303,6 +317,7 @@ def persist_sections(
     document_id: str,
     filename: str,
     sections: Sequence[dict],
+    headers: Sequence[dict] | None = None,
 ) -> None:
     """Persist section metadata emitted by the alignment pipeline."""
 
@@ -317,6 +332,8 @@ def persist_sections(
             except IntegrityError:
                 session.rollback()
                 document = session.get(Document, document_id)
+
+        sections_by_start: dict[int, str] = {}
         for entry in sections:
             title = str(entry.get("header_text") or entry.get("title") or "").strip()
             if not title:
@@ -346,7 +363,9 @@ def persist_sections(
                     updated_at=timestamp,
                 )
                 session.add(section)
+                session.flush()
             else:
+                section = existing
                 updated = False
                 if existing.start_global_idx != start_idx:
                     existing.start_global_idx = start_idx
@@ -356,7 +375,67 @@ def persist_sections(
                     updated = True
                 if updated:
                     existing.updated_at = timestamp
+
+            if start_idx is not None and section.id:
+                sections_by_start[start_idx] = section.id
+
+        if headers is not None:
+            _persist_headers(
+                session,
+                document_id=document_id,
+                headers=headers,
+                sections_by_start=sections_by_start,
+            )
+
         session.commit()
+
+
+def _persist_headers(
+    session: Session,
+    *,
+    document_id: str,
+    headers: Sequence[dict],
+    sections_by_start: dict[int, str],
+) -> None:
+    """Replace persisted headers for ``document_id`` with the supplied payload."""
+
+    session.exec(delete(Header).where(Header.document_id == document_id))
+
+    if not headers:
+        return
+
+    sorted_starts = sorted((idx, section_id) for idx, section_id in sections_by_start.items())
+    start_values = [item[0] for item in sorted_starts]
+    section_ids = [item[1] for item in sorted_starts]
+
+    for entry in headers:
+        title = str(entry.get("text") or entry.get("title") or "").strip()
+        if not title:
+            continue
+        number_raw = entry.get("number")
+        number = str(number_raw).strip() if number_raw not in (None, "") else None
+        level = _safe_int(entry.get("level")) or 1
+        page = _safe_int(entry.get("page"))
+        line_idx = _safe_int(entry.get("line_idx"))
+        global_idx = _safe_int(entry.get("global_idx"))
+
+        section_id: str | None = None
+        if global_idx is not None and start_values:
+            position = bisect_right(start_values, global_idx) - 1
+            if position >= 0:
+                section_id = section_ids[position]
+
+        header = Header(
+            document_id=document_id,
+            section_id=section_id,
+            title=title,
+            number=number,
+            level=level,
+            page=page,
+            line_idx=line_idx,
+            global_idx=global_idx,
+        )
+        session.add(header)
 
 
 def _safe_int(value) -> int | None:

--- a/backend/spec_extraction/models.py
+++ b/backend/spec_extraction/models.py
@@ -54,6 +54,42 @@ class Section(SQLModel, table=True):
     )
 
 
+class Header(SQLModel, table=True):
+    """LLM-aligned header metadata persisted for downstream extraction."""
+
+    __tablename__ = "specx_headers"
+    __table_args__ = (
+        UniqueConstraint(
+            "document_id",
+            "title",
+            "page",
+            "line_idx",
+            name="uq_spec_header_span",
+        ),
+    )
+
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    document_id: str = Field(foreign_key="specx_documents.id", index=True, nullable=False)
+    section_id: Optional[str] = Field(
+        default=None,
+        foreign_key="specx_sections.id",
+        nullable=True,
+        index=True,
+    )
+    title: str = Field(nullable=False)
+    number: Optional[str] = Field(default=None, nullable=True)
+    level: int = Field(default=1, nullable=False)
+    page: Optional[int] = Field(default=None, nullable=True)
+    line_idx: Optional[int] = Field(default=None, nullable=True)
+    global_idx: Optional[int] = Field(default=None, nullable=True, index=True)
+    created_at: datetime = Field(default_factory=_utcnow, nullable=False)
+    updated_at: datetime = Field(
+        default_factory=_utcnow,
+        nullable=False,
+        sa_column_kwargs={"onupdate": _utcnow},
+    )
+
+
 class Agent(SQLModel, table=True):
     """Static lookup table describing the configured agents."""
 
@@ -109,6 +145,7 @@ class SpecRecord(SQLModel, table=True):
 __all__ = [
     "Agent",
     "AgentJob",
+    "Header",
     "Document",
     "Section",
     "SpecRecord",

--- a/tests/spec_extraction/test_header_persistence.py
+++ b/tests/spec_extraction/test_header_persistence.py
@@ -1,0 +1,90 @@
+from sqlmodel import Session, select
+
+from backend.spec_extraction import get_engine
+from backend.spec_extraction.jobs import persist_sections
+from backend.spec_extraction.models import Header, Section
+
+
+def test_persist_sections_records_headers() -> None:
+    """Headers should be persisted and associated with their sections."""
+
+    sections = [
+        {
+            "header_text": "1 Scope",
+            "start_page": 1,
+            "end_page": 2,
+            "start_global_idx": 0,
+            "end_global_idx": 4,
+        },
+        {
+            "header_text": "2 Requirements",
+            "start_page": 3,
+            "end_page": 5,
+            "start_global_idx": 5,
+            "end_global_idx": 9,
+        },
+    ]
+    headers = [
+        {
+            "text": "1 Scope",
+            "number": "1",
+            "level": 1,
+            "page": 1,
+            "line_idx": 10,
+            "global_idx": 0,
+        },
+        {
+            "text": "2 Requirements",
+            "number": "2",
+            "level": 1,
+            "page": 3,
+            "line_idx": 2,
+            "global_idx": 5,
+        },
+    ]
+
+    persist_sections(
+        document_id="hdr-1",
+        filename="doc.pdf",
+        sections=sections,
+        headers=headers,
+    )
+
+    with Session(get_engine()) as session:
+        stored_sections = session.exec(
+            select(Section).where(Section.document_id == "hdr-1")
+        ).all()
+        starts = {section.start_global_idx: section.id for section in stored_sections}
+        stored_headers = session.exec(
+            select(Header).where(Header.document_id == "hdr-1").order_by(Header.global_idx)
+        ).all()
+        assert len(stored_headers) == 2
+        assert stored_headers[0].title == "1 Scope"
+        assert stored_headers[0].section_id == starts.get(0)
+        assert stored_headers[1].section_id == starts.get(5)
+
+    updated_headers = [
+        {
+            "text": "1 Scope",
+            "number": "1",
+            "level": 1,
+            "page": 1,
+            "line_idx": 15,
+            "global_idx": 0,
+        }
+    ]
+
+    persist_sections(
+        document_id="hdr-1",
+        filename="doc.pdf",
+        sections=sections,
+        headers=updated_headers,
+    )
+
+    with Session(get_engine()) as session:
+        stored_headers = session.exec(
+            select(Header).where(Header.document_id == "hdr-1")
+        ).all()
+        assert len(stored_headers) == 1
+        assert stored_headers[0].line_idx == 15
+        assert stored_headers[0].section_id is not None


### PR DESCRIPTION
## Summary
- persist headers from the header pipeline into the specs database alongside sections
- associate stored headers with their sections and refresh them on subsequent runs
- log the section title and agent whenever an extraction job dispatches an LLM request
- cover the new persistence flow with regression tests

## Testing
- pytest tests/spec_extraction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3713752483338a01a1b75a72412a)