### PR TITLE
Persist raw header outlines alongside disk cache

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -56,6 +56,7 @@ def init_db() -> None:
         artifacts,
         document,
         header_anchor,
+        header_outline,
         section,
         spec_record,
     )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,6 +12,7 @@ from .artifacts import (
 )
 from .document import Document
 from .header_anchor import HeaderAnchor
+from .header_outline import HeaderOutlineCache, HeaderOutlineRun
 from .section import DocumentSection
 from .spec_record import SpecAuditEntry, SpecRecord
 
@@ -26,6 +27,8 @@ __all__ = [
     "DocumentTable",
     "DocumentSection",
     "HeaderAnchor",
+    "HeaderOutlineCache",
+    "HeaderOutlineRun",
     "PromptResponse",
     "SpecRecord",
     "SpecAuditEntry",

--- a/backend/models/header_outline.py
+++ b/backend/models/header_outline.py
@@ -1,0 +1,49 @@
+"""Models for persisting raw LLM header outlines."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Return the current time in UTC."""
+
+    return datetime.now(UTC)
+
+
+class HeaderOutlineRun(SQLModel, table=True):
+    """Tracks metadata about a single header outline extraction run."""
+
+    __tablename__ = "header_outline_runs"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id", index=True, nullable=False)
+    model: str = Field(nullable=False)
+    prompt_hash: str = Field(index=True, nullable=False)
+    source_hash: str = Field(index=True, nullable=False)
+    status: str = Field(default="completed", index=True, nullable=False)
+    error: str | None = Field(default=None, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, index=True, nullable=False)
+
+
+class HeaderOutlineCache(SQLModel, table=True):
+    """Stores the raw outline JSON for a given :class:`HeaderOutlineRun`."""
+
+    __tablename__ = "header_outline_cache"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    run_id: int = Field(foreign_key="header_outline_runs.id", index=True, nullable=False)
+    document_id: int = Field(index=True, nullable=False)
+    outline_json: str = Field(nullable=False)
+    meta_json: str | None = Field(default=None, nullable=True)
+    tokens_prompt: int | None = Field(default=None, nullable=True)
+    tokens_completion: int | None = Field(default=None, nullable=True)
+    latency_ms: int | None = Field(default=None, nullable=True)
+    unique_key: str | None = Field(default=None, index=True, nullable=True)
+    created_at: datetime = Field(default_factory=_utcnow, index=True, nullable=False)
+
+
+__all__ = ["HeaderOutlineRun", "HeaderOutlineCache"]

--- a/backend/services/headers_orchestrator.py
+++ b/backend/services/headers_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import time
@@ -23,6 +24,7 @@ from .pdf_headers_llm_full import (
     LLMFullHeadersResult,
     get_headers_llm_full,
 )
+from .outline_cache import persist_outline_cache
 from .pdf_native import collect_line_metrics
 from .section_chunking import single_chunks_from_headers
 from ..utils.logging import configure_logging
@@ -106,6 +108,7 @@ async def extract_headers_and_chunks(
         tracer.log_call(f"{__name__}.extract_headers_and_chunks")
 
     start_time = time.perf_counter()
+    source_hash = hashlib.sha256(document_bytes).hexdigest()
     if tracer:
         tracer.ev(
             "start_run",
@@ -263,6 +266,45 @@ async def extract_headers_and_chunks(
             fenced_text = llm_result.combined_fenced()
             strict_attempted = False
             vector_attempted = False
+
+            if (
+                session is not None
+                and doc_id is not None
+                and not llm_result.from_cache
+                and llm_result.prompt_hash
+            ):
+                outline_payload = {
+                    "headers": llm_result.headers,
+                    "raw_responses": llm_result.raw_responses,
+                    "fenced_blocks": llm_result.fenced_blocks,
+                }
+                outline_meta = {
+                    "model": settings.headers_llm_model,
+                    "headers_mode": settings.headers_mode,
+                    "header_count": len(llm_result.headers),
+                    "raw_response_count": len(llm_result.raw_responses),
+                    "doc_hash": doc_hash,
+                }
+                if llm_result.latency_ms is not None:
+                    outline_meta["latency_ms"] = llm_result.latency_ms
+                try:
+                    persist_outline_cache(
+                        session,
+                        document_id=doc_id,
+                        outline=outline_payload,
+                        meta=outline_meta,
+                        model=settings.headers_llm_model,
+                        prompt_hash=llm_result.prompt_hash,
+                        source_hash=source_hash,
+                        tokens_prompt=None,
+                        tokens_completion=None,
+                        latency_ms=llm_result.latency_ms,
+                        supersede_old=True,
+                    )
+                except Exception:  # pragma: no cover - defensive logging
+                    LOGGER.warning(
+                        "[headers] Failed to persist outline cache to DB", exc_info=True
+                    )
 
             if settings.headers_llm_strict and llm_headers:
                 strict_attempted = True

--- a/backend/services/outline_cache.py
+++ b/backend/services/outline_cache.py
@@ -1,0 +1,110 @@
+"""Persistence helpers for header outline caching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Optional
+
+from sqlmodel import Session, select
+
+from ..models import HeaderOutlineCache, HeaderOutlineRun
+
+
+def _sha256_bytes(data: bytes) -> str:
+    """Return the SHA-256 digest for ``data``."""
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    """Return the SHA-256 digest for ``text`` interpreted as UTF-8."""
+
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def supersede_previous_runs(session: Session, document_id: int) -> None:
+    """Mark completed runs for ``document_id`` as superseded."""
+
+    runs = session.exec(
+        select(HeaderOutlineRun).where(
+            HeaderOutlineRun.document_id == document_id,
+            HeaderOutlineRun.status == "completed",
+        )
+    ).all()
+    if not runs:
+        return
+    for run in runs:
+        run.status = "superseded"
+    session.add_all(runs)
+    session.commit()
+
+
+def persist_outline_cache(
+    session: Session,
+    *,
+    document_id: int,
+    outline: Any,
+    meta: Optional[dict],
+    model: str,
+    prompt_hash: str,
+    source_hash: str,
+    tokens_prompt: Optional[int] = None,
+    tokens_completion: Optional[int] = None,
+    latency_ms: Optional[int] = None,
+    supersede_old: bool = False,
+) -> int:
+    """Persist a header outline run and its cached payload.
+
+    Returns the database identifier of the created :class:`HeaderOutlineRun`.
+    """
+
+    if supersede_old:
+        supersede_previous_runs(session, document_id)
+
+    run = HeaderOutlineRun(
+        document_id=document_id,
+        model=model,
+        prompt_hash=prompt_hash,
+        source_hash=source_hash,
+        status="completed",
+    )
+    session.add(run)
+    session.flush()  # ensures ``run.id`` is available
+
+    unique_key = f"{document_id}:{prompt_hash}:{source_hash}"
+    cache = HeaderOutlineCache(
+        run_id=run.id or 0,
+        document_id=document_id,
+        outline_json=json.dumps(outline, ensure_ascii=False),
+        meta_json=json.dumps(meta or {}, ensure_ascii=False),
+        tokens_prompt=tokens_prompt,
+        tokens_completion=tokens_completion,
+        latency_ms=latency_ms,
+        unique_key=unique_key,
+    )
+    session.add(cache)
+    session.commit()
+    return int(run.id or 0)
+
+
+def latest_outline_for_document(
+    session: Session, document_id: int
+) -> HeaderOutlineCache | None:
+    """Return the most recent cached outline for ``document_id``."""
+
+    statement = (
+        select(HeaderOutlineCache)
+        .where(HeaderOutlineCache.document_id == document_id)
+        .order_by(HeaderOutlineCache.created_at.desc())
+        .limit(1)
+    )
+    return session.exec(statement).first()
+
+
+__all__ = [
+    "latest_outline_for_document",
+    "persist_outline_cache",
+    "sha256_text",
+    "supersede_previous_runs",
+]

--- a/backend/services/pdf_headers_llm_full.py
+++ b/backend/services/pdf_headers_llm_full.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, TYPE_CHECKING
@@ -34,6 +36,9 @@ class LLMFullHeadersResult:
     headers: List[Dict]
     raw_responses: List[str]
     fenced_blocks: List[str]
+    prompt_hash: str | None = None
+    latency_ms: int | None = None
+    from_cache: bool = False
 
     def combined_fenced(self) -> str:
         """Return a single fenced block for downstream consumers."""
@@ -167,6 +172,7 @@ async def get_headers_llm_full(
                         for entry in cached.get("fenced_blocks", [])
                         if isinstance(entry, str)
                     ],
+                    from_cache=True,
                 )
         except Exception:
             if tracer is not None:
@@ -176,10 +182,13 @@ async def get_headers_llm_full(
         tracer.ev("llm_cache_miss", path=str(cache_file))
 
     # --------- Build LLM inputs ----------
+    start_time = time.perf_counter()
     text_blocks = _build_text_blocks(lines, excluded_pages)
     token_limit = min(int(settings.headers_llm_max_input_tokens), HEADER_CHUNK_TOKEN_LIMIT)
     parts = split_by_token_limit(text_blocks, token_limit) or ["\n".join(text_blocks)]
     total_parts = len(parts)
+
+    prompt_hasher = hashlib.sha256()
 
     client_params: dict[str, str] = {}
     if settings.openrouter_http_referer:
@@ -219,6 +228,10 @@ async def get_headers_llm_full(
                 ),
             },
         ]
+
+        prompt_hasher.update(
+            json.dumps(messages, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        )
 
         loop = asyncio.get_running_loop()
         if tracer is not None:
@@ -307,10 +320,15 @@ async def get_headers_llm_full(
             if tracer is not None:
                 tracer.ev("llm_cache_write_failed", path=str(cache_file))
 
+    latency_ms = int((time.perf_counter() - start_time) * 1000)
+    prompt_hash = prompt_hasher.hexdigest()
+
     return LLMFullHeadersResult(
         headers=deduped,
         raw_responses=raw_responses,
         fenced_blocks=fenced_blocks,
+        prompt_hash=prompt_hash,
+        latency_ms=latency_ms,
     )
 
 


### PR DESCRIPTION
## Summary
- add SQLModel tables to record header outline runs and cached payloads
- provide an outline cache service that hashes inputs and dual-writes to the database
- capture prompt metadata from the LLM headers pipeline and persist each run alongside the existing disk cache

## Testing
- pytest backend/tests/test_llm_full_headers.py backend/tests/test_headers_orchestrator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691212d4bfb883249e13b21857e60c0b)